### PR TITLE
maint: added p*trcon to library fixes #11

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -19,7 +19,7 @@ set (SLASRC
    psdbsv.f  psdbtrf.f psdbtrs.f psdbtrsv.f 
    psdtsv.f  psdttrf.f psdttrs.f psdttrsv.f 
    psgbsv.f  psgbtrf.f psgbtrs.f 
-   psgebd2.f psgebrd.f psgecon.f           psgeequ.f psgehd2.f psgehrd.f 
+   psgebd2.f psgebrd.f psgecon.f pstrcon.f psgeequ.f psgehd2.f psgehrd.f
    psgelq2.f psgelqf.f psgels.f  psgeql2.f psgeqlf.f psgeqpf.f psgeqr2.f 
    psgeqrf.f psgerfs.f psgerq2.f psgerqf.f                               
    psgesv.f  psgesvd.f psgesvx.f psgetf2.f psgetrf.f psgetri.f psgetrs.f 
@@ -51,7 +51,7 @@ set (CLASRC
    pcdbsv.f  pcdbtrf.f pcdbtrs.f pcdbtrsv.f 
    pcdtsv.f  pcdttrf.f pcdttrs.f pcdttrsv.f 
    pcgbsv.f  pcgbtrf.f pcgbtrs.f 
-   pcgebd2.f pcgebrd.f pcgecon.f          pcgeequ.f pcgehd2.f pcgehrd.f 
+   pcgebd2.f pcgebrd.f pcgecon.f pctrcon.f pcgeequ.f pcgehd2.f pcgehrd.f
    pcgelq2.f pcgelqf.f  pcgels.f pcgeql2.f pcgeqlf.f pcgeqpf.f pcgeqr2.f 
    pcgeqrf.f pcgerfs.f pcgerq2.f pcgerqf.f                               
    pcgesv.f  pcgesvd.f pcgesvx.f pcgetf2.f pcgetrf.f pcgetri.f pcgetrs.f 
@@ -82,7 +82,7 @@ set (DLASRC
    pddbsv.f  pddbtrf.f pddbtrs.f pddbtrsv.f 
    pddtsv.f  pddttrf.f pddttrs.f pddttrsv.f 
    pdgbsv.f  pdgbtrf.f pdgbtrs.f 
-   pdgebd2.f pdgebrd.f pdgecon.f           pdgeequ.f pdgehd2.f pdgehrd.f 
+   pdgebd2.f pdgebrd.f pdgecon.f pdtrcon.f pdgeequ.f pdgehd2.f pdgehrd.f
    pdgelq2.f pdgelqf.f pdgels.f  pdgeql2.f pdgeqlf.f pdgeqpf.f pdgeqr2.f 
    pdgeqrf.f pdgerfs.f pdgerq2.f pdgerqf.f                               
    pdgesv.f  pdgesvd.f pdgesvx.f pdgetf2.f pdgetrf.f pdgetri.f pdgetrs.f 
@@ -114,7 +114,7 @@ set (ZLASRC
    pzdbsv.f  pzdbtrf.f pzdbtrs.f pzdbtrsv.f 
    pzdtsv.f  pzdttrf.f pzdttrs.f pzdttrsv.f 
    pzgbsv.f  pzgbtrf.f pzgbtrs.f 
-   pzgebd2.f pzgebrd.f pzgecon.f           pzgeequ.f pzgehd2.f pzgehrd.f 
+   pzgebd2.f pzgebrd.f pzgecon.f pztrcon.f pzgeequ.f pzgehd2.f pzgehrd.f
    pzgelq2.f pzgelqf.f pzgels.f  pzgeql2.f pzgeqlf.f pzgeqpf.f pzgeqr2.f 
    pzgeqrf.f pzgerfs.f pzgerq2.f pzgerqf.f                               
    pzgesv.f  pzgesvd.f pzgesvx.f pzgetf2.f pzgetrf.f pzgetri.f pzgetrs.f 

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -68,7 +68,7 @@ SLASRC = \
    psdbsv.o  psdbtrf.o psdbtrs.o psdbtrsv.o \
    psdtsv.o  psdttrf.o psdttrs.o psdttrsv.o \
    psgbsv.o  psgbtrf.o psgbtrs.o \
-   psgebd2.o psgebrd.o psgecon.o           psgeequ.o psgehd2.o psgehrd.o \
+   psgebd2.o psgebrd.o psgecon.o pstrcon.o psgeequ.o psgehd2.o psgehrd.o \
    psgelq2.o psgelqf.o psgels.o  psgeql2.o psgeqlf.o psgeqpf.o psgeqr2.o \
    psgeqrf.o psgerfs.o psgerq2.o psgerqf.o                               \
    psgesv.o  psgesvd.o psgesvx.o psgetf2.o psgetrf.o psgetri.o psgetrs.o \
@@ -100,7 +100,7 @@ CLASRC = \
    pcdbsv.o  pcdbtrf.o pcdbtrs.o pcdbtrsv.o \
    pcdtsv.o  pcdttrf.o pcdttrs.o pcdttrsv.o \
    pcgbsv.o  pcgbtrf.o pcgbtrs.o \
-   pcgebd2.o pcgebrd.o pcgecon.o          pcgeequ.o pcgehd2.o pcgehrd.o \
+   pcgebd2.o pcgebrd.o pcgecon.o pctrcon.o pcgeequ.o pcgehd2.o pcgehrd.o \
    pcgelq2.o pcgelqf.o  pcgels.o pcgeql2.o pcgeqlf.o pcgeqpf.o pcgeqr2.o \
    pcgeqrf.o pcgerfs.o pcgerq2.o pcgerqf.o                               \
    pcgesv.o  pcgesvd.o pcgesvx.o pcgetf2.o pcgetrf.o pcgetri.o pcgetrs.o \
@@ -131,7 +131,7 @@ DLASRC = \
    pddbsv.o  pddbtrf.o pddbtrs.o pddbtrsv.o \
    pddtsv.o  pddttrf.o pddttrs.o pddttrsv.o \
    pdgbsv.o  pdgbtrf.o pdgbtrs.o \
-   pdgebd2.o pdgebrd.o pdgecon.o           pdgeequ.o pdgehd2.o pdgehrd.o \
+   pdgebd2.o pdgebrd.o pdgecon.o pdtrcon.o pdgeequ.o pdgehd2.o pdgehrd.o \
    pdgelq2.o pdgelqf.o pdgels.o  pdgeql2.o pdgeqlf.o pdgeqpf.o pdgeqr2.o \
    pdgeqrf.o pdgerfs.o pdgerq2.o pdgerqf.o                               \
    pdgesv.o  pdgesvd.o pdgesvx.o pdgetf2.o pdgetrf.o pdgetri.o pdgetrs.o \
@@ -163,7 +163,7 @@ ZLASRC = \
    pzdbsv.o  pzdbtrf.o pzdbtrs.o pzdbtrsv.o \
    pzdtsv.o  pzdttrf.o pzdttrs.o pzdttrsv.o \
    pzgbsv.o  pzgbtrf.o pzgbtrs.o \
-   pzgebd2.o pzgebrd.o pzgecon.o           pzgeequ.o pzgehd2.o pzgehrd.o \
+   pzgebd2.o pzgebrd.o pzgecon.o pztrcon.o pzgeequ.o pzgehd2.o pzgehrd.o \
    pzgelq2.o pzgelqf.o pzgels.o  pzgeql2.o pzgeqlf.o pzgeqpf.o pzgeqr2.o \
    pzgeqrf.o pzgerfs.o pzgerq2.o pzgerqf.o                               \
    pzgesv.o  pzgesvd.o pzgesvx.o pzgetf2.o pzgetrf.o pzgetri.o pzgetrs.o \


### PR DESCRIPTION
This adds the missing functions to the library.
However, it seems no function is calling these functions.