### PR TITLE
Change Fortran mangling test in CMake

### DIFF
--- a/CMAKE/FortranMangling.cmake
+++ b/CMAKE/FortranMangling.cmake
@@ -17,27 +17,29 @@ FUNCTION(COMPILE RESULT)
    # Configure: 
     EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND}  
          "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
-         "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+         "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}" "${PROJECT_SOURCE_DIR}//BLACS/INSTALL"
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/BLACS/INSTALL/        
-        RESULT_VARIABLE RESVAR OUTPUT_VARIABLE LOG1 ERROR_VARIABLE LOG1
+        RESULT_VARIABLE RESVAR OUTPUT_VARIABLE LOG1_OUT ERROR_VARIABLE LOG1_ERR
     )
     if(RESVAR EQUAL 0)
     MESSAGE(STATUS "Configure in the INSTALL directory successful")
     else()
+    MESSAGE(STATUS " Build Output:\n ${LOG1_OUT}")
+    MESSAGE(STATUS " Error Output:\n ${LOG1_ERR}")
     MESSAGE(FATAL_ERROR " Configure in the BLACS INSTALL directory FAILED")
-    MESSAGE(FATAL_ERROR " Output Build:\n ${LOG1}")
     endif()
 
     # Build:
     EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build
         ${PROJECT_SOURCE_DIR}/BLACS/INSTALL/ 
-        RESULT_VARIABLE RESVAR OUTPUT_VARIABLE LOG2 ERROR_VARIABLE LOG2
+        RESULT_VARIABLE RESVAR OUTPUT_VARIABLE LOG2_OUT ERROR_VARIABLE LOG2_ERR
     )
     if(RESVAR  EQUAL 0)
     MESSAGE(STATUS "Build in the BLACS INSTALL directory successful")
     else()
+    MESSAGE(STATUS " Build Output:\n ${LOG2_OUT}")
+    MESSAGE(STATUS " Error Output:\n ${LOG2_ERR}")
     MESSAGE(FATAL_ERROR " Build in the BLACS INSTALL directory FAILED")
-    MESSAGE(FATAL_ERROR " Output Build:\n ${LOG2}")
     endif()
     # Clean up:
     FILE(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/BLACS/INSTALL/CMakeCache.txt)
@@ -62,6 +64,7 @@ MESSAGE(STATUS "Testing FORTRAN_MANGLING")
           MESSAGE(STATUS "CDEFS set to ${xintface_OUT}")
           SET(CDEFS ${xintface_OUT} CACHE STRING "Fortran Mangling" FORCE)
       else()
+          MESSAGE(STATUS " xintface Output:\n ${xintface_OUT}")
           MESSAGE(FATAL_ERROR "FORTRAN_MANGLING:ERROR ${xintface_ERR}")
       endif() 
 endmacro(FORTRAN_MANGLING)


### PR DESCRIPTION
Fix CMake invocation that breaks some versions of CMake as described in Kitware's regression:

https://gitlab.kitware.com/cmake/cmake/issues/18817

Fixes #9