### PR TITLE
MPI-3+ updates required by Open MPI 4

### DIFF
--- a/BLACS/SRC/blacs_get_.c
+++ b/BLACS/SRC/blacs_get_.c
@@ -22,7 +22,7 @@ F_VOID_FUNC blacs_get_(int *ConTxt, int *what, int *val)
    case SGET_MSGIDS:
       if (BI_COMM_WORLD == NULL) Cblacs_pinfo(val, &val[1]);
       iptr = &val[1];
-      ierr=MPI_Attr_get(MPI_COMM_WORLD, MPI_TAG_UB, (BVOID **) &iptr,val);
+      ierr=MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, (BVOID **) &iptr,val);
       val[0] = 0;
       val[1] = *iptr;
       break;

--- a/BLACS/SRC/cgamn2d_.c
+++ b/BLACS/SRC/cgamn2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/cgamx2d_.c
+++ b/BLACS/SRC/cgamx2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/dgamn2d_.c
+++ b/BLACS/SRC/dgamn2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/dgamx2d_.c
+++ b/BLACS/SRC/dgamx2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/igamn2d_.c
+++ b/BLACS/SRC/igamn2d_.c
@@ -218,7 +218,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/igamx2d_.c
+++ b/BLACS/SRC/igamx2d_.c
@@ -218,7 +218,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/sgamn2d_.c
+++ b/BLACS/SRC/sgamn2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/sgamx2d_.c
+++ b/BLACS/SRC/sgamx2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/zgamn2d_.c
+++ b/BLACS/SRC/zgamn2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;

--- a/BLACS/SRC/zgamx2d_.c
+++ b/BLACS/SRC/zgamx2d_.c
@@ -221,7 +221,7 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       {
 #endif
       i = 2;
-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
+      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
       ierr=MPI_Type_commit(&MyType);
       bp->N = bp2->N = 1;
       bp->dtype = bp2->dtype = MyType;


### PR DESCRIPTION
MPI_Attr_get and MPI_Type_struct were deprecated in MPI-2 and removed
in MPI-3.  Open MPI 4.0 is the first widely used implementation that
actually removed these symbols.  This change breaks compatibility with
MPI-1 implementations.