### PR TITLE
Use pointer macro to prevent integer oveflow

### DIFF
--- a/PBLAS/SRC/pdamax_.c
+++ b/PBLAS/SRC/pdamax_.c
@@ -233,7 +233,7 @@ void pdamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
       if( ( ( myrow == Xrow ) || ( Xrow < 0 ) ) &&
           ( ( mycol == Xcol ) || ( Xcol < 0 ) ) )
       {
-         *INDX = *JX; *AMAX = X[Xii+Xjj*Xd[LLD_]];
+         *INDX = *JX; *AMAX = *Mptr(X,Xii,Xjj,Xd[LLD_],1);
       }
       return;
    }
@@ -260,9 +260,9 @@ void pdamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
             {
                Xld = Xd[LLD_];
                Xlindx = Xjj - 1 +
-                        idamax_( &Xnq, ((char*)(X+(Xii+Xjj*Xld))), &Xld );
+                        idamax_( &Xnq, ((char*)Mptr(X,Xii,Xjj,Xld,1)), &Xld );
                Mindxl2g( Xgindx, Xlindx, Xinb, Xnb, mycol, Xsrc, npcol );
-               work[0] = X[Xii+Xlindx*Xld];
+               work[0] = *Mptr(X,Xii,Xlindx,Xld,1);
                work[1] = ((double)( Xgindx+1 ));
             }
             else
@@ -343,8 +343,8 @@ l_20:
 */
                Xld = Xd[LLD_];
                Xlindx = Xjj - 1 +
-                        idamax_( &Xnq, ((char*)(X+(Xii+Xjj*Xld))), &Xld );
-               *AMAX = X[Xii+Xlindx*Xld];
+                        idamax_( &Xnq, ((char*)Mptr(X,Xii,Xjj,Xld,1)), &Xld );
+               *AMAX = *Mptr(X,Xii,Xlindx,Xld,1);
             }
             else
             {
@@ -419,9 +419,9 @@ l_20:
             {
                Xld     = Xd[LLD_];
                Xlindx  = Xii - 1 +
-                         idamax_( &Xnp, ((char*)(X+(Xii+Xjj*Xld))), INCX );
+                         idamax_( &Xnp, ((char*)Mptr(X,Xii,Xjj,Xld,1)), INCX );
                Mindxl2g( Xgindx, Xlindx, Ximb, Xmb, myrow, Xsrc, nprow );
-               work[0] = X[Xlindx+Xjj*Xld];
+               work[0] = *Mptr(X,Xlindx,Xjj,Xld,1);
                work[1] = ((double)( Xgindx+1 ));
             }
             else
@@ -503,8 +503,8 @@ l_40:
 */
                Xld = Xd[LLD_];
                Xlindx = Xii - 1 +
-                        idamax_( &Xnp, ((char*)(X+(Xii+Xjj*Xld))), INCX );
-               *AMAX = X[Xlindx+Xjj*Xld];
+                        idamax_( &Xnp, ((char*)Mptr(X,Xii,Xjj,Xld,1)), INCX );
+               *AMAX = *Mptr(X,Xlindx,Xjj,Xld,1);
             }
             else
             {

--- a/PBLAS/SRC/pdasum_.c
+++ b/PBLAS/SRC/pdasum_.c
@@ -225,7 +225,7 @@ void pdasum_( N, ASUM, X, IX, JX, DESCX, INCX )
       if( ( ( myrow == Xrow ) || ( Xrow < 0 ) ) &&
           ( ( mycol == Xcol ) || ( Xcol < 0 ) ) )
       {
-         *ASUM = ABS( X[Xii+Xjj*Xd[LLD_]] );
+         *ASUM = ABS( *Mptr(X,Xii,Xjj,Xd[LLD_],1) );
       }
       return;
    }
@@ -243,7 +243,7 @@ void pdasum_( N, ASUM, X, IX, JX, DESCX, INCX )
          if( Xnq > 0 )
          {
             Xld = Xd[LLD_];
-            dvasum_( &Xnq, ((char *) ASUM), ((char *)( X+(Xii+Xjj*Xld) )),
+            dvasum_( &Xnq, ((char *) ASUM), ((char *)Mptr( X,Xii,Xjj,Xld,1 )),
                      &Xld );
          }
 /*
@@ -276,7 +276,7 @@ void pdasum_( N, ASUM, X, IX, JX, DESCX, INCX )
          if( Xnp > 0 )
          {
             dvasum_( &Xnp, ((char *) ASUM),
-                     ((char *)( X+(Xii+Xjj*Xd[LLD_]) )), INCX );
+                     ((char *)Mptr( X,Xii,Xjj,Xd[LLD_],1) ), INCX );
          }
 /*
 *  If Xnp <= 0, ASUM is zero (see initialization above)

--- a/PBLAS/SRC/pdger_.c
+++ b/PBLAS/SRC/pdger_.c
@@ -286,7 +286,7 @@ void pdger_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
    if( ( Amp > 0 ) && ( Anq > 0 ) )
    {
       dger_( &Amp, &Anq, ((char *) ALPHA), XA, &ione, YA, &YAd[LLD_],
-             ((char *) (A+(Aii+Ajj*Ald))), &Ald );
+             ((char *)Mptr(A,Aii,Ajj,Ald,1)), &Ald );
    }
    if( XAfr ) free( XA );
    if( YAfr ) free( YA );

--- a/PBLAS/SRC/pdnrm2_.c
+++ b/PBLAS/SRC/pdnrm2_.c
@@ -224,7 +224,7 @@ void pdnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 */
       if( ( ( myrow == Xrow ) || ( Xrow < 0 ) ) &&
           ( ( mycol == Xcol ) || ( Xcol < 0 ) ) )
-         *NORM2 = ABS( X[Xii+Xjj*Xd[LLD_]] );
+         *NORM2 = ABS( *Mptr(X,Xii,Xjj,Xd[LLD_],1) );
       return;
    }
    else if( *INCX == Xd[M_] )
@@ -246,7 +246,7 @@ void pdnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
          if( Xnq > 0 )
          {
             Xld  = Xd[LLD_];
-            Xptr = X+(Xii+Xjj*Xld);
+            Xptr = Mptr(X,Xii,Xjj,Xld,1);
 
             for( k = 0; k < Xnq; k++ )
             {
@@ -366,7 +366,7 @@ l_20:
          Xnp = PB_Cnumroc( *N, Xi, Xd[IMB_], Xd[MB_], myrow, Xd[RSRC_], nprow );
          if( Xnp > 0 )
          {
-            Xptr = X+(Xii+Xjj*Xd[LLD_]);
+            Xptr = Mptr(X,Xii,Xjj,Xd[LLD_],1);
 
             for( k = 0; k < Xnp; k++ )
             {

--- a/PBLAS/SRC/pdscal_.c
+++ b/PBLAS/SRC/pdscal_.c
@@ -210,12 +210,12 @@ void pdscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
             Xld = Xd[LLD_];
             if( ALPHA[REAL_PART] == ZERO )
             {
-               dset_( &Xnq, ((char *) ALPHA), ((char *)(X+(Xii+Xjj*Xld))),
+               dset_( &Xnq, ((char *) ALPHA), ((char *)Mptr(X,Xii,Xjj,Xld,1)),
                       &Xld );
             }
             else
             {
-               dscal_( &Xnq, ((char *) ALPHA), ((char *)(X+(Xii+Xjj*Xld))),
+               dscal_( &Xnq, ((char *) ALPHA), ((char *)Mptr(X,Xii,Xjj,Xld,1)),
                        &Xld );
             }
          }
@@ -239,12 +239,12 @@ void pdscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
             if( ALPHA[REAL_PART] == ZERO )
             {
                dset_( &Xnp, ((char *) ALPHA),
-                      ((char *)( X+(Xii+Xjj*Xd[LLD_]) )), INCX );
+                      ((char *)Mptr( X,Xii,Xjj,Xd[LLD_],1) ), INCX );
             }
             else
             {
                dscal_( &Xnp, ((char *) ALPHA),
-                       ((char *)( X+(Xii+Xjj*Xd[LLD_]) )), INCX );
+                       ((char *)Mptr( X,Xii,Xjj,Xd[LLD_],1) ), INCX );
             }
          }
       }

--- a/PBLAS/SRC/psamax_.c
+++ b/PBLAS/SRC/psamax_.c
@@ -260,7 +260,7 @@ void psamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
             {
                Xld = Xd[LLD_];
                Xlindx = Xjj - 1 +
-                        isamax_( &Xnq, ((char*)(X+(Xii+Xjj*Xld))), &Xld );
+                        isamax_( &Xnq, ((char*)(Mptr(X,Xii,Xjj,Xld,1))), &Xld );
                Mindxl2g( Xgindx, Xlindx, Xinb, Xnb, mycol, Xsrc, npcol );
                work[0] = X[Xii+Xlindx*Xld];
                work[1] = ((float )( Xgindx+1 ));
@@ -343,8 +343,8 @@ l_20:
 */
                Xld = Xd[LLD_];
                Xlindx = Xjj - 1 +
-                        isamax_( &Xnq, ((char*)(X+(Xii+Xjj*Xld))), &Xld );
-               *AMAX = X[Xii+Xlindx*Xld];
+                        isamax_( &Xnq, ((char*)(Mptr(X,Xii,Xjj,Xld, 1))), &Xld );
+               *AMAX = *Mptr(X,Xii,Xlindx,Xld,1);
             }
             else
             {
@@ -419,9 +419,9 @@ l_20:
             {
                Xld     = Xd[LLD_];
                Xlindx  = Xii - 1 +
-                         isamax_( &Xnp, ((char*)(X+(Xii+Xjj*Xld))), INCX );
+                         isamax_( &Xnp, ((char*)Mptr(X,Xii,Xjj,Xld,1)), INCX );
                Mindxl2g( Xgindx, Xlindx, Ximb, Xmb, myrow, Xsrc, nprow );
-               work[0] = X[Xlindx+Xjj*Xld];
+               work[0] = *Mptr(X,Xlindx,Xjj,Xld,1);
                work[1] = ((float )( Xgindx+1 ));
             }
             else

--- a/PBLAS/SRC/psasum_.c
+++ b/PBLAS/SRC/psasum_.c
@@ -225,7 +225,7 @@ void psasum_( N, ASUM, X, IX, JX, DESCX, INCX )
       if( ( ( myrow == Xrow ) || ( Xrow < 0 ) ) &&
           ( ( mycol == Xcol ) || ( Xcol < 0 ) ) )
       {
-         *ASUM = ABS( X[Xii+Xjj*Xd[LLD_]] );
+         *ASUM = ABS( *Mptr(X,Xii,Xjj,Xd[LLD_],1) );
       }
       return;
    }
@@ -243,7 +243,7 @@ void psasum_( N, ASUM, X, IX, JX, DESCX, INCX )
          if( Xnq > 0 )
          {
             Xld = Xd[LLD_];
-            svasum_( &Xnq, ((char *) ASUM), ((char *)( X+(Xii+Xjj*Xld) )),
+            svasum_( &Xnq, ((char *) ASUM), ((char *)Mptr( X,Xii,Xjj,Xld,1) ),
                      &Xld );
          }
 /*
@@ -276,7 +276,7 @@ void psasum_( N, ASUM, X, IX, JX, DESCX, INCX )
          if( Xnp > 0 )
          {
             svasum_( &Xnp, ((char *) ASUM),
-                     ((char *)( X+(Xii+Xjj*Xd[LLD_]) )), INCX );
+                     ((char *)Mptr( X,Xii,Xjj,Xd[LLD_],1) ), INCX );
          }
 /*
 *  If Xnp <= 0, ASUM is zero (see initialization above)

--- a/PBLAS/SRC/psger_.c
+++ b/PBLAS/SRC/psger_.c
@@ -286,7 +286,7 @@ void psger_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
    if( ( Amp > 0 ) && ( Anq > 0 ) )
    {
       sger_( &Amp, &Anq, ((char *) ALPHA), XA, &ione, YA, &YAd[LLD_],
-             ((char *) (A+(Aii+Ajj*Ald))), &Ald );
+             ((char *)Mptr(A,Aii,Ajj,Ald,1)), &Ald );
    }
    if( XAfr ) free( XA );
    if( YAfr ) free( YA );

--- a/PBLAS/SRC/psnrm2_.c
+++ b/PBLAS/SRC/psnrm2_.c
@@ -224,7 +224,7 @@ void psnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 */
       if( ( ( myrow == Xrow ) || ( Xrow < 0 ) ) &&
           ( ( mycol == Xcol ) || ( Xcol < 0 ) ) )
-         *NORM2 = ABS( X[Xii+Xjj*Xd[LLD_]] );
+         *NORM2 = ABS( *Mptr(X,Xii,Xjj,Xd[LLD_],1) );
       return;
    }
    else if( *INCX == Xd[M_] )
@@ -246,7 +246,7 @@ void psnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
          if( Xnq > 0 )
          {
             Xld  = Xd[LLD_];
-            Xptr = X+(Xii+Xjj*Xld);
+            Xptr = Mptr(X,Xii,Xjj,Xld,1);
 
             for( k = 0; k < Xnq; k++ )
             {
@@ -366,7 +366,7 @@ l_20:
          Xnp = PB_Cnumroc( *N, Xi, Xd[IMB_], Xd[MB_], myrow, Xd[RSRC_], nprow );
          if( Xnp > 0 )
          {
-            Xptr = X+(Xii+Xjj*Xd[LLD_]);
+            Xptr = Mptr(X,Xii,Xjj,Xd[LLD_],1);
 
             for( k = 0; k < Xnp; k++ )
             {

--- a/PBLAS/SRC/psscal_.c
+++ b/PBLAS/SRC/psscal_.c
@@ -210,12 +210,12 @@ void psscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
             Xld = Xd[LLD_];
             if( ALPHA[REAL_PART] == ZERO )
             {
-               sset_( &Xnq, ((char *) ALPHA), ((char *)(X+(Xii+Xjj*Xld))),
+               sset_( &Xnq, ((char *) ALPHA), ((char *)Mptr(X,Xii,Xjj,Xld,1)),
                       &Xld );
             }
             else
             {
-               sscal_( &Xnq, ((char *) ALPHA), ((char *)(X+(Xii+Xjj*Xld))),
+               sscal_( &Xnq, ((char *) ALPHA), ((char *)Mptr(X,Xii,Xjj,Xld,1)),
                        &Xld );
             }
          }
@@ -239,12 +239,12 @@ void psscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
             if( ALPHA[REAL_PART] == ZERO )
             {
                sset_( &Xnp, ((char *) ALPHA),
-                      ((char *)( X+(Xii+Xjj*Xd[LLD_]) )), INCX );
+                      ((char *)Mptr( X,Xii,Xjj,Xd[LLD_],1) ), INCX );
             }
             else
             {
                sscal_( &Xnp, ((char *) ALPHA),
-                       ((char *)( X+(Xii+Xjj*Xd[LLD_]) )), INCX );
+                       ((char *)Mptr( X,Xii,Xjj,Xd[LLD_],1 )), INCX );
             }
          }
       }


### PR DESCRIPTION
An integer overflow occurs and causes segmentation fault
when 2D row/col index is linearized using 32-bit integers.
PBLAS Mptr() macro should be used instead.

This fix only fixes address calculations with row, column, and leading
dimension. There might be other places where an overflow occurs but
they may not matter for practical purposes because they would require
very large matrices or very long vectors within a single process.