### PR TITLE
ILP64 support

### DIFF
--- a/BLACS/SRC/BI_Arecv.c
+++ b/BLACS/SRC/BI_Arecv.c
@@ -1,8 +1,9 @@
 #include "Bdef.h"
 
-void BI_Arecv(BLACSCONTEXT *ctxt, int src, int msgid, BLACBUFF *bp)
+void BI_Arecv(BLACSCONTEXT *ctxt, Int src, Int msgid, BLACBUFF *bp)
 {
-   int i, info, errclass;
+   Int i, info;
+   MpiInt errclass;
 
    info=MPI_Irecv(bp->Buff, bp->N, bp->dtype, src, msgid, ctxt->scp->comm,
                 &bp->Aops[bp->nAops]);

--- a/BLACS/SRC/BI_ArgCheck.c
+++ b/BLACS/SRC/BI_ArgCheck.c
@@ -1,13 +1,13 @@
 #include "Bdef.h"
 
 
-void BI_ArgCheck(int ConTxt, int RoutType, char *routine, char scope,
-                 char uplo, char diag, int m, int n, int lda, int nprocs,
-                 int *prows, int *pcols)
+void BI_ArgCheck(Int ConTxt, Int RoutType, char *routine, char scope,
+                 char uplo, char diag, Int m, Int n, Int lda, Int nprocs,
+                 Int *prows, Int *pcols)
 {
 #if (BlacsDebugLvl > 0)
    char *srcdest;
-   int i=1, prow, pcol, Ng, nprow, npcol, myrow, mycol;
+   Int i=1, prow, pcol, Ng, nprow, npcol, myrow, mycol;
    BLACSCONTEXT *ctxt;
 
    MGetConTxt(ConTxt, ctxt);

--- a/BLACS/SRC/BI_Asend.c
+++ b/BLACS/SRC/BI_Asend.c
@@ -1,8 +1,9 @@
 #include "Bdef.h"
 
-void BI_Asend(BLACSCONTEXT *ctxt, int dest, int msgid, BLACBUFF *bp)
+void BI_Asend(BLACSCONTEXT *ctxt, Int dest, Int msgid, BLACBUFF *bp)
 {
-   int i, info, errclass;
+   Int i, info;
+   MpiInt errclass;
 
    info=MPI_Isend(bp->Buff, bp->N, bp->dtype, dest, msgid, ctxt->scp->comm,
                 &bp->Aops[bp->nAops]);

--- a/BLACS/SRC/BI_BeComb.c
+++ b/BLACS/SRC/BI_BeComb.c
@@ -8,7 +8,7 @@
  *  Robert van de Geijn, et al.
  */
 void BI_BeComb(BLACSCONTEXT *ctxt, BLACBUFF *bp, BLACBUFF *bp2,
-               int N, VVFUNPTR Xvvop)
+               Int N, VVFUNPTR Xvvop)
 /*
  *  -- V1.1ALPHA (test version) BLACS routine --
  *  University of Tennessee, October 1, 1995
@@ -47,15 +47,15 @@ void BI_BeComb(BLACSCONTEXT *ctxt, BLACBUFF *bp, BLACBUFF *bp2,
  * ------------------------------------------------------------------------
  */
 {
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Rsend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Arecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Rsend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Arecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int Np, Iam, dest, msgid, Rmsgid, np2, bit, ierr;
+   Int Np, Iam, dest, msgid, Rmsgid, np2, bit, ierr;
    extern MPI_Status *BI_Stats;
 
    Np = ctxt->scp->Np;

--- a/BLACS/SRC/BI_BlacsAbort.c
+++ b/BLACS/SRC/BI_BlacsAbort.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_BlacsAbort(int ErrNo)
+void BI_BlacsAbort(Int ErrNo)
 {
-   int ierr;
+   Int ierr;
    fflush(stderr);
    fflush(stdout);
    ierr=MPI_Abort(MPI_COMM_WORLD, ErrNo);

--- a/BLACS/SRC/BI_BlacsErr.c
+++ b/BLACS/SRC/BI_BlacsErr.c
@@ -1,14 +1,14 @@
 #include "Bdef.h"
 
-void BI_BlacsErr(int ConTxt, int line, char *file, char *form, ...)
+void BI_BlacsErr(Int ConTxt, Int line, char *file, char *form, ...)
 {
 #ifdef __STDC__
-   void BI_BlacsAbort(int ErrNo);
+   void BI_BlacsAbort(Int ErrNo);
 #else
    void BI_BlacsAbort();
 #endif
-   extern int BI_Iam;
-   int myrow, mycol;
+   extern Int BI_Iam;
+   Int myrow, mycol;
    va_list argptr;
    char cline[100];
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/BI_BlacsWarn.c
+++ b/BLACS/SRC/BI_BlacsWarn.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
-void BI_BlacsWarn(int ConTxt, int line, char *file, char *form, ...)
+void BI_BlacsWarn(Int ConTxt, Int line, char *file, char *form, ...)
 {
-   extern int BI_Iam;
+   extern Int BI_Iam;
    extern BLACSCONTEXT **BI_MyContxts;
-   int myrow, mycol;
+   Int myrow, mycol;
    va_list argptr;
    char cline[100];
 

--- a/BLACS/SRC/BI_BuffIsFree.c
+++ b/BLACS/SRC/BI_BuffIsFree.c
@@ -1,14 +1,14 @@
 #include "Bdef.h"
 
-int BI_BuffIsFree(BLACBUFF *bp, int Wait)
+Int BI_BuffIsFree(BLACBUFF *bp, Int Wait)
 /*
  *  Check to see if buff is finished with async. operations.  If Wait != 0,
  *  wait for all async. operations to complete.
  */
 {
-   int i, info;
+   MpiInt i, info;
    extern MPI_Status *BI_Stats;
-   extern int BI_Np;
+   extern Int BI_Np;
 
 
    if (!Wait)

--- a/BLACS/SRC/BI_ContxtNum.c
+++ b/BLACS/SRC/BI_ContxtNum.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
-int BI_ContxtNum(BLACSCONTEXT *ctxt)
+Int BI_ContxtNum(BLACSCONTEXT *ctxt)
 /*
  *  Returns the integer ID of ctxt
  */
 {
-   int i;
-   extern int BI_MaxNCtxt;
+   Int i;
+   extern Int BI_MaxNCtxt;
    extern BLACSCONTEXT **BI_MyContxts;
 
    if (ctxt == NULL) return(-1);

--- a/BLACS/SRC/BI_EmergencyBuff.c
+++ b/BLACS/SRC/BI_EmergencyBuff.c
@@ -6,15 +6,15 @@
  *  the user-changeable macro value BUFWAIT.  If in that time no active    *
  *  buffer becomes inactive, a hang is assumed, and the grid is killed.    *
  ***************************************************************************/
-void BI_EmergencyBuff(int length)
+void BI_EmergencyBuff(Int length)
 {
    void BI_UpdateBuffs(BLACBUFF *);
 
    char *cptr;
-   int i, j;
+   Int i, j;
    double Mwalltime(void);
    double t1;
-   extern int BI_Np;
+   extern Int BI_Np;
    extern BLACBUFF *BI_ReadyB, *BI_ActiveQ;
 
    j = sizeof(BLACBUFF);

--- a/BLACS/SRC/BI_GetBuff.c
+++ b/BLACS/SRC/BI_GetBuff.c
@@ -34,13 +34,13 @@
  *  it a little more complex.						   *
  ***************************************************************************/
 
-BLACBUFF *BI_GetBuff(int length)
+BLACBUFF *BI_GetBuff(Int length)
 {
-   void BI_EmergencyBuff(int length);
+   void BI_EmergencyBuff(Int length);
 
    char *cptr;
-   int i, j;
-   extern int BI_Np;
+   Int i, j;
+   extern Int BI_Np;
    extern BLACBUFF *BI_ReadyB;
 
 /*

--- a/BLACS/SRC/BI_GetMpiGeType.c
+++ b/BLACS/SRC/BI_GetMpiGeType.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
-MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *ctxt, int m, int n, int lda,
-                                MPI_Datatype Dtype, int *N)
+MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *ctxt, Int m, Int n, Int lda,
+                                MPI_Datatype Dtype, Int *N)
 {
-   int info;
+   Int info;
    MPI_Datatype GeType;
 
 /*

--- a/BLACS/SRC/BI_GetMpiTrType.c
+++ b/BLACS/SRC/BI_GetMpiTrType.c
@@ -1,14 +1,13 @@
 #include "Bdef.h"
 
-
 MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *ctxt, char uplo, char diag,
-                                int m, int n, int lda, MPI_Datatype Dtype,
-                                int *N)
+                                Int m, Int n, Int lda, MPI_Datatype Dtype,
+                                Int *N)
 {
-   BLACBUFF *BI_GetBuff(int);
+   BLACBUFF *BI_GetBuff(Int);
    MPI_Datatype TrType;
-   int info, start, i, k;
-   int *len, *disp;
+   Int info, start, i, k;
+   MpiInt *len, *disp;
    BLACBUFF *bp;
 
    if (diag == 'u') start = 1;
@@ -32,9 +31,9 @@ MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *ctxt, char uplo, char diag,
 /*
  * Get space to hold the length and displacement values
  */
-   bp = BI_GetBuff( 2 * n * sizeof(int) );
-   len = (int *) bp->Buff;
-   disp = (int *) &bp->Buff[n*sizeof(int)];
+   bp = BI_GetBuff( 2 * n * sizeof(MpiInt) );
+   len = (MpiInt *) bp->Buff;
+   disp = (MpiInt *) &bp->Buff[n*sizeof(MpiInt)];
 
    if (m > n)
    {

--- a/BLACS/SRC/BI_GlobalVars.c
+++ b/BLACS/SRC/BI_GlobalVars.c
@@ -2,13 +2,13 @@
 /*
  * Define global variables
  */
-int BI_MaxNCtxt=0;		  /* Number of context pointers allocated */
-int BI_MaxNSysCtxt=0;             /* Number of system ctxt ptrs allocated */
-int BI_Iam, BI_Np=(-1);	          /* My pnum, and # of procs in system */
+Int BI_MaxNCtxt=0;		  /* Number of context pointers allocated */
+Int BI_MaxNSysCtxt=0;             /* Number of system ctxt ptrs allocated */
+Int BI_Iam, BI_Np=(-1);	          /* My pnum, and # of procs in system */
 BLACBUFF *BI_ReadyB=NULL;         /* buffer that is ready for use */
 BLACBUFF *BI_ActiveQ=NULL;        /* pointer to start of active buffer queue */
 BLACBUFF BI_AuxBuff;
 BLACSCONTEXT **BI_MyContxts=NULL; /* Array of pointers to my contexts */
 MPI_Comm *BI_SysContxts=NULL;
-int *BI_COMM_WORLD=NULL;
+Int *BI_COMM_WORLD=NULL;
 MPI_Status *BI_Stats=NULL;

--- a/BLACS/SRC/BI_HypBR.c
+++ b/BLACS/SRC/BI_HypBR.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
-int BI_HypBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int src)
+Int BI_HypBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int src)
 {
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   int relnode, bit, Np, Iam, msgid;
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   Int relnode, bit, Np, Iam, msgid;
 
    Np = ctxt->scp->Np;
    Iam = ctxt->scp->Iam;

--- a/BLACS/SRC/BI_HypBS.c
+++ b/BLACS/SRC/BI_HypBS.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-int BI_HypBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send)
+Int BI_HypBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send)
 {
-   int bit, Np, Iam, msgid;
+   Int bit, Np, Iam, msgid;
 
    Np = ctxt->scp->Np;
    if (Np < 2) return(NORV);

--- a/BLACS/SRC/BI_IdringBR.c
+++ b/BLACS/SRC/BI_IdringBR.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
-void BI_IdringBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int src, int step)
+void BI_IdringBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int src, Int step)
 {
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   int Np, Iam, msgid, dest;
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   Int Np, Iam, msgid, dest;
 
    Np = ctxt->scp->Np;
    Iam = ctxt->scp->Iam;

--- a/BLACS/SRC/BI_IdringBS.c
+++ b/BLACS/SRC/BI_IdringBS.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_IdringBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int step)
+void BI_IdringBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int step)
 {
-   int Np, Iam, msgid;
+   Int Np, Iam, msgid;
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_MpathBR.c
+++ b/BLACS/SRC/BI_MpathBR.c
@@ -1,15 +1,15 @@
 #include "Bdef.h"
 
-void BI_MpathBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int src, int npaths)
+void BI_MpathBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int src, Int npaths)
 {
-   void BI_Arecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   void BI_Arecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int pathlen;		/* the minimal length of each path */
-   int mydist;		/* my distance from src */
-   int faredge;		/* node at far end of path */
-   int lastlong;	/* distance to node on end of last path with extra node */
-   int Np, Iam, msgid, Np_1, dest;
+   Int pathlen;		/* the minimal length of each path */
+   Int mydist;		/* my distance from src */
+   Int faredge;		/* node at far end of path */
+   Int lastlong;	/* distance to node on end of last path with extra node */
+   Int Np, Iam, msgid, Np_1, dest;
 
    msgid = Mscopeid(ctxt);
    BI_Arecv(ctxt, BANYNODE, msgid, bp);

--- a/BLACS/SRC/BI_MpathBS.c
+++ b/BLACS/SRC/BI_MpathBS.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
-void BI_MpathBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int npaths)
+void BI_MpathBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int npaths)
 {
-   int pathlen;		/* the length of each path */
-   int dist;	        /* the distance to the node closest to src on each path */
-   int pdest;           /* part of dest calculation -- saves unneeded ops */
-   int lastlong;	/* number of paths with extra node */
-   int Np, Iam, msgid, Np_1, dir;
+   Int pathlen;		/* the length of each path */
+   Int dist;	        /* the distance to the node closest to src on each path */
+   Int pdest;           /* part of dest calculation -- saves unneeded ops */
+   Int lastlong;	/* number of paths with extra node */
+   Int Np, Iam, msgid, Np_1, dir;
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_MringComb.c
+++ b/BLACS/SRC/BI_MringComb.c
@@ -1,16 +1,16 @@
 #include "Bdef.h"
 void BI_MringComb(BLACSCONTEXT *ctxt, BLACBUFF *bp, BLACBUFF *bp2,
-                  int N, VVFUNPTR Xvvop, int dest, int nrings)
+                  Int N, VVFUNPTR Xvvop, Int dest, Int nrings)
 {
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
 
-   int Np, Iam, msgid, i, inc, mysrc, mydest, Np_1;
-   int mydist, ringlen, myring;
-   int nearedge, faredge;  /* edge closest and farthest from dest */
-   int REBS;               /* Is result leave-on-all? */
+   Int Np, Iam, msgid, i, inc, mysrc, mydest, Np_1;
+   Int mydist, ringlen, myring;
+   Int nearedge, faredge;  /* edge closest and farthest from dest */
+   Int REBS;               /* Is result leave-on-all? */
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_Pack.c
+++ b/BLACS/SRC/BI_Pack.c
@@ -1,13 +1,13 @@
 #include "Bdef.h"
 BLACBUFF *BI_Pack(BLACSCONTEXT *ctxt,BVOID *A,BLACBUFF *bp,MPI_Datatype Dtype)
 {
-   BLACBUFF *BI_GetBuff(int);
-   int i, info, one=1;
+   BLACBUFF *BI_GetBuff(Int);
+   MpiInt i, info, one=1;
    MPI_Aint eltsiz;
 #ifdef ZeroByteTypeBug
    char *cptr;
    extern BLACBUFF BI_AuxBuff;
-   extern int BI_Np;
+   extern Int BI_Np;
 #endif
 
 /*

--- a/BLACS/SRC/BI_Rsend.c
+++ b/BLACS/SRC/BI_Rsend.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
 
-void BI_Rsend(BLACSCONTEXT *ctxt, int dest, int msgid, BLACBUFF *bp)
+void BI_Rsend(BLACSCONTEXT *ctxt, Int dest, Int msgid, BLACBUFF *bp)
 {
-   int info;
+   Int info;
 
    info=MPI_Rsend(bp->Buff, bp->N, bp->dtype, dest, msgid, ctxt->scp->comm);
 }

--- a/BLACS/SRC/BI_Srecv.c
+++ b/BLACS/SRC/BI_Srecv.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_Srecv(BLACSCONTEXT *ctxt, int src, int msgid, BLACBUFF *bp)
+void BI_Srecv(BLACSCONTEXT *ctxt, Int src, Int msgid, BLACBUFF *bp)
 {
-   int i, info;
+   Int i, info;
    extern MPI_Status *BI_Stats;
 
    info=MPI_Recv(bp->Buff, bp->N, bp->dtype, src, msgid, ctxt->scp->comm,BI_Stats);

--- a/BLACS/SRC/BI_SringBR.c
+++ b/BLACS/SRC/BI_SringBR.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
-void BI_SringBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int src)
+void BI_SringBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int src)
 {
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
-   int mydist;  	/* my distance from source */
-   int Np, Iam, msgid, rightedge;
+   Int mydist;  	/* my distance from source */
+   Int Np, Iam, msgid, rightedge;
 
    Np = ctxt->scp->Np;
    Iam = ctxt->scp->Iam;

--- a/BLACS/SRC/BI_SringBS.c
+++ b/BLACS/SRC/BI_SringBS.c
@@ -2,7 +2,7 @@
 
 void BI_SringBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send)
 {
-   int Np, Iam, msgid;
+   Int Np, Iam, msgid;
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_Ssend.c
+++ b/BLACS/SRC/BI_Ssend.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
 
-void BI_Ssend(BLACSCONTEXT *ctxt, int dest, int msgid, BLACBUFF *bp)
+void BI_Ssend(BLACSCONTEXT *ctxt, Int dest, Int msgid, BLACBUFF *bp)
 {
-   int info;
+   Int info;
    info=MPI_Send(bp->Buff, bp->N, bp->dtype, dest, msgid, ctxt->scp->comm);
 }

--- a/BLACS/SRC/BI_TransDist.c
+++ b/BLACS/SRC/BI_TransDist.c
@@ -1,14 +1,14 @@
 #include "Bdef.h"
 
-void BI_TransDist(BLACSCONTEXT *ctxt, char scope, int m, int n, int *rA,
-                  int *cA, int ldrc, BI_DistType *dist, int rdest, int cdest)
+void BI_TransDist(BLACSCONTEXT *ctxt, char scope, Int m, Int n, Int *rA,
+                  Int *cA, Int ldrc, BI_DistType *dist, Int rdest, Int cdest)
 /*
  *  This routine translates distances (offsets from the destination node),
  *  stored in location dist, into row and column coordinates.
  */
 {
-   int i, j, k, dest;
-   int Ng, nprow, npcol, myrow, mycol;
+   Int i, j, k, dest;
+   Int Ng, nprow, npcol, myrow, mycol;
 
    Mgridinfo(ctxt, Ng, nprow, npcol, myrow, mycol);
    if (rdest == -1) rdest = cdest = 0;
@@ -21,7 +21,7 @@ void BI_TransDist(BLACSCONTEXT *ctxt, char scope, int m, int n, int *rA,
          for (i=0; i < m; i++)
          {
             rA[i] = myrow;
-            cA[i] = (int) (cdest + dist[i]) % npcol;
+            cA[i] = (Int) (cdest + dist[i]) % npcol;
          }
          rA += ldrc;
          cA += ldrc;
@@ -33,7 +33,7 @@ void BI_TransDist(BLACSCONTEXT *ctxt, char scope, int m, int n, int *rA,
       {
          for (i=0; i < m; i++)
          {
-            rA[i] = (int) (rdest + dist[i]) % nprow;
+            rA[i] = (Int) (rdest + dist[i]) % nprow;
             cA[i] = mycol;
          }
          rA += ldrc;
@@ -47,7 +47,7 @@ void BI_TransDist(BLACSCONTEXT *ctxt, char scope, int m, int n, int *rA,
       {
          for (i=0; i < m; i++)
          {
-            k = (int) (dest + dist[i]) % Ng;   /* figure node number */
+            k = (Int) (dest + dist[i]) % Ng;   /* figure node number */
             Mvpcoord(ctxt, k, rA[i], cA[i]);   /* figure node coordinates */
          }
          rA += ldrc;

--- a/BLACS/SRC/BI_TransUserComm.c
+++ b/BLACS/SRC/BI_TransUserComm.c
@@ -1,16 +1,22 @@
 #include "Bdef.h"
 
-MPI_Comm BI_TransUserComm(int Ucomm, int Np, int *pmap)
+MPI_Comm BI_TransUserComm(Int Ucomm, Int Np, Int *pmap)
 {
    MPI_Comm bcomm, ucomm;
    MPI_Group bgrp, ugrp;
-   int i;
+   Int i;
+
+   MpiInt *mpmap = (MpiInt *)malloc(Np * sizeof(MpiInt));
+   for (i=0; i<Np; i++) mpmap[i] = pmap[i];
+
    ucomm = MPI_Comm_f2c(Ucomm);
    i=MPI_Comm_group(ucomm, &ugrp);
-   i=MPI_Group_incl(ugrp, Np, pmap, &bgrp);
+   i=MPI_Group_incl(ugrp, Np, mpmap, &bgrp);
    i=MPI_Comm_create(ucomm, bgrp, &bcomm);
    i=MPI_Group_free(&ugrp);
    i=MPI_Group_free(&bgrp);
+
+   free(mpmap);
 
    return(bcomm);
 }

--- a/BLACS/SRC/BI_TreeBR.c
+++ b/BLACS/SRC/BI_TreeBR.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
-void BI_TreeBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int src, int nbranches)
+void BI_TreeBR(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int src, Int nbranches)
 {
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   int Np, Iam, msgid, i, j;
-   int mydist;          /* my distance from src */
-   int destdist;	/* the distance of the destination node */
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   Int Np, Iam, msgid, i, j;
+   Int mydist;          /* my distance from src */
+   Int destdist;	/* the distance of the destination node */
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_TreeBS.c
+++ b/BLACS/SRC/BI_TreeBS.c
@@ -34,10 +34,10 @@
  *   |
  *   7
  */
-void BI_TreeBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, int nbranches)
+void BI_TreeBS(BLACSCONTEXT *ctxt, BLACBUFF *bp, SDRVPTR send, Int nbranches)
 {
-   int Np, Iam, msgid, i, j;
-   int destdist;	/* the distance of the destination node */
+   Int Np, Iam, msgid, i, j;
+   Int destdist;	/* the distance of the destination node */
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_TreeComb.c
+++ b/BLACS/SRC/BI_TreeComb.c
@@ -17,7 +17,7 @@
  */
 
 void BI_TreeComb(BLACSCONTEXT *ctxt, BLACBUFF *bp, BLACBUFF *bp2,
-                 int N, VVFUNPTR Xvvop, int dest, int nbranches)
+                 Int N, VVFUNPTR Xvvop, Int dest, Int nbranches)
 /*
  *  -- V1.1ALPHA (test version) BLACS routine --
  *  University of Tennessee, October 1, 1995
@@ -47,38 +47,38 @@ void BI_TreeComb(BLACSCONTEXT *ctxt, BLACBUFF *bp, BLACBUFF *bp2,
  *            This BLACBUFF is used to receive information for combining with
  *            this process's information.
  *
- *  DEST      (input) int
+ *  DEST      (input) Int
  *            Node to receive answer.  If DEST == -1, all nodes in receive
  *            the answer.
  *
- *  N         (input) int
+ *  N         (input) Int
  *            The number of elements in the vector.  N >= 0.
  *
  *  Xvvop     (input) pointer to typed operation function
  *            Points to a typed function which performs the required operation
  *            (e.g. summation) on the two N-element vectors.
  *
- *  NBRANCHES (input) int
+ *  NBRANCHES (input) Int
  *            Indicates the degree of the tree to use (see picture above).
  *
  * ------------------------------------------------------------------------
  */
 {
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Rsend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Arecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Rsend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Arecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
-   int Np, Iam, msgid, Rmsgid, i, j;
-   int nrcvs=0;	  /* Number of ReCeiVeS to do */
-   int REBS;	  /* should info be RE-BroadcaSt? */
-   int rightedge; /* right-most receiving node */
-   int mydist;    /* my distance from destination node */
-   int dist;
-   int src;       /* Used if we must force repeatability */
+   Int Np, Iam, msgid, Rmsgid, i, j;
+   Int nrcvs=0;	  /* Number of ReCeiVeS to do */
+   Int REBS;	  /* should info be RE-BroadcaSt? */
+   Int rightedge; /* right-most receiving node */
+   Int mydist;    /* my distance from destination node */
+   Int dist;
+   Int src;       /* Used if we must force repeatability */
 
    Np = ctxt->scp->Np;
    if (Np < 2) return;

--- a/BLACS/SRC/BI_Unpack.c
+++ b/BLACS/SRC/BI_Unpack.c
@@ -2,7 +2,7 @@
 
 void BI_Unpack(BLACSCONTEXT *ctxt, BVOID *A, BLACBUFF *bp, MPI_Datatype Dtype)
 {
-   int i=0, info, one=1;
+   MpiInt i=0, info, one=1;
 
 /*
  * Some versions of mpich and its derivitives cannot handle 0 byte typedefs,

--- a/BLACS/SRC/BI_UpdateBuffs.c
+++ b/BLACS/SRC/BI_UpdateBuffs.c
@@ -2,7 +2,7 @@
 
 void BI_UpdateBuffs(BLACBUFF *Newbp)
 {
-   int BI_BuffIsFree(BLACBUFF *, int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
    BLACBUFF *bp, *bp2;
    extern BLACBUFF *BI_ReadyB, *BI_ActiveQ;
 

--- a/BLACS/SRC/BI_cMPI_amn.c
+++ b/BLACS/SRC/BI_cMPI_amn.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_cMPI_amn(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_cMPI_amn(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_cvvamn(int, char *, char *);
+   void BI_cvvamn(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_cvvamn(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_cMPI_amn2.c
+++ b/BLACS/SRC/BI_cMPI_amn2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_cMPI_amn2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_cMPI_amn2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_cvvamn2(int, char *, char *);
+   void BI_cvvamn2(Int, char *, char *);
    BI_cvvamn2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_cMPI_amx.c
+++ b/BLACS/SRC/BI_cMPI_amx.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_cMPI_amx(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_cMPI_amx(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_cvvamx(int, char *, char *);
+   void BI_cvvamx(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_cvvamx(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_cMPI_amx2.c
+++ b/BLACS/SRC/BI_cMPI_amx2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_cMPI_amx2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_cMPI_amx2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_cvvamx2(int, char *, char *);
+   void BI_cvvamx2(Int, char *, char *);
    BI_cvvamx2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_cMPI_sum.c
+++ b/BLACS/SRC/BI_cMPI_sum.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_cMPI_sum(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_cMPI_sum(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_cvvsum(int, char *, char *);
+   void BI_cvvsum(Int, char *, char *);
    BI_cvvsum(*N, inout, in);
 }

--- a/BLACS/SRC/BI_cvvamn.c
+++ b/BLACS/SRC/BI_cvvamn.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_cvvamn(int N, char *vec1, char *vec2)
+void BI_cvvamn(Int N, char *vec1, char *vec2)
 {
    SCOMPLEX *v1=(SCOMPLEX*)vec1, *v2=(SCOMPLEX*)vec2;
    float diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(SCOMPLEX);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_cvvamn2.c
+++ b/BLACS/SRC/BI_cvvamn2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_cvvamn2(int N, char *vec1, char *vec2)
+void BI_cvvamn2(Int N, char *vec1, char *vec2)
 {
-   int r, i;
+   Int r, i;
    float *v1=(float*)vec1, *v2=(float*)vec2;
    float diff;
 

--- a/BLACS/SRC/BI_cvvamx.c
+++ b/BLACS/SRC/BI_cvvamx.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_cvvamx(int N, char *vec1, char *vec2)
+void BI_cvvamx(Int N, char *vec1, char *vec2)
 {
    SCOMPLEX *v1=(SCOMPLEX*)vec1, *v2=(SCOMPLEX*)vec2;
    float diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(SCOMPLEX);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_cvvamx2.c
+++ b/BLACS/SRC/BI_cvvamx2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_cvvamx2(int N, char *vec1, char *vec2)
+void BI_cvvamx2(Int N, char *vec1, char *vec2)
 {
-   int r, i;
+   Int r, i;
    float *v1=(float*)vec1, *v2=(float*)vec2;
    float diff;
 

--- a/BLACS/SRC/BI_cvvsum.c
+++ b/BLACS/SRC/BI_cvvsum.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
-void BI_cvvsum(int N, char *vec1, char *vec2)
+void BI_cvvsum(Int N, char *vec1, char *vec2)
 {
    float *v1=(float*)vec1, *v2=(float*)vec2;
-   int k;
+   Int k;
    N *=2;
    for (k=0; k < N; k++) v1[k] += v2[k];
 }

--- a/BLACS/SRC/BI_dMPI_amn.c
+++ b/BLACS/SRC/BI_dMPI_amn.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_dMPI_amn(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_dMPI_amn(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_dvvamn(int, char *, char *);
+   void BI_dvvamn(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_dvvamn(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_dMPI_amn2.c
+++ b/BLACS/SRC/BI_dMPI_amn2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_dMPI_amn2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_dMPI_amn2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_dvvamn2(int, char *, char *);
+   void BI_dvvamn2(Int, char *, char *);
    BI_dvvamn2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_dMPI_amx.c
+++ b/BLACS/SRC/BI_dMPI_amx.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_dMPI_amx(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_dMPI_amx(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_dvvamx(int, char *, char *);
+   void BI_dvvamx(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_dvvamx(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_dMPI_amx2.c
+++ b/BLACS/SRC/BI_dMPI_amx2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_dMPI_amx2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_dMPI_amx2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_dvvamx2(int, char *, char *);
+   void BI_dvvamx2(Int, char *, char *);
    BI_dvvamx2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_dmvcopy.c
+++ b/BLACS/SRC/BI_dmvcopy.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_dmvcopy(int m, int n, double *A, int lda, double *buff)
+void BI_dmvcopy(Int m, Int n, double *A, Int lda, double *buff)
 /*
  * Performs a matrix to vector copy (pack) for the data type double
  */
 {
-   int i, j;
+   Int i, j;
 
    if ( (m == lda) || (n == 1) )
    {

--- a/BLACS/SRC/BI_dvmcopy.c
+++ b/BLACS/SRC/BI_dvmcopy.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
-void BI_dvmcopy(int m, int n, double *A, int lda, double *buff)
+void BI_dvmcopy(Int m, Int n, double *A, Int lda, double *buff)
 /*
  *  performs an vector to matrix copy (unpack) for the data type double
  */
 {
-   int i, j;
+   Int i, j;
 
    if ( (m == lda) || (n == 1) )
    {

--- a/BLACS/SRC/BI_dvvamn.c
+++ b/BLACS/SRC/BI_dvvamn.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_dvvamn(int N, char *vec1, char *vec2)
+void BI_dvvamn(Int N, char *vec1, char *vec2)
 {
    double *v1=(double*)vec1, *v2=(double*)vec2;
    double diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(double);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_dvvamn2.c
+++ b/BLACS/SRC/BI_dvvamn2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_dvvamn2(int N, char *vec1, char *vec2)
+void BI_dvvamn2(Int N, char *vec1, char *vec2)
 {
-   int k;
+   Int k;
    double *v1=(double*)vec1, *v2=(double*)vec2;
    double diff;
 

--- a/BLACS/SRC/BI_dvvamx.c
+++ b/BLACS/SRC/BI_dvvamx.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_dvvamx(int N, char *vec1, char *vec2)
+void BI_dvvamx(Int N, char *vec1, char *vec2)
 {
    double *v1=(double*)vec1, *v2=(double*)vec2;
    double diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(double);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_dvvamx2.c
+++ b/BLACS/SRC/BI_dvvamx2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_dvvamx2(int N, char *vec1, char *vec2)
+void BI_dvvamx2(Int N, char *vec1, char *vec2)
 {
-   int k;
+   Int k;
    double *v1=(double*)vec1, *v2=(double*)vec2;
    double diff;
 

--- a/BLACS/SRC/BI_dvvsum.c
+++ b/BLACS/SRC/BI_dvvsum.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_dvvsum(int N, char *vec1, char *vec2)
+void BI_dvvsum(Int N, char *vec1, char *vec2)
 {
    double *v1=(double*)vec1, *v2=(double*)vec2;
-   int k;
+   Int k;
    for (k=0; k < N; k++) v1[k] += v2[k];
 }

--- a/BLACS/SRC/BI_iMPI_amn.c
+++ b/BLACS/SRC/BI_iMPI_amn.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_iMPI_amn(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_iMPI_amn(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_ivvamn(int, char *, char *);
+   void BI_ivvamn(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_ivvamn(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_iMPI_amn2.c
+++ b/BLACS/SRC/BI_iMPI_amn2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_iMPI_amn2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_iMPI_amn2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_ivvamn2(int, char *, char *);
+   void BI_ivvamn2(Int, char *, char *);
    BI_ivvamn2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_iMPI_amx.c
+++ b/BLACS/SRC/BI_iMPI_amx.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_iMPI_amx(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_iMPI_amx(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_ivvamx(int, char *, char *);
+   void BI_ivvamx(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_ivvamx(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_iMPI_amx2.c
+++ b/BLACS/SRC/BI_iMPI_amx2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_iMPI_amx2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_iMPI_amx2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_ivvamx2(int, char *, char *);
+   void BI_ivvamx2(Int, char *, char *);
    BI_ivvamx2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_imvcopy.c
+++ b/BLACS/SRC/BI_imvcopy.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_imvcopy(int m, int n, int *A, int lda, int *buff)
+void BI_imvcopy(Int m, Int n, Int *A, Int lda, Int *buff)
 /*
- * Performs a matrix to vector copy (pack) for the data type int
+ * Performs a matrix to vector copy (pack) for the data type Int
  */
 {
-   int i, j;
+   Int i, j;
 
    if ( (m == lda) || (n == 1) )
    {

--- a/BLACS/SRC/BI_ivmcopy.c
+++ b/BLACS/SRC/BI_ivmcopy.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
-void BI_ivmcopy(int m, int n, int *A, int lda, int *buff)
+void BI_ivmcopy(Int m, Int n, Int *A, Int lda, Int *buff)
 /*
- *  performs an vector to matrix copy (unpack) for the data type int
+ *  performs an vector to matrix copy (unpack) for the data type Int
  */
 {
-   int i, j;
+   Int i, j;
 
    if ( (m == lda) || (n == 1) )
    {

--- a/BLACS/SRC/BI_ivvamn.c
+++ b/BLACS/SRC/BI_ivvamn.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
-void BI_ivvamn(int N, char *vec1, char *vec2)
+void BI_ivvamn(Int N, char *vec1, char *vec2)
 {
-   int *v1=(int*)vec1, *v2=(int*)vec2;
-   int diff;
+   Int *v1=(Int*)vec1, *v2=(Int*)vec2;
+   Int diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
-   k = N * sizeof(int);
+   k = N * sizeof(Int);
    i = k % sizeof(BI_DistType);
    if (i) k += sizeof(BI_DistType) - i;
    dist1 = (BI_DistType *) &vec1[k];

--- a/BLACS/SRC/BI_ivvamn2.c
+++ b/BLACS/SRC/BI_ivvamn2.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
-void BI_ivvamn2(int N, char *vec1, char *vec2)
+void BI_ivvamn2(Int N, char *vec1, char *vec2)
 {
-   int k;
-   int *v1=(int*)vec1, *v2=(int*)vec2;
-   int diff;
+   Int k;
+   Int *v1=(Int*)vec1, *v2=(Int*)vec2;
+   Int diff;
 
    for (k=0; k != N; k++)
    {

--- a/BLACS/SRC/BI_ivvamx.c
+++ b/BLACS/SRC/BI_ivvamx.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
-void BI_ivvamx(int N, char *vec1, char *vec2)
+void BI_ivvamx(Int N, char *vec1, char *vec2)
 {
-   int *v1=(int*)vec1, *v2=(int*)vec2;
-   int diff;
+   Int *v1=(Int*)vec1, *v2=(Int*)vec2;
+   Int diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
-   k = N * sizeof(int);
+   k = N * sizeof(Int);
    i = k % sizeof(BI_DistType);
    if (i) k += sizeof(BI_DistType) - i;
    dist1 = (BI_DistType *) &vec1[k];

--- a/BLACS/SRC/BI_ivvamx2.c
+++ b/BLACS/SRC/BI_ivvamx2.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
-void BI_ivvamx2(int N, char *vec1, char *vec2)
+void BI_ivvamx2(Int N, char *vec1, char *vec2)
 {
-   int k;
-   int *v1=(int*)vec1, *v2=(int*)vec2;
-   int diff;
+   Int k;
+   Int *v1=(Int*)vec1, *v2=(Int*)vec2;
+   Int diff;
 
    for (k=0; k != N; k++)
    {

--- a/BLACS/SRC/BI_ivvsum.c
+++ b/BLACS/SRC/BI_ivvsum.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_ivvsum(int N, char *vec1, char *vec2)
+void BI_ivvsum(Int N, char *vec1, char *vec2)
 {
-   int *v1=(int*)vec1, *v2=(int*)vec2;
-   int k;
+   Int *v1=(Int*)vec1, *v2=(Int*)vec2;
+   Int k;
    for (k=0; k < N; k++) v1[k] += v2[k];
 }

--- a/BLACS/SRC/BI_sMPI_amn.c
+++ b/BLACS/SRC/BI_sMPI_amn.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_sMPI_amn(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_sMPI_amn(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_svvamn(int, char *, char *);
+   void BI_svvamn(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_svvamn(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_sMPI_amn2.c
+++ b/BLACS/SRC/BI_sMPI_amn2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_sMPI_amn2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_sMPI_amn2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_svvamn2(int, char *, char *);
+   void BI_svvamn2(Int, char *, char *);
    BI_svvamn2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_sMPI_amx.c
+++ b/BLACS/SRC/BI_sMPI_amx.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_sMPI_amx(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_sMPI_amx(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_svvamx(int, char *, char *);
+   void BI_svvamx(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_svvamx(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_sMPI_amx2.c
+++ b/BLACS/SRC/BI_sMPI_amx2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_sMPI_amx2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_sMPI_amx2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_svvamx2(int, char *, char *);
+   void BI_svvamx2(Int, char *, char *);
    BI_svvamx2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_smvcopy.c
+++ b/BLACS/SRC/BI_smvcopy.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_smvcopy(int m, int n, float *A, int lda, float *buff)
+void BI_smvcopy(Int m, Int n, float *A, Int lda, float *buff)
 /*
  * Performs a matrix to vector copy (pack) for the data type float
  */
 {
-   int i, j;
+   Int i, j;
 
    if ( (m == lda) || (n == 1) )
    {

--- a/BLACS/SRC/BI_svmcopy.c
+++ b/BLACS/SRC/BI_svmcopy.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
-void BI_svmcopy(int m, int n, float *A, int lda, float *buff)
+void BI_svmcopy(Int m, Int n, float *A, Int lda, float *buff)
 /*
  *  performs an vector to matrix copy (unpack) for the data type float
  */
 {
-   int i, j;
+   Int i, j;
 
    if ( (m == lda) || (n == 1) )
    {

--- a/BLACS/SRC/BI_svvamn.c
+++ b/BLACS/SRC/BI_svvamn.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_svvamn(int N, char *vec1, char *vec2)
+void BI_svvamn(Int N, char *vec1, char *vec2)
 {
    float *v1=(float*)vec1, *v2=(float*)vec2;
    float diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(float);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_svvamn2.c
+++ b/BLACS/SRC/BI_svvamn2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_svvamn2(int N, char *vec1, char *vec2)
+void BI_svvamn2(Int N, char *vec1, char *vec2)
 {
-   int k;
+   Int k;
    float *v1=(float*)vec1, *v2=(float*)vec2;
    float diff;
 

--- a/BLACS/SRC/BI_svvamx.c
+++ b/BLACS/SRC/BI_svvamx.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_svvamx(int N, char *vec1, char *vec2)
+void BI_svvamx(Int N, char *vec1, char *vec2)
 {
    float *v1=(float*)vec1, *v2=(float*)vec2;
    float diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(float);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_svvamx2.c
+++ b/BLACS/SRC/BI_svvamx2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_svvamx2(int N, char *vec1, char *vec2)
+void BI_svvamx2(Int N, char *vec1, char *vec2)
 {
-   int k;
+   Int k;
    float *v1=(float*)vec1, *v2=(float*)vec2;
    float diff;
 

--- a/BLACS/SRC/BI_svvsum.c
+++ b/BLACS/SRC/BI_svvsum.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_svvsum(int N, char *vec1, char *vec2)
+void BI_svvsum(Int N, char *vec1, char *vec2)
 {
    float *v1=(float*)vec1, *v2=(float*)vec2;
-   int k;
+   Int k;
    for (k=0; k < N; k++) v1[k] += v2[k];
 }

--- a/BLACS/SRC/BI_zMPI_amn.c
+++ b/BLACS/SRC/BI_zMPI_amn.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_zMPI_amn(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_zMPI_amn(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_zvvamn(int, char *, char *);
+   void BI_zvvamn(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_zvvamn(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_zMPI_amn2.c
+++ b/BLACS/SRC/BI_zMPI_amn2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_zMPI_amn2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_zMPI_amn2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_zvvamn2(int, char *, char *);
+   void BI_zvvamn2(Int, char *, char *);
    BI_zvvamn2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_zMPI_amx.c
+++ b/BLACS/SRC/BI_zMPI_amx.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
 
-void BI_zMPI_amx(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_zMPI_amx(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_zvvamx(int, char *, char *);
+   void BI_zvvamx(Int, char *, char *);
    extern BLACBUFF BI_AuxBuff;
 
    BI_zvvamx(BI_AuxBuff.Len, inout, in);

--- a/BLACS/SRC/BI_zMPI_amx2.c
+++ b/BLACS/SRC/BI_zMPI_amx2.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_zMPI_amx2(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_zMPI_amx2(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_zvvamx2(int, char *, char *);
+   void BI_zvvamx2(Int, char *, char *);
    BI_zvvamx2(*N, inout, in);
 }

--- a/BLACS/SRC/BI_zMPI_sum.c
+++ b/BLACS/SRC/BI_zMPI_sum.c
@@ -1,6 +1,6 @@
 #include "Bdef.h"
-void BI_zMPI_sum(void *in, void *inout, int *N, MPI_Datatype *dtype)
+void BI_zMPI_sum(void *in, void *inout, MpiInt *N, MPI_Datatype *dtype)
 {
-   void BI_zvvsum(int, char *, char *);
+   void BI_zvvsum(Int, char *, char *);
    BI_zvvsum(*N, inout, in);
 }

--- a/BLACS/SRC/BI_zvvamn.c
+++ b/BLACS/SRC/BI_zvvamn.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_zvvamn(int N, char *vec1, char *vec2)
+void BI_zvvamn(Int N, char *vec1, char *vec2)
 {
    DCOMPLEX *v1=(DCOMPLEX*)vec1, *v2=(DCOMPLEX*)vec2;
    double diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(DCOMPLEX);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_zvvamn2.c
+++ b/BLACS/SRC/BI_zvvamn2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_zvvamn2(int N, char *vec1, char *vec2)
+void BI_zvvamn2(Int N, char *vec1, char *vec2)
 {
-   int r, i;
+   Int r, i;
    double *v1=(double*)vec1, *v2=(double*)vec2;
    double diff;
 

--- a/BLACS/SRC/BI_zvvamx.c
+++ b/BLACS/SRC/BI_zvvamx.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
-void BI_zvvamx(int N, char *vec1, char *vec2)
+void BI_zvvamx(Int N, char *vec1, char *vec2)
 {
    DCOMPLEX *v1=(DCOMPLEX*)vec1, *v2=(DCOMPLEX*)vec2;
    double diff;
    BI_DistType *dist1, *dist2;
-   int i, k;
+   Int i, k;
 
    k = N * sizeof(DCOMPLEX);
    i = k % sizeof(BI_DistType);

--- a/BLACS/SRC/BI_zvvamx2.c
+++ b/BLACS/SRC/BI_zvvamx2.c
@@ -1,7 +1,7 @@
 #include "Bdef.h"
-void BI_zvvamx2(int N, char *vec1, char *vec2)
+void BI_zvvamx2(Int N, char *vec1, char *vec2)
 {
-   int r, i;
+   Int r, i;
    double *v1=(double*)vec1, *v2=(double*)vec2;
    double diff;
 

--- a/BLACS/SRC/BI_zvvsum.c
+++ b/BLACS/SRC/BI_zvvsum.c
@@ -1,8 +1,8 @@
 #include "Bdef.h"
-void BI_zvvsum(int N, char *vec1, char *vec2)
+void BI_zvvsum(Int N, char *vec1, char *vec2)
 {
    double *v1=(double*)vec1, *v2=(double*)vec2;
-   int k;
+   Int k;
    N *=2;
    for (k=0; k < N; k++) v1[k] += v2[k];
 }

--- a/BLACS/SRC/Bconfig.h
+++ b/BLACS/SRC/Bconfig.h
@@ -16,6 +16,16 @@
 #include <mpi.h>
 
 /*
+ * Integer types used by BLACS
+ */
+#ifndef Int
+#define Int int
+#endif
+#ifndef MpiInt
+#define MpiInt int
+#endif
+
+/*
  * These macros define the naming strategy needed for a fortran
  * routine to call a C routine, and whether to build so they may be
  * called from C or fortran.  For the fortran call C interface, ADD_ assumes that

--- a/BLACS/SRC/Bdef.h
+++ b/BLACS/SRC/Bdef.h
@@ -13,8 +13,8 @@ typedef struct bLaCsScOpE BLACSSCOPE;
 struct bLaCsScOpE
 {
    MPI_Comm comm;
-   int ScpId, MaxId, MinId;
-   int Np, Iam;
+   Int ScpId, MaxId, MinId;
+   Int Np, Iam;
 };
 /*
  * Data type defining a context for the BLACS
@@ -24,10 +24,10 @@ struct bLaCsCoNtExT
 {
    BLACSSCOPE rscp, cscp, ascp, pscp; /* row, column, all, and pt2pt scopes */
    BLACSSCOPE *scp;                   /* pointer to present scope */
-   int TopsRepeat;                    /* Use only repeatable topologies? */
-   int TopsCohrnt;                    /* Use only coherent topologies? */
-   int Nb_bs, Nr_bs;           /* for bcast general tree and multiring tops */
-   int Nb_co, Nr_co;           /* for combine general tree and multiring tops */
+   Int TopsRepeat;                    /* Use only repeatable topologies? */
+   Int TopsCohrnt;                    /* Use only coherent topologies? */
+   Int Nb_bs, Nr_bs;           /* for bcast general tree and multiring tops */
+   Int Nb_co, Nr_co;           /* for combine general tree and multiring tops */
 };
 
 /*
@@ -44,7 +44,7 @@ typedef struct {float r, i;} SCOMPLEX;
  *  these guys external in every file that needs them.
  */
 #ifndef GlobalVars
-   extern int *BI_COMM_WORLD;
+   extern Int *BI_COMM_WORLD;
 #endif
 
 /*
@@ -54,19 +54,19 @@ typedef struct bLaCbUfF BLACBUFF;
 struct bLaCbUfF
 {
    char *Buff;             /* send/recv buffer */
-   int Len;                /* length of buffer in bytes */
-   int nAops;              /* number of asynchronous operations out of buff */
+   Int Len;                /* length of buffer in bytes */
+   Int nAops;              /* number of asynchronous operations out of buff */
    MPI_Request *Aops;   /* list of async. operations out of buff */
    MPI_Datatype dtype;  /* data type of buffer */
-   int N;                  /* number of elements of data type in buff */
+   Int N;                  /* number of elements of data type in buff */
    BLACBUFF *prev, *next;  /* pointer to the other BLACBUFF in queue */
 };
 
 /*
  * Pointer to the combine's vector-vector functions
  */
-typedef void (*VVFUNPTR)(int, char *, char *);
-typedef void (*SDRVPTR)(BLACSCONTEXT *, int, int, BLACBUFF *);
+typedef void (*VVFUNPTR)(Int, char *, char *);
+typedef void (*SDRVPTR)(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
 
 #define BI_DistType                  unsigned short
@@ -126,9 +126,9 @@ typedef void (*SDRVPTR)(BLACSCONTEXT *, int, int, BLACBUFF *);
  * These are prototypes for error and warning functions -- I don't want
  * to prototype them in each routine.
  */
-void BI_BlacsWarn(int ConTxt, int line, char *file, char *form, ...);
-void BI_BlacsErr(int ConTxt, int line, char *file, char *form, ...);
-int BI_ContxtNum(BLACSCONTEXT *ctxt);
+void BI_BlacsWarn(Int ConTxt, Int line, char *file, char *form, ...);
+void BI_BlacsErr(Int ConTxt, Int line, char *file, char *form, ...);
+Int BI_ContxtNum(BLACSCONTEXT *ctxt);
 
 /*
  * If we've got an ANSI standard C compiler, we can use void pointers...
@@ -187,7 +187,7 @@ int BI_ContxtNum(BLACSCONTEXT *ctxt);
 #define MGetConTxt(Context, ctxtptr)\
 {\
    extern BLACSCONTEXT **BI_MyContxts;\
-   extern int BI_MaxNCtxt;\
+   extern Int BI_MaxNCtxt;\
    if ( ((Context) >= BI_MaxNCtxt) || ((Context) < 0) )\
       BI_BlacsErr(-1, __LINE__, __FILE__, "Invalid context handle: %d",\
                   (Context));\
@@ -221,7 +221,7 @@ int BI_ContxtNum(BLACSCONTEXT *ctxt);
  */
 #define ErrPrint \
 { \
-   extern int BI_Iam; \
+   extern Int BI_Iam; \
    fprintf(stderr, "%d: line %d of file %s\n", BI_Iam, __LINE__, __FILE__); \
 }
 
@@ -230,7 +230,7 @@ int BI_ContxtNum(BLACSCONTEXT *ctxt);
  * needed on the CRAY to have a C routine callable from fortran
  */
 #define F_VOID_FUNC void
-#define F_INT_FUNC  int
+#define F_INT_FUNC  Int
 #define F_DOUBLE_FUNC double
 
 #if (INTFACE == C_CALL)

--- a/BLACS/SRC/blacs2sys_.c
+++ b/BLACS/SRC/blacs2sys_.c
@@ -1,13 +1,13 @@
 #include "Bdef.h"
 #if (INTFACE == C_CALL)
-MPI_Comm Cblacs2sys_handle(int BlacsCtxt)
+MPI_Comm Cblacs2sys_handle(Int BlacsCtxt)
 #else
-int blacs2sys_handle_(int *BlacsCtxt)
+Int blacs2sys_handle_(Int *BlacsCtxt)
 #endif
 {
 #if (INTFACE == C_CALL)
-   int i[2];
-   extern int BI_MaxNSysCtxt;
+   Int i[2];
+   extern Int BI_MaxNSysCtxt;
    extern MPI_Comm *BI_SysContxts;
 
    if (BI_COMM_WORLD == NULL) Cblacs_pinfo(i, &i[1]);

--- a/BLACS/SRC/blacs_abort_.c
+++ b/BLACS/SRC/blacs_abort_.c
@@ -1,14 +1,15 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_abort(int ConTxt, int ErrNo)
+void Cblacs_abort(Int ConTxt, Int ErrNo)
 #else
-F_VOID_FUNC blacs_abort_(int *ConTxt, int *ErrNo)
+F_VOID_FUNC blacs_abort_(Int *ConTxt, Int *ErrNo)
 #endif
 {
-   void BI_BlacsAbort(int ErrNo);
-   int nprow, npcol, myrow, mycol;
-   extern int BI_Iam;
+   void Cblacs_gridinfo(Int, Int *, Int *, Int *, Int *);
+   void BI_BlacsAbort(Int ErrNo);
+   Int nprow, npcol, myrow, mycol;
+   extern Int BI_Iam;
 
    Cblacs_gridinfo(Mpval(ConTxt), &nprow, &npcol, &myrow, &mycol);
    fprintf(stderr,

--- a/BLACS/SRC/blacs_barr_.c
+++ b/BLACS/SRC/blacs_barr_.c
@@ -1,13 +1,13 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_barrier(int ConTxt, char *scope)
+void Cblacs_barrier(Int ConTxt, char *scope)
 #else
-F_VOID_FUNC blacs_barrier_(int *ConTxt, F_CHAR scope)
+F_VOID_FUNC blacs_barrier_(Int *ConTxt, F_CHAR scope)
 #endif
 {
    char tscope;
-   int ierr;
+   Int ierr;
    BLACSCONTEXT *ctxt;
 
    tscope = F2C_CharTrans(scope);

--- a/BLACS/SRC/blacs_exit_.c
+++ b/BLACS/SRC/blacs_exit_.c
@@ -1,18 +1,19 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_exit(int NotDone)
+void Cblacs_exit(Int NotDone)
 #else
-F_VOID_FUNC blacs_exit_(int *NotDone)
+F_VOID_FUNC blacs_exit_(Int *NotDone)
 #endif
 {
+   void Cblacs_gridexit(Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
    BLACBUFF *bp;
    extern BLACBUFF *BI_ReadyB, *BI_ActiveQ, BI_AuxBuff;
-   int i;
-   extern int BI_MaxNCtxt, BI_Np;
+   Int i;
+   extern Int BI_MaxNCtxt, BI_Np;
    extern BLACSCONTEXT **BI_MyContxts;
 /*
  * Destroy all contexts

--- a/BLACS/SRC/blacs_free_.c
+++ b/BLACS/SRC/blacs_free_.c
@@ -1,13 +1,13 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_freebuff(int ConTxt, int Wait)
+void Cblacs_freebuff(Int ConTxt, Int Wait)
 #else
-F_VOID_FUNC blacs_freebuff_(int *ConTxt, int *Wait)
+F_VOID_FUNC blacs_freebuff_(Int *ConTxt, Int *Wait)
 #endif
 {
    void BI_UpdateBuffs(BLACBUFF *);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
    extern BLACBUFF *BI_ReadyB, *BI_ActiveQ;
 
    if (Mpval(Wait))  /* wait for all buffers to be done */

--- a/BLACS/SRC/blacs_get_.c
+++ b/BLACS/SRC/blacs_get_.c
@@ -1,12 +1,14 @@
 #include "Bdef.h"
 #if (INTFACE == C_CALL)
-void Cblacs_get(int ConTxt, int what, int *val)
+void Cblacs_get(Int ConTxt, Int what, Int *val)
 #else
-F_VOID_FUNC blacs_get_(int *ConTxt, int *what, int *val)
+F_VOID_FUNC blacs_get_(Int *ConTxt, Int *what, Int *val)
 #endif
 {
-   int ierr, *iptr;
-   int comm;
+   Int Csys2blacs_handle(MPI_Comm);
+   Int ierr, *iptr;
+   MpiInt flag;
+   Int comm;
    BLACSCONTEXT *ctxt;
 
    switch( Mpval(what) )
@@ -22,7 +24,7 @@ F_VOID_FUNC blacs_get_(int *ConTxt, int *what, int *val)
    case SGET_MSGIDS:
       if (BI_COMM_WORLD == NULL) Cblacs_pinfo(val, &val[1]);
       iptr = &val[1];
-      ierr=MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, (BVOID **) &iptr,val);
+      ierr=MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, (BVOID **) &iptr,&flag);
       val[0] = 0;
       val[1] = *iptr;
       break;

--- a/BLACS/SRC/blacs_grid_.c
+++ b/BLACS/SRC/blacs_grid_.c
@@ -1,14 +1,14 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_gridexit(int ConTxt)
+void Cblacs_gridexit(Int ConTxt)
 #else
-F_VOID_FUNC blacs_gridexit_(int *ConTxt)
+F_VOID_FUNC blacs_gridexit_(Int *ConTxt)
 #endif
 {
-   int i;
+   Int i;
    BLACSCONTEXT *ctxt;
-   extern int BI_MaxNCtxt;
+   extern Int BI_MaxNCtxt;
    extern BLACSCONTEXT **BI_MyContxts;
 
    if ( (Mpval(ConTxt) < 0) || (Mpval(ConTxt) >= BI_MaxNCtxt) )

--- a/BLACS/SRC/blacs_info_.c
+++ b/BLACS/SRC/blacs_info_.c
@@ -1,14 +1,14 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_gridinfo(int ConTxt, int *nprow, int *npcol, int *myrow, int *mycol)
+void Cblacs_gridinfo(Int ConTxt, Int *nprow, Int *npcol, Int *myrow, Int *mycol)
 #else
-F_VOID_FUNC blacs_gridinfo_(int *ConTxt, int *nprow, int *npcol,
-                            int *myrow, int *mycol)
+F_VOID_FUNC blacs_gridinfo_(Int *ConTxt, Int *nprow, Int *npcol,
+                            Int *myrow, Int *mycol)
 #endif
 {
    extern BLACSCONTEXT **BI_MyContxts;
-   extern int BI_MaxNCtxt;
+   extern Int BI_MaxNCtxt;
    BLACSCONTEXT *ctxt;
 /*
  * Make sure context handle is in range

--- a/BLACS/SRC/blacs_init_.c
+++ b/BLACS/SRC/blacs_init_.c
@@ -1,20 +1,21 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_gridinit(int *ConTxt, char *order, int nprow, int npcol)
+void Cblacs_gridinit(Int *ConTxt, char *order, Int nprow, Int npcol)
 #else
-F_VOID_FUNC blacs_gridinit_(int *ConTxt, F_CHAR order, int *nprow, int *npcol)
+F_VOID_FUNC blacs_gridinit_(Int *ConTxt, F_CHAR order, Int *nprow, Int *npcol)
 #endif
 {
-   int *tmpgrid, *iptr;
-   int i, j;
+   void Cblacs_gridmap(Int *, Int *, Int, Int, Int);
+   Int *tmpgrid, *iptr;
+   Int i, j;
 
 /*
  * Grid can be row- or column-major natural ordering when blacs_gridinit is
  * called.  Define a tmpgrid to reflect this, and call blacs_gridmap to
  * set it up
  */
-   iptr = tmpgrid = (int*) malloc( Mpval(nprow)*Mpval(npcol)*sizeof(*tmpgrid) );
+   iptr = tmpgrid = (Int*) malloc( Mpval(nprow)*Mpval(npcol)*sizeof(*tmpgrid) );
    if (Mlowcase(F2C_CharTrans(order)) == 'c')
    {
       i = Mpval(npcol) * Mpval(nprow);

--- a/BLACS/SRC/blacs_pcoord_.c
+++ b/BLACS/SRC/blacs_pcoord_.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_pcoord(int ConTxt, int nodenum, int *prow, int *pcol)
+void Cblacs_pcoord(Int ConTxt, Int nodenum, Int *prow, Int *pcol)
 #else
-F_VOID_FUNC blacs_pcoord_(int *ConTxt, int *nodenum, int *prow, int *pcol)
+F_VOID_FUNC blacs_pcoord_(Int *ConTxt, Int *nodenum, Int *prow, Int *pcol)
 #endif
 {
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/blacs_pinfo_.c
+++ b/BLACS/SRC/blacs_pinfo_.c
@@ -1,27 +1,28 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_pinfo(int *mypnum, int *nprocs)
+void Cblacs_pinfo(Int *mypnum, Int *nprocs)
 #else
-F_VOID_FUNC blacs_pinfo_(int *mypnum, int *nprocs)
+F_VOID_FUNC blacs_pinfo_(Int *mypnum, Int *nprocs)
 #endif
 {
-   int ierr;
-   extern int BI_Iam, BI_Np;
-   int argc=0;
+   Int ierr;
+   extern Int BI_Iam, BI_Np;
+   MpiInt flag, Iam = BI_Iam, Np = BI_Np;
+   MpiInt argc=0;
    char **argv=NULL;
    if (BI_COMM_WORLD == NULL)
    {
-      MPI_Initialized(nprocs);
+      MPI_Initialized(&flag);
 
-      if (!(*nprocs)) 
+      if (!flag) 
          ierr = MPI_Init(&argc,&argv);  // call Init and ignore argc and argv
 
-      BI_COMM_WORLD = (int *) malloc(sizeof(int));
+      BI_COMM_WORLD = (Int *) malloc(sizeof(Int));
       *BI_COMM_WORLD = MPI_Comm_c2f(MPI_COMM_WORLD);
-      MPI_Comm_size(MPI_COMM_WORLD, &BI_Np);
-      MPI_Comm_rank(MPI_COMM_WORLD, &BI_Iam);
+      MPI_Comm_size(MPI_COMM_WORLD, &Np);
+      MPI_Comm_rank(MPI_COMM_WORLD, &Iam);
    }
-   *mypnum = BI_Iam;
-   *nprocs = BI_Np;
+   *mypnum = BI_Iam = Iam;
+   *nprocs = BI_Np  = Np;
 }

--- a/BLACS/SRC/blacs_pnum_.c
+++ b/BLACS/SRC/blacs_pnum_.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-int Cblacs_pnum(int ConTxt, int prow, int pcol)
+Int Cblacs_pnum(Int ConTxt, Int prow, Int pcol)
 #else
-F_INT_FUNC blacs_pnum_(int *ConTxt, int *prow, int *pcol)
+F_INT_FUNC blacs_pnum_(Int *ConTxt, Int *prow, Int *pcol)
 #endif
 {
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/blacs_set_.c
+++ b/BLACS/SRC/blacs_set_.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_set(int ConTxt, int what, int *val)
+void Cblacs_set(Int ConTxt, Int what, Int *val)
 #else
-F_VOID_FUNC blacs_set_(int *ConTxt, int *what, int *val)
+F_VOID_FUNC blacs_set_(Int *ConTxt, Int *what, Int *val)
 #endif
 {
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/blacs_setup_.c
+++ b/BLACS/SRC/blacs_setup_.c
@@ -1,13 +1,14 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cblacs_setup(int *mypnum, int *nprocs)
+void Cblacs_setup(Int *mypnum, Int *nprocs)
 #else
-F_VOID_FUNC blacs_setup_(int *mypnum, int *nprocs)
+F_VOID_FUNC blacs_setup_(Int *mypnum, Int *nprocs)
 #endif
 {
 /*
  * blacs_setup same as blacs_pinfo for non-PVM versions of the BLACS
  */
+   void Cblacs_pinfo(Int *, Int *);
    Cblacs_pinfo(mypnum, nprocs);
 }

--- a/BLACS/SRC/cgamn2d_.c
+++ b/BLACS/SRC/cgamn2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Ccgamn2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Ccgamn2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC cgamn2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amn.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amn.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_cvvamn(int, char *, char *);
-   void BI_cvvamn2(int, char *, char *);
-   void BI_cMPI_amn(void *, void *, int *, MPI_Datatype *);
-   void BI_cMPI_amn2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_cvvamn(Int, char *, char *);
+   void BI_cvvamn2(Int, char *, char *);
+   void BI_cMPI_amn(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_cMPI_amn2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/cgamx2d_.c
+++ b/BLACS/SRC/cgamx2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Ccgamx2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Ccgamx2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC cgamx2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amx.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amx.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_cvvamx(int, char *, char *);
-   void BI_cvvamx2(int, char *, char *);
-   void BI_cMPI_amx(void *, void *, int *, MPI_Datatype *);
-   void BI_cMPI_amx2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_cvvamx(Int, char *, char *);
+   void BI_cvvamx2(Int, char *, char *);
+   void BI_cMPI_amx(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_cMPI_amx2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/cgebr2d_.c
+++ b/BLACS/SRC/cgebr2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Ccgebr2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int rsrc, int csrc)
+void Ccgebr2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC cgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC cgebr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC cgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -31,51 +31,51 @@ F_VOID_FUNC cgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/cgebs2d_.c
+++ b/BLACS/SRC/cgebs2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Ccgebs2d(int ConTxt, char *scope, char *top, int m, int n, float *A, int lda)
+void Ccgebs2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A, Int lda)
 #else
-F_VOID_FUNC cgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda)
+F_VOID_FUNC cgebs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,7 +18,7 @@ F_VOID_FUNC cgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -30,40 +30,40 @@ F_VOID_FUNC cgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/cgerv2d_.c
+++ b/BLACS/SRC/cgerv2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Ccgerv2d(int ConTxt, int m, int n, float *A, int lda, int rsrc, int csrc)
+void Ccgerv2d(Int ConTxt, Int m, Int n, float *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC cgerv2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC cgerv2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,27 +18,27 @@ F_VOID_FUNC cgerv2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -48,17 +48,17 @@ F_VOID_FUNC cgerv2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tlda;
-   int ierr;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tlda;
+   Int ierr;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;

--- a/BLACS/SRC/cgesd2d_.c
+++ b/BLACS/SRC/cgesd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Ccgesd2d(int ConTxt, int m, int n, float *A, int lda,
-              int rdest, int cdest)
+void Ccgesd2d(Int ConTxt, Int m, Int n, float *A, Int lda,
+              Int rdest, Int cdest)
 #else
-F_VOID_FUNC cgesd2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
-                     int *rdest, int *cdest)
+F_VOID_FUNC cgesd2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,43 +19,43 @@ F_VOID_FUNC cgesd2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int dest, tlda, ierr;
+   Int dest, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/cgsum2d_.c
+++ b/BLACS/SRC/cgsum2d_.c
@@ -2,11 +2,11 @@
 
 
 #if (INTFACE == C_CALL)
-void Ccgsum2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int rdest, int cdest)
+void Ccgsum2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC cgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC cgsum2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC cgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,55 +32,55 @@ F_VOID_FUNC cgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the sum.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the sum.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_cvvsum(int, char *, char *);
-   void BI_cMPI_sum(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_cvvsum(Int, char *, char *);
+   void BI_cMPI_sum(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int N, length, dest, tlda, trdest, ierr;
+   Int N, length, dest, tlda, trdest, ierr;
    MPI_Op BlacComb;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;

--- a/BLACS/SRC/ctrbr2d_.c
+++ b/BLACS/SRC/ctrbr2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cctrbr2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, float *A, int lda, int rsrc, int csrc)
+void Cctrbr2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, float *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC ctrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, float *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC ctrbr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, float *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC ctrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -42,10 +42,10 @@ F_VOID_FUNC ctrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
@@ -54,41 +54,41 @@ F_VOID_FUNC ctrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope, tuplo, tdiag;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/ctrbs2d_.c
+++ b/BLACS/SRC/ctrbs2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cctrbs2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, float *A, int lda)
+void Cctrbs2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, float *A, Int lda)
 #else
-F_VOID_FUNC ctrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, float *A, int *lda)
+F_VOID_FUNC ctrbs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, float *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC ctrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -41,10 +41,10 @@ F_VOID_FUNC ctrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to complex two dimensional array
@@ -53,30 +53,30 @@ F_VOID_FUNC ctrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope, tuplo, tdiag;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/ctrrv2d_.c
+++ b/BLACS/SRC/ctrrv2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cctrrv2d(int ConTxt, char *uplo, char *diag, int m, int n, float *A,
-              int lda, int rsrc, int csrc)
+void Cctrrv2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, float *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC ctrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     float *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC ctrrv2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     float *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC ctrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC ctrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to complex two dimensional array
@@ -44,14 +44,14 @@ F_VOID_FUNC ctrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -61,17 +61,17 @@ F_VOID_FUNC ctrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tuplo, tdiag, tlda;
-   int ierr, length;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tuplo, tdiag, tlda;
+   Int ierr, length;
    BLACBUFF *bp;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/ctrsd2d_.c
+++ b/BLACS/SRC/ctrsd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cctrsd2d(int ConTxt, char *uplo, char *diag, int m, int n, float *A,
-              int lda, int rdest, int cdest)
+void Cctrsd2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, float *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC ctrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     float *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC ctrsd2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     float *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC ctrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC ctrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to complex two dimensional array
@@ -44,31 +44,31 @@ F_VOID_FUNC ctrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
    char tuplo, tdiag;
-   int dest, length, tlda, ierr;
+   Int dest, length, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/dgamn2d_.c
+++ b/BLACS/SRC/dgamn2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Cdgamn2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Cdgamn2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC dgamn2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amn.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amn.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_dvvamn(int, char *, char *);
-   void BI_dvvamn2(int, char *, char *);
-   void BI_dMPI_amn(void *, void *, int *, MPI_Datatype *);
-   void BI_dMPI_amn2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_dvvamn(Int, char *, char *);
+   void BI_dvvamn2(Int, char *, char *);
+   void BI_dMPI_amn(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_dMPI_amn2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/dgamx2d_.c
+++ b/BLACS/SRC/dgamx2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Cdgamx2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Cdgamx2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC dgamx2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amx.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amx.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_dvvamx(int, char *, char *);
-   void BI_dvvamx2(int, char *, char *);
-   void BI_dMPI_amx(void *, void *, int *, MPI_Datatype *);
-   void BI_dMPI_amx2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_dvvamx(Int, char *, char *);
+   void BI_dvvamx2(Int, char *, char *);
+   void BI_dMPI_amx(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_dMPI_amx2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/dgebr2d_.c
+++ b/BLACS/SRC/dgebr2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdgebr2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int rsrc, int csrc)
+void Cdgebr2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC dgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC dgebr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC dgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -31,51 +31,51 @@ F_VOID_FUNC dgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/dgebs2d_.c
+++ b/BLACS/SRC/dgebs2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdgebs2d(int ConTxt, char *scope, char *top, int m, int n, double *A, int lda)
+void Cdgebs2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A, Int lda)
 #else
-F_VOID_FUNC dgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda)
+F_VOID_FUNC dgebs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,7 +18,7 @@ F_VOID_FUNC dgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -30,40 +30,40 @@ F_VOID_FUNC dgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/dgerv2d_.c
+++ b/BLACS/SRC/dgerv2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdgerv2d(int ConTxt, int m, int n, double *A, int lda, int rsrc, int csrc)
+void Cdgerv2d(Int ConTxt, Int m, Int n, double *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC dgerv2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC dgerv2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,27 +18,27 @@ F_VOID_FUNC dgerv2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -48,17 +48,17 @@ F_VOID_FUNC dgerv2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tlda;
-   int ierr;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tlda;
+   Int ierr;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;

--- a/BLACS/SRC/dgesd2d_.c
+++ b/BLACS/SRC/dgesd2d_.c
@@ -2,11 +2,11 @@
 
 
 #if (INTFACE == C_CALL)
-void Cdgesd2d(int ConTxt, int m, int n, double *A, int lda,
-              int rdest, int cdest)
+void Cdgesd2d(Int ConTxt, Int m, Int n, double *A, Int lda,
+              Int rdest, Int cdest)
 #else
-F_VOID_FUNC dgesd2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
-                     int *rdest, int *cdest)
+F_VOID_FUNC dgesd2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,43 +20,43 @@ F_VOID_FUNC dgesd2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int dest, tlda, ierr;
+   Int dest, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/dgsum2d_.c
+++ b/BLACS/SRC/dgsum2d_.c
@@ -2,11 +2,11 @@
 
 
 #if (INTFACE == C_CALL)
-void Cdgsum2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int rdest, int cdest)
+void Cdgsum2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC dgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC dgsum2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC dgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,54 +32,54 @@ F_VOID_FUNC dgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the sum.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the sum.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_dvvsum(int, char *, char *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_dvvsum(Int, char *, char *);
 /*
  *  Variable Declarations
  */
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int N, length, dest, tlda, trdest, ierr;
+   Int N, length, dest, tlda, trdest, ierr;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
 

--- a/BLACS/SRC/dtrbr2d_.c
+++ b/BLACS/SRC/dtrbr2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdtrbr2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, double *A, int lda, int rsrc, int csrc)
+void Cdtrbr2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, double *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC dtrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, double *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC dtrbr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, double *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC dtrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -42,10 +42,10 @@ F_VOID_FUNC dtrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
@@ -54,41 +54,41 @@ F_VOID_FUNC dtrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope, tuplo, tdiag;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/dtrbs2d_.c
+++ b/BLACS/SRC/dtrbs2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdtrbs2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, double *A, int lda)
+void Cdtrbs2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, double *A, Int lda)
 #else
-F_VOID_FUNC dtrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, double *A, int *lda)
+F_VOID_FUNC dtrbs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, double *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC dtrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -41,10 +41,10 @@ F_VOID_FUNC dtrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double precision two dimensional array
@@ -53,30 +53,30 @@ F_VOID_FUNC dtrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope, tuplo, tdiag;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/dtrrv2d_.c
+++ b/BLACS/SRC/dtrrv2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdtrrv2d(int ConTxt, char *uplo, char *diag, int m, int n, double *A,
-              int lda, int rsrc, int csrc)
+void Cdtrrv2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, double *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC dtrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     double *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC dtrrv2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     double *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC dtrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC dtrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double precision two dimensional array
@@ -44,14 +44,14 @@ F_VOID_FUNC dtrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -61,17 +61,17 @@ F_VOID_FUNC dtrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tuplo, tdiag, tlda;
-   int ierr, length;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tuplo, tdiag, tlda;
+   Int ierr, length;
    BLACBUFF *bp;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/dtrsd2d_.c
+++ b/BLACS/SRC/dtrsd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cdtrsd2d(int ConTxt, char *uplo, char *diag, int m, int n, double *A,
-              int lda, int rdest, int cdest)
+void Cdtrsd2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, double *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC dtrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     double *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC dtrsd2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     double *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC dtrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC dtrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double precision two dimensional array
@@ -44,31 +44,31 @@ F_VOID_FUNC dtrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
    char tuplo, tdiag;
-   int dest, length, tlda, ierr;
+   Int dest, length, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/free_handle_.c
+++ b/BLACS/SRC/free_handle_.c
@@ -1,15 +1,15 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cfree_blacs_system_handle(int ISysCtxt)
+void Cfree_blacs_system_handle(Int ISysCtxt)
 #else
-void free_blacs_system_handle_(int *ISysCxt)
+void free_blacs_system_handle_(Int *ISysCxt)
 #endif
 {
 #if (INTFACE == C_CALL)
-   int i, j, DEF_WORLD;
+   Int i, j, DEF_WORLD;
    MPI_Comm *tSysCtxt;
-   extern int BI_MaxNSysCtxt;
+   extern Int BI_MaxNSysCtxt;
    extern MPI_Comm *BI_SysContxts;
 
 

--- a/BLACS/SRC/igamn2d_.c
+++ b/BLACS/SRC/igamn2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cigamn2d(int ConTxt, char *scope, char *top, int m, int n, int *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Cigamn2d(Int ConTxt, char *scope, char *top, Int m, Int n, Int *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     int *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC igamn2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     Int *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,17 +32,17 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -63,41 +63,44 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amn.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amn.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_ivvamn(int, char *, char *);
-   void BI_ivvamn2(int, char *, char *);
-   void BI_iMPI_amn(void *, void *, int *, MPI_Datatype *);
-   void BI_iMPI_amn2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_ivvamn(Int, char *, char *);
+   void BI_ivvamn2(Int, char *, char *);
+   void BI_iMPI_amn(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_iMPI_amn2(void *, void *, MpiInt *, MPI_Datatype *);
+   
+   printf("%ld %c %c %ld %ld %ld... %ld %ld... %ld... %ld %ld %d\n", ConTxt, *scope, *top, m, n, *A,
+              lda, *rA, *cA, ldia, rdest, cdest);
 /*
  *  Variable Declarations
  */
@@ -105,15 +108,17 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -179,7 +184,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    if (Mpval(ldia) != -1)
    {
       vvop = BI_ivvamn;
-      length = N * sizeof(int);
+      length = N * sizeof(Int);
       i = length % sizeof(BI_DistType);  /* ensure dist vec aligned correctly */
       if (i) length += sizeof(BI_DistType) - i;
       idist = length;
@@ -188,7 +193,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *    For performance, insist second buffer is at least 8-byte aligned
  */
       j = 8;
-      if (sizeof(int) > j) j = sizeof(int);
+      if (sizeof(Int) > j) j = sizeof(Int);
       i = length % j;
       if (i) length += j - i;
       i = 2 * length;
@@ -211,7 +216,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       len[0] = len[1] = N;
       disp[0] = 0;
       disp[1] = idist;
-      dtypes[0] = MPI_INT;
+      dtypes[0] = IntTyp;
       dtypes[1] = BI_MpiDistType;
 #ifdef ZeroByteTypeBug
       if (N > 0)
@@ -227,14 +232,14 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }
    else
    {
       vvop = BI_ivvamn2;
-      length = N * sizeof(int);
+      length = N * sizeof(Int);
 /*
  *    If A is contiguous, we can use it as one of our buffers
  */
@@ -252,7 +257,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
          BI_imvcopy(Mpval(m), Mpval(n), A, tlda, bp->Buff);
       }
       bp->N = bp2->N = N;
-      bp->dtype = bp2->dtype = MPI_INT;
+      bp->dtype = bp2->dtype = IntTyp;
    }
 
    switch(ttop)

--- a/BLACS/SRC/igamn2d_.c
+++ b/BLACS/SRC/igamn2d_.c
@@ -98,9 +98,6 @@ F_VOID_FUNC igamn2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
    void BI_ivvamn2(Int, char *, char *);
    void BI_iMPI_amn(void *, void *, MpiInt *, MPI_Datatype *);
    void BI_iMPI_amn2(void *, void *, MpiInt *, MPI_Datatype *);
-   
-   printf("%ld %c %c %ld %ld %ld... %ld %ld... %ld... %ld %ld %d\n", ConTxt, *scope, *top, m, n, *A,
-              lda, *rA, *cA, ldia, rdest, cdest);
 /*
  *  Variable Declarations
  */

--- a/BLACS/SRC/igamx2d_.c
+++ b/BLACS/SRC/igamx2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cigamx2d(int ConTxt, char *scope, char *top, int m, int n, int *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Cigamx2d(Int ConTxt, char *scope, char *top, Int m, Int n, Int *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     int *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC igamx2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     Int *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,17 +32,17 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -63,41 +63,41 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amx.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amx.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_ivvamx(int, char *, char *);
-   void BI_ivvamx2(int, char *, char *);
-   void BI_iMPI_amx(void *, void *, int *, MPI_Datatype *);
-   void BI_iMPI_amx2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_ivvamx(Int, char *, char *);
+   void BI_ivvamx2(Int, char *, char *);
+   void BI_iMPI_amx(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_iMPI_amx2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -105,15 +105,17 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -179,7 +181,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    if (Mpval(ldia) != -1)
    {
       vvop = BI_ivvamx;
-      length = N * sizeof(int);
+      length = N * sizeof(Int);
       i = length % sizeof(BI_DistType);  /* ensure dist vec aligned correctly */
       if (i) length += sizeof(BI_DistType) - i;
       idist = length;
@@ -188,7 +190,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *    For performance, insist second buffer is at least 8-byte aligned
  */
       j = 8;
-      if (sizeof(int) > j) j = sizeof(int);
+      if (sizeof(Int) > j) j = sizeof(Int);
       i = length % j;
       if (i) length += j - i;
       i = 2 * length;
@@ -211,7 +213,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       len[0] = len[1] = N;
       disp[0] = 0;
       disp[1] = idist;
-      dtypes[0] = MPI_INT;
+      dtypes[0] = IntTyp;
       dtypes[1] = BI_MpiDistType;
 #ifdef ZeroByteTypeBug
       if (N > 0)
@@ -227,14 +229,14 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }
    else
    {
       vvop = BI_ivvamx2;
-      length = N * sizeof(int);
+      length = N * sizeof(Int);
 /*
  *    If A is contiguous, we can use it as one of our buffers
  */
@@ -252,7 +254,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
          BI_imvcopy(Mpval(m), Mpval(n), A, tlda, bp->Buff);
       }
       bp->N = bp2->N = N;
-      bp->dtype = bp2->dtype = MPI_INT;
+      bp->dtype = bp2->dtype = IntTyp;
    }
 
    switch(ttop)

--- a/BLACS/SRC/igebr2d_.c
+++ b/BLACS/SRC/igebr2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cigebr2d(int ConTxt, char *scope, char *top, int m, int n, int *A,
-              int lda, int rsrc, int csrc)
+void Cigebr2d(Int ConTxt, char *scope, char *top, Int m, Int n, Int *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC igebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     int *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC igebr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     Int *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC igebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -31,51 +31,51 @@ F_VOID_FUNC igebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
-   MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   MPI_Datatype IntTyp, MatTyp;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 
@@ -117,8 +117,9 @@ F_VOID_FUNC igebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
                   tscope);
    }
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiGeType(ctxt, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
 /*
  * If using default topology, use MPI native broadcast
  */

--- a/BLACS/SRC/igebs2d_.c
+++ b/BLACS/SRC/igebs2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cigebs2d(int ConTxt, char *scope, char *top, int m, int n, int *A, int lda)
+void Cigebs2d(Int ConTxt, char *scope, char *top, Int m, Int n, Int *A, Int lda)
 #else
-F_VOID_FUNC igebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     int *A, int *lda)
+F_VOID_FUNC igebs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     Int *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,7 +18,7 @@ F_VOID_FUNC igebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -30,41 +30,41 @@ F_VOID_FUNC igebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope;
-   int error, tlda;
-   MPI_Datatype MatTyp;
+   Int error, tlda;
+   MPI_Datatype IntTyp, MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
@@ -107,8 +107,9 @@ F_VOID_FUNC igebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
                   tscope);
    }
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiGeType(ctxt, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
 /*
  * If using default topology, use MPI native broadcast
  */

--- a/BLACS/SRC/igerv2d_.c
+++ b/BLACS/SRC/igerv2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cigerv2d(int ConTxt, int m, int n, int *A, int lda, int rsrc, int csrc)
+void Cigerv2d(Int ConTxt, Int m, Int n, Int *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC igerv2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC igerv2d_(Int *ConTxt, Int *m, Int *n, Int *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,27 +18,27 @@ F_VOID_FUNC igerv2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -48,18 +48,18 @@ F_VOID_FUNC igerv2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tlda;
-   int ierr;
-   MPI_Datatype MatTyp;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tlda;
+   Int ierr;
+   MPI_Datatype IntTyp, MatTyp;
    BLACSCONTEXT *ctxt;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 
@@ -72,8 +72,9 @@ F_VOID_FUNC igerv2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
    else tlda = Mpval(lda);
    ctxt->scp = &ctxt->pscp;
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiGeType(ctxt, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
    BI_AuxBuff.Buff = (char *) A;
    BI_AuxBuff.dtype = MatTyp;
    BI_Srecv(ctxt, Mkpnum(ctxt, Mpval(rsrc), Mpval(csrc)), PT2PTID, &BI_AuxBuff);

--- a/BLACS/SRC/igesd2d_.c
+++ b/BLACS/SRC/igesd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cigesd2d(int ConTxt, int m, int n, int *A, int lda,
-              int rdest, int cdest)
+void Cigesd2d(Int ConTxt, Int m, Int n, Int *A, Int lda,
+              Int rdest, Int cdest)
 #else
-F_VOID_FUNC igesd2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
-                     int *rdest, int *cdest)
+F_VOID_FUNC igesd2d_(Int *ConTxt, Int *m, Int *n, Int *A, Int *lda,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,46 +19,46 @@ F_VOID_FUNC igesd2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int dest, tlda, ierr;
+   Int dest, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
-   MPI_Datatype MatTyp;
+   MPI_Datatype IntTyp, MatTyp;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 
    MGetConTxt(Mpval(ConTxt), ctxt);
@@ -71,8 +71,9 @@ F_VOID_FUNC igesd2d_(int *ConTxt, int *m, int *n, int *A, int *lda,
    dest = Mvkpnum(ctxt, Mpval(rdest), Mpval(cdest));
    ctxt->scp = &ctxt->pscp;
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiGeType(ctxt, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
 #ifdef SndIsLocBlk
    BI_AuxBuff.Buff = (char *) A;
    BI_AuxBuff.dtype = MatTyp;

--- a/BLACS/SRC/igsum2d_.c
+++ b/BLACS/SRC/igsum2d_.c
@@ -2,11 +2,11 @@
 
 
 #if (INTFACE == C_CALL)
-void Cigsum2d(int ConTxt, char *scope, char *top, int m, int n, int *A,
-              int lda, int rdest, int cdest)
+void Cigsum2d(Int ConTxt, char *scope, char *top, Int m, Int n, Int *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC igsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     int *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC igsum2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     Int *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC igsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,54 +32,55 @@ F_VOID_FUNC igsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the sum.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the sum.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_ivvsum(int, char *, char *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_ivvsum(Int, char *, char *);
 /*
  *  Variable Declarations
  */
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int N, length, dest, tlda, trdest, ierr, itr;
+   Int N, length, dest, tlda, trdest, ierr, itr;
+   MPI_Datatype Dtype;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
 
@@ -132,7 +133,7 @@ F_VOID_FUNC igsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  */
    if (ttop == ' ') if ( (Mpval(m) < 1) || (Mpval(n) < 1) ) ttop = '1';
    N = Mpval(m) * Mpval(n);
-   length = N * sizeof(int);
+   length = N * sizeof(Int);
 /*
  * If A is contiguous, we can use it as one of the buffers
  */
@@ -152,7 +153,9 @@ F_VOID_FUNC igsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       bp2->Buff = &bp->Buff[length];
       BI_imvcopy(Mpval(m), Mpval(n), A, tlda, bp->Buff);
    }
-   bp->dtype = bp2->dtype = MPI_INT;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &Dtype);
+   bp->dtype = bp2->dtype = Dtype;
    bp->N = bp2->N = N;
 
    switch(ttop)

--- a/BLACS/SRC/itrbr2d_.c
+++ b/BLACS/SRC/itrbr2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Citrbr2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, int *A, int lda, int rsrc, int csrc)
+void Citrbr2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, Int *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC itrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, int *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC itrbr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, Int *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC itrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -42,10 +42,10 @@ F_VOID_FUNC itrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
@@ -54,41 +54,41 @@ F_VOID_FUNC itrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
-   MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   MPI_Datatype IntTyp, MatTyp;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope, tuplo, tdiag;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 
@@ -134,8 +134,9 @@ F_VOID_FUNC itrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
                   tscope);
    }
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiTrType(ctxt, tuplo, tdiag, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
 /*
  * If using default topology, use MPI native broadcast
  */

--- a/BLACS/SRC/itrbs2d_.c
+++ b/BLACS/SRC/itrbs2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Citrbs2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, int *A, int lda)
+void Citrbs2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, Int *A, Int lda)
 #else
-F_VOID_FUNC itrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, int *A, int *lda)
+F_VOID_FUNC itrbs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, Int *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC itrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -41,10 +41,10 @@ F_VOID_FUNC itrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to integer two dimensional array
@@ -53,31 +53,31 @@ F_VOID_FUNC itrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope, tuplo, tdiag;
-   int error, tlda;
-   MPI_Datatype MatTyp;
+   Int error, tlda;
+   MPI_Datatype IntTyp, MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
@@ -123,8 +123,10 @@ F_VOID_FUNC itrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
       BI_BlacsErr(Mpval(ConTxt), __LINE__, __FILE__, "Unknown scope '%c'",
                   tscope);
    }
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiTrType(ctxt, tuplo, tdiag, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
 /*
  * If using default topology, use MPI native broadcast
  */

--- a/BLACS/SRC/itrrv2d_.c
+++ b/BLACS/SRC/itrrv2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Citrrv2d(int ConTxt, char *uplo, char *diag, int m, int n, int *A,
-              int lda, int rsrc, int csrc)
+void Citrrv2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, Int *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC itrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     int *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC itrrv2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     Int *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC itrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC itrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to integer two dimensional array
@@ -44,14 +44,14 @@ F_VOID_FUNC itrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -61,19 +61,19 @@ F_VOID_FUNC itrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tuplo, tdiag, tlda;
-   int ierr, length;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tuplo, tdiag, tlda;
+   Int ierr, length;
    BLACBUFF *bp;
-   MPI_Datatype MatTyp;
+   MPI_Datatype IntTyp, MatTyp;
    BLACSCONTEXT *ctxt;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 
@@ -91,8 +91,9 @@ F_VOID_FUNC itrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
    else tlda = Mpval(lda);
    ctxt->scp = &ctxt->pscp;
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiTrType(ctxt, tuplo, tdiag, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
    BI_AuxBuff.Buff = (char *) A;
    BI_AuxBuff.dtype = MatTyp;
    BI_Srecv(ctxt, Mkpnum(ctxt, Mpval(rsrc), Mpval(csrc)), PT2PTID, &BI_AuxBuff);

--- a/BLACS/SRC/itrsd2d_.c
+++ b/BLACS/SRC/itrsd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Citrsd2d(int ConTxt, char *uplo, char *diag, int m, int n, int *A,
-              int lda, int rdest, int cdest)
+void Citrsd2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, Int *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC itrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     int *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC itrsd2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     Int *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC itrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC itrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to integer two dimensional array
@@ -44,34 +44,34 @@ F_VOID_FUNC itrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
    char tuplo, tdiag;
-   int dest, length, tlda, ierr;
+   Int dest, length, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
-   MPI_Datatype MatTyp;
+   MPI_Datatype IntTyp, MatTyp;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 
    MGetConTxt(Mpval(ConTxt), ctxt);
@@ -89,8 +89,9 @@ F_VOID_FUNC itrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
    dest = Mvkpnum(ctxt, Mpval(rdest), Mpval(cdest));
    ctxt->scp = &ctxt->pscp;
 
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
    MatTyp = BI_GetMpiTrType(ctxt, tuplo, tdiag, Mpval(m), Mpval(n), tlda,
-                            MPI_INT, &BI_AuxBuff.N);
+                            IntTyp, &BI_AuxBuff.N);
 #ifdef SndIsLocBlk
    BI_AuxBuff.Buff = (char *) A;
    BI_AuxBuff.dtype = MatTyp;

--- a/BLACS/SRC/kbrid_.c
+++ b/BLACS/SRC/kbrid_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-int Ckbrid(int ConTxt, char *scope, int rsrc, int csrc)
+Int Ckbrid(Int ConTxt, char *scope, Int rsrc, Int csrc)
 #else
-F_INT_FUNC kbrid_(int *ConTxt, F_CHAR scope, int *rsrc, int *csrc)
+F_INT_FUNC kbrid_(Int *ConTxt, F_CHAR scope, Int *rsrc, Int *csrc)
 #endif
 {
-   int msgid;
+   Int msgid;
    char tmpscope;
    BLACSCONTEXT *ctxt;
 

--- a/BLACS/SRC/kbsid_.c
+++ b/BLACS/SRC/kbsid_.c
@@ -1,13 +1,13 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-int Ckbsid(int ConTxt, char *scope)
+Int Ckbsid(Int ConTxt, char *scope)
 #else
-F_INT_FUNC kbsid_(int *ConTxt, F_CHAR scope)
+F_INT_FUNC kbsid_(Int *ConTxt, F_CHAR scope)
 #endif
 {
    char tmpscope;
-   int msgid;
+   Int msgid;
    BLACSCONTEXT *ctxt;
 
    MGetConTxt(Mpval(ConTxt), ctxt);

--- a/BLACS/SRC/krecvid_.c
+++ b/BLACS/SRC/krecvid_.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-int Ckrecvid(int ConTxt, int rsrc, int csrc)
+Int Ckrecvid(Int ConTxt, Int rsrc, Int csrc)
 #else
-F_INT_FUNC krecvid_(int *ConTxt, int *rsrc, int *csrc)
+F_INT_FUNC krecvid_(Int *ConTxt, Int *rsrc, Int *csrc)
 #endif
 {
    return(PT2PTID+1);

--- a/BLACS/SRC/ksendid_.c
+++ b/BLACS/SRC/ksendid_.c
@@ -1,9 +1,9 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-int Cksendid(int ConTxt, int rdest, int cdest)
+Int Cksendid(Int ConTxt, Int rdest, Int cdest)
 #else
-F_INT_FUNC ksendid_(int *ConTxt, int *rdest, int *cdest)
+F_INT_FUNC ksendid_(Int *ConTxt, Int *rdest, Int *cdest)
 #endif
 {
    return(PT2PTID+1);

--- a/BLACS/SRC/sgamn2d_.c
+++ b/BLACS/SRC/sgamn2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Csgamn2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Csgamn2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC sgamn2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amn.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amn.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_svvamn(int, char *, char *);
-   void BI_svvamn2(int, char *, char *);
-   void BI_sMPI_amn(void *, void *, int *, MPI_Datatype *);
-   void BI_sMPI_amn2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_svvamn(Int, char *, char *);
+   void BI_svvamn2(Int, char *, char *);
+   void BI_sMPI_amn(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_sMPI_amn2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/sgamx2d_.c
+++ b/BLACS/SRC/sgamx2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Csgamx2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Csgamx2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC sgamx2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amx.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amx.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_svvamx(int, char *, char *);
-   void BI_svvamx2(int, char *, char *);
-   void BI_sMPI_amx(void *, void *, int *, MPI_Datatype *);
-   void BI_sMPI_amx2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_svvamx(Int, char *, char *);
+   void BI_svvamx2(Int, char *, char *);
+   void BI_sMPI_amx(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_sMPI_amx2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/sgebr2d_.c
+++ b/BLACS/SRC/sgebr2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Csgebr2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int rsrc, int csrc)
+void Csgebr2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC sgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC sgebr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC sgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -31,51 +31,51 @@ F_VOID_FUNC sgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/sgebs2d_.c
+++ b/BLACS/SRC/sgebs2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Csgebs2d(int ConTxt, char *scope, char *top, int m, int n, float *A, int lda)
+void Csgebs2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A, Int lda)
 #else
-F_VOID_FUNC sgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda)
+F_VOID_FUNC sgebs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,7 +18,7 @@ F_VOID_FUNC sgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -30,40 +30,40 @@ F_VOID_FUNC sgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/sgerv2d_.c
+++ b/BLACS/SRC/sgerv2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Csgerv2d(int ConTxt, int m, int n, float *A, int lda, int rsrc, int csrc)
+void Csgerv2d(Int ConTxt, Int m, Int n, float *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC sgerv2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC sgerv2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,27 +18,27 @@ F_VOID_FUNC sgerv2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -48,17 +48,17 @@ F_VOID_FUNC sgerv2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tlda;
-   int ierr;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tlda;
+   Int ierr;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;

--- a/BLACS/SRC/sgesd2d_.c
+++ b/BLACS/SRC/sgesd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Csgesd2d(int ConTxt, int m, int n, float *A, int lda,
-              int rdest, int cdest)
+void Csgesd2d(Int ConTxt, Int m, Int n, float *A, Int lda,
+              Int rdest, Int cdest)
 #else
-F_VOID_FUNC sgesd2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
-                     int *rdest, int *cdest)
+F_VOID_FUNC sgesd2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,43 +19,43 @@ F_VOID_FUNC sgesd2d_(int *ConTxt, int *m, int *n, float *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int dest, tlda, ierr;
+   Int dest, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/sgsum2d_.c
+++ b/BLACS/SRC/sgsum2d_.c
@@ -2,11 +2,11 @@
 
 
 #if (INTFACE == C_CALL)
-void Csgsum2d(int ConTxt, char *scope, char *top, int m, int n, float *A,
-              int lda, int rdest, int cdest)
+void Csgsum2d(Int ConTxt, char *scope, char *top, Int m, Int n, float *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC sgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     float *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC sgsum2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     float *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC sgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,54 +32,54 @@ F_VOID_FUNC sgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the sum.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the sum.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_svvsum(int, char *, char *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_svvsum(Int, char *, char *);
 /*
  *  Variable Declarations
  */
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int N, length, dest, tlda, trdest, ierr;
+   Int N, length, dest, tlda, trdest, ierr;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
 

--- a/BLACS/SRC/strbr2d_.c
+++ b/BLACS/SRC/strbr2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cstrbr2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, float *A, int lda, int rsrc, int csrc)
+void Cstrbr2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, float *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC strbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, float *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC strbr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, float *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC strbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -42,10 +42,10 @@ F_VOID_FUNC strbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
@@ -54,41 +54,41 @@ F_VOID_FUNC strbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope, tuplo, tdiag;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/strbs2d_.c
+++ b/BLACS/SRC/strbs2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cstrbs2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, float *A, int lda)
+void Cstrbs2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, float *A, Int lda)
 #else
-F_VOID_FUNC strbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, float *A, int *lda)
+F_VOID_FUNC strbs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, float *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC strbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -41,10 +41,10 @@ F_VOID_FUNC strbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to real two dimensional array
@@ -53,30 +53,30 @@ F_VOID_FUNC strbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope, tuplo, tdiag;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/strrv2d_.c
+++ b/BLACS/SRC/strrv2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cstrrv2d(int ConTxt, char *uplo, char *diag, int m, int n, float *A,
-              int lda, int rsrc, int csrc)
+void Cstrrv2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, float *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC strrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     float *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC strrv2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     float *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC strrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC strrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to real two dimensional array
@@ -44,14 +44,14 @@ F_VOID_FUNC strrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -61,17 +61,17 @@ F_VOID_FUNC strrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tuplo, tdiag, tlda;
-   int ierr, length;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tuplo, tdiag, tlda;
+   Int ierr, length;
    BLACBUFF *bp;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/strsd2d_.c
+++ b/BLACS/SRC/strsd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cstrsd2d(int ConTxt, char *uplo, char *diag, int m, int n, float *A,
-              int lda, int rdest, int cdest)
+void Cstrsd2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, float *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC strsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     float *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC strsd2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     float *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC strsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC strsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to real two dimensional array
@@ -44,31 +44,31 @@ F_VOID_FUNC strsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
    char tuplo, tdiag;
-   int dest, length, tlda, ierr;
+   Int dest, length, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/sys2blacs_.c
+++ b/BLACS/SRC/sys2blacs_.c
@@ -1,15 +1,15 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-int Csys2blacs_handle(MPI_Comm SysCtxt)
+Int Csys2blacs_handle(MPI_Comm SysCtxt)
 #else
-int sys2blacs_handle_(int *SysCtxt)
+Int sys2blacs_handle_(Int *SysCtxt)
 #endif
 {
 #if (INTFACE == C_CALL)
-   int i, j, DEF_WORLD;
+   Int i, j, DEF_WORLD;
    MPI_Comm *tSysCtxt;
-   extern int BI_MaxNSysCtxt;
+   extern Int BI_MaxNSysCtxt;
    extern MPI_Comm *BI_SysContxts;
 
    if (BI_COMM_WORLD == NULL) 

--- a/BLACS/SRC/zgamn2d_.c
+++ b/BLACS/SRC/zgamn2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Czgamn2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Czgamn2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC zgamn2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amn.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amn.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_zvvamn(int, char *, char *);
-   void BI_zvvamn2(int, char *, char *);
-   void BI_zMPI_amn(void *, void *, int *, MPI_Datatype *);
-   void BI_zMPI_amn2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_zvvamn(Int, char *, char *);
+   void BI_zvvamn2(Int, char *, char *);
+   void BI_zMPI_amn(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_zMPI_amn2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/zgamx2d_.c
+++ b/BLACS/SRC/zgamx2d_.c
@@ -3,12 +3,12 @@
 
 
 #if (INTFACE == C_CALL)
-void Czgamx2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int *rA, int *cA, int ldia, int rdest, int cdest)
+void Czgamx2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int *rA, Int *cA, Int ldia, Int rdest, Int cdest)
 #else
-F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rA, int *cA, int *ldia,
-                     int *rdest, int *cdest)
+F_VOID_FUNC zgamx2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rA, Int *cA, Int *ldia,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -22,7 +22,7 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -34,17 +34,17 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *  RA      (output) Integer Array, dimension (LDIA, N)
@@ -65,41 +65,41 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *          If rdest == -1, then result is left on all processes in scope.
  *          If LDIA == -1, this array is not accessed, and need not exist.
  *
- *  LDIA    (input) Ptr to int
+ *  LDIA    (input) Ptr to Int
  *          If (LDIA == -1), then the arrays RA and CA are not accessed.
  *          ELSE leading dimension of the arrays RA and CA.  LDIA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the amx.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the amx.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_zvvamx(int, char *, char *);
-   void BI_zvvamx2(int, char *, char *);
-   void BI_zMPI_amx(void *, void *, int *, MPI_Datatype *);
-   void BI_zMPI_amx2(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_zvvamx(Int, char *, char *);
+   void BI_zvvamx2(Int, char *, char *);
+   void BI_zMPI_amx(void *, void *, MpiInt *, MPI_Datatype *);
+   void BI_zMPI_amx2(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
@@ -107,15 +107,17 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
-   int len[2];
+   Int i, j, N, dest, idist, length, tlda, tldia, trdest, ierr;
+   MpiInt len[2];
    MPI_Aint disp[2];
    MPI_Datatype dtypes[2];
    MPI_Op BlacComb;
-   MPI_Datatype MyType;
+   MPI_Datatype IntTyp, MyType;
    BI_DistType *dist, mydist;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;
+
+   MPI_Type_match_size(MPI_TYPECLASS_INTEGER, sizeof(Int), &IntTyp);
 
    MGetConTxt(Mpval(ConTxt), ctxt);
    ttop = F2C_CharTrans(top);
@@ -230,7 +232,7 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
       else
       {
          bp->N = bp2->N = 0;
-         bp->dtype = bp2->dtype = MPI_INT;
+         bp->dtype = bp2->dtype = IntTyp;
       }
 #endif
    }

--- a/BLACS/SRC/zgebr2d_.c
+++ b/BLACS/SRC/zgebr2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Czgebr2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int rsrc, int csrc)
+void Czgebr2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC zgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC zgebr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC zgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -31,51 +31,51 @@ F_VOID_FUNC zgebr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/zgebs2d_.c
+++ b/BLACS/SRC/zgebs2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Czgebs2d(int ConTxt, char *scope, char *top, int m, int n, double *A, int lda)
+void Czgebs2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A, Int lda)
 #else
-F_VOID_FUNC zgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda)
+F_VOID_FUNC zgebs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,7 +18,7 @@ F_VOID_FUNC zgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -30,40 +30,40 @@ F_VOID_FUNC zgebs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/zgerv2d_.c
+++ b/BLACS/SRC/zgerv2d_.c
@@ -1,10 +1,10 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Czgerv2d(int ConTxt, int m, int n, double *A, int lda, int rsrc, int csrc)
+void Czgerv2d(Int ConTxt, Int m, Int n, double *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC zgerv2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC zgerv2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -18,27 +18,27 @@ F_VOID_FUNC zgerv2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -48,17 +48,17 @@ F_VOID_FUNC zgerv2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tlda;
-   int ierr;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tlda;
+   Int ierr;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;

--- a/BLACS/SRC/zgesd2d_.c
+++ b/BLACS/SRC/zgesd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Czgesd2d(int ConTxt, int m, int n, double *A, int lda,
-              int rdest, int cdest)
+void Czgesd2d(Int ConTxt, Int m, Int n, double *A, Int lda,
+              Int rdest, Int cdest)
 #else
-F_VOID_FUNC zgesd2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
-                     int *rdest, int *cdest)
+F_VOID_FUNC zgesd2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda,
+                     Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,43 +19,43 @@ F_VOID_FUNC zgesd2d_(int *ConTxt, int *m, int *n, double *A, int *lda,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
-   int dest, tlda, ierr;
+   Int dest, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/SRC/zgsum2d_.c
+++ b/BLACS/SRC/zgsum2d_.c
@@ -2,11 +2,11 @@
 
 
 #if (INTFACE == C_CALL)
-void Czgsum2d(int ConTxt, char *scope, char *top, int m, int n, double *A,
-              int lda, int rdest, int cdest)
+void Czgsum2d(Int ConTxt, char *scope, char *top, Int m, Int n, double *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC zgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
-                     double *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC zgsum2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, Int *m, Int *n,
+                     double *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC zgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -32,55 +32,55 @@ F_VOID_FUNC zgsum2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
  *  TOP     (input) Ptr to char
  *          Controls fashion in which messages flow within the operation.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
  *          The m by n matrix A.  Fortran77 (column-major) storage
  *          assumed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination of the sum.
  *          If rdest == -1, then result is left on all processes in scope.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination of the sum.
  *          If rdest == -1, then CDEST ignored.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, int, int, int,
-                                   MPI_Datatype, int *);
+   MPI_Datatype BI_GetMpiGeType(BLACSCONTEXT *, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                     int, int);
-   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR,
-                    int, int);
-   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, int, VVFUNPTR);
-   void BI_zvvsum(int, char *, char *);
-   void BI_zMPI_sum(void *, void *, int *, MPI_Datatype *);
+   void BI_MringComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                     Int, Int);
+   void BI_TreeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR,
+                    Int, Int);
+   void BI_BeComb(BLACSCONTEXT *, BLACBUFF *, BLACBUFF *, Int, VVFUNPTR);
+   void BI_zvvsum(Int, char *, char *);
+   void BI_zMPI_sum(void *, void *, MpiInt *, MPI_Datatype *);
 /*
  *  Variable Declarations
  */
    BLACBUFF *bp, *bp2;
    BLACSCONTEXT *ctxt;
    char ttop, tscope;
-   int N, length, dest, tlda, trdest, ierr;
+   Int N, length, dest, tlda, trdest, ierr;
    MPI_Op BlacComb;
    extern BLACBUFF *BI_ActiveQ;
    extern BLACBUFF BI_AuxBuff;

--- a/BLACS/SRC/ztrbr2d_.c
+++ b/BLACS/SRC/ztrbr2d_.c
@@ -1,12 +1,12 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cztrbr2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, double *A, int lda, int rsrc, int csrc)
+void Cztrbr2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, double *A, Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC ztrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, double *A, int *lda,
-                     int *rsrc, int *csrc)
+F_VOID_FUNC ztrbr2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, double *A, Int *lda,
+                     Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -20,7 +20,7 @@ F_VOID_FUNC ztrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -42,10 +42,10 @@ F_VOID_FUNC ztrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
@@ -54,41 +54,41 @@ F_VOID_FUNC ztrbr2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
-   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_IdringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_SringBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_MpathBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
+   void BI_TreeBR(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    BLACSCONTEXT *ctxt;
    BLACBUFF *bp=NULL;
    SDRVPTR send;
    MPI_Datatype MatTyp;
-   int length, src, tlda, error, one=1;
+   Int length, src, tlda, error, one=1;
    char ttop, tscope, tuplo, tdiag;
    extern BLACBUFF BI_AuxBuff, *BI_ActiveQ;
 

--- a/BLACS/SRC/ztrbs2d_.c
+++ b/BLACS/SRC/ztrbs2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cztrbs2d(int ConTxt, char *scope, char *top, char *uplo, char *diag,
-              int m, int n, double *A, int lda)
+void Cztrbs2d(Int ConTxt, char *scope, char *top, char *uplo, char *diag,
+              Int m, Int n, double *A, Int lda)
 #else
-F_VOID_FUNC ztrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
-                     F_CHAR diag, int *m, int *n, double *A, int *lda)
+F_VOID_FUNC ztrbs2d_(Int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
+                     F_CHAR diag, Int *m, Int *n, double *A, Int *lda)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC ztrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  SCOPE   (input) Ptr to char
@@ -41,10 +41,10 @@ F_VOID_FUNC ztrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double complex two dimensional array
@@ -53,30 +53,30 @@ F_VOID_FUNC ztrbs2d_(int *ConTxt, F_CHAR scope, F_CHAR top, F_CHAR uplo,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   Int BI_HypBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
+   void BI_IdringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_SringBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR);
-   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
-   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, int);
+   void BI_MpathBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
+   void BI_TreeBS(BLACSCONTEXT *, BLACBUFF *, SDRVPTR, Int);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
 
    char ttop, tscope, tuplo, tdiag;
-   int error, tlda;
+   Int error, tlda;
    MPI_Datatype MatTyp;
    SDRVPTR send;
    BLACBUFF *bp;

--- a/BLACS/SRC/ztrrv2d_.c
+++ b/BLACS/SRC/ztrrv2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cztrrv2d(int ConTxt, char *uplo, char *diag, int m, int n, double *A,
-              int lda, int rsrc, int csrc)
+void Cztrrv2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, double *A,
+              Int lda, Int rsrc, Int csrc)
 #else
-F_VOID_FUNC ztrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     double *A, int *lda, int *rsrc, int *csrc)
+F_VOID_FUNC ztrrv2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     double *A, Int *lda, Int *rsrc, Int *csrc)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC ztrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC ztrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (output) Ptr to double complex two dimensional array
@@ -44,14 +44,14 @@ F_VOID_FUNC ztrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
  *
- *  RSRC    (input) Ptr to int
+ *  RSRC    (input) Ptr to Int
  *          The process row of the source of the matrix.
  *
- *  CSRC    (input) Ptr to int
+ *  CSRC    (input) Ptr to Int
  *          The process column of the source of the matrix.
  *
  *
@@ -61,17 +61,17 @@ F_VOID_FUNC ztrrv2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
 /*
  *  Prototypes and variable declarations
  */
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    void BI_Unpack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Srecv(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Srecv(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
-   int tuplo, tdiag, tlda;
-   int ierr, length;
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
+   Int tuplo, tdiag, tlda;
+   Int ierr, length;
    BLACBUFF *bp;
    MPI_Datatype MatTyp;
    BLACSCONTEXT *ctxt;

--- a/BLACS/SRC/ztrsd2d_.c
+++ b/BLACS/SRC/ztrsd2d_.c
@@ -1,11 +1,11 @@
 #include "Bdef.h"
 
 #if (INTFACE == C_CALL)
-void Cztrsd2d(int ConTxt, char *uplo, char *diag, int m, int n, double *A,
-              int lda, int rdest, int cdest)
+void Cztrsd2d(Int ConTxt, char *uplo, char *diag, Int m, Int n, double *A,
+              Int lda, Int rdest, Int cdest)
 #else
-F_VOID_FUNC ztrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
-                     double *A, int *lda, int *rdest, int *cdest)
+F_VOID_FUNC ztrsd2d_(Int *ConTxt, F_CHAR uplo, F_CHAR diag, Int *m, Int *n,
+                     double *A, Int *lda, Int *rdest, Int *cdest)
 #endif
 /*
  *  -- V1.1 BLACS routine --
@@ -19,7 +19,7 @@ F_VOID_FUNC ztrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *  Arguments
  *  =========
  *
- *  ConTxt  (input) Ptr to int
+ *  ConTxt  (input) Ptr to Int
  *          Index into MyConTxts00 (my contexts array).
  *
  *  UPLO    (input) Ptr to char
@@ -32,10 +32,10 @@ F_VOID_FUNC ztrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          = 'U':      Matrix is unit diagonal, diagonal not communicated.
  *          ELSE :      Matrix is not unit diagonal, diagonal is communicated.
  *
- *  M       (input) Ptr to int
+ *  M       (input) Ptr to Int
  *          The number of rows of the matrix A.  M >= 0.
  *
- *  N       (input) Ptr to int
+ *  N       (input) Ptr to Int
  *          The number of columns of the matrix A.  N >= 0.
  *
  *  A       (input) Ptr to double complex two dimensional array
@@ -44,31 +44,31 @@ F_VOID_FUNC ztrsd2d_(int *ConTxt, F_CHAR uplo, F_CHAR diag, int *m, int *n,
  *          If UPLO = 'U', only the upper trapezoid is accessed;
  *          if UPLO = 'L', only the lower trapezoid is accessed.
  *
- *  LDA     (input) Ptr to int
+ *  LDA     (input) Ptr to Int
  *          The leading dimension of the array A.  LDA >= M.
  *
- *  RDEST   (input) Ptr to int
+ *  RDEST   (input) Ptr to Int
  *          The process row of the destination process.
  *
- *  CDEST   (input) Ptr to int
+ *  CDEST   (input) Ptr to Int
  *          The process column of the destination process.
  *
  * ------------------------------------------------------------------------
  */
 {
-   void BI_ArgCheck(int, int, char *, char, char, char, int, int, int, int,
-                    int *, int *);
-   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, int, int, int,
-                                   MPI_Datatype, int *);
+   void BI_ArgCheck(Int, Int, char *, char, char, char, Int, Int, Int, Int,
+                    Int *, Int *);
+   MPI_Datatype BI_GetMpiTrType(BLACSCONTEXT *, char, char, Int, Int, Int,
+                                   MPI_Datatype, Int *);
    BLACBUFF *BI_Pack(BLACSCONTEXT *, BVOID *, BLACBUFF *, MPI_Datatype);
-   void BI_Ssend(BLACSCONTEXT *, int, int, BLACBUFF *);
-   void BI_Asend(BLACSCONTEXT *, int, int, BLACBUFF *);
+   void BI_Ssend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
+   void BI_Asend(BLACSCONTEXT *, Int, Int, BLACBUFF *);
    void BI_UpdateBuffs(BLACBUFF *);
-   BLACBUFF *BI_GetBuff(int);
-   int BI_BuffIsFree(BLACBUFF *, int);
+   BLACBUFF *BI_GetBuff(Int);
+   Int BI_BuffIsFree(BLACBUFF *, Int);
 
    char tuplo, tdiag;
-   int dest, length, tlda, ierr;
+   Int dest, length, tlda, ierr;
    BLACBUFF *bp;
    BLACSCONTEXT *ctxt;
    MPI_Datatype MatTyp;

--- a/BLACS/TESTING/Cbt.c
+++ b/BLACS/TESTING/Cbt.c
@@ -2,10 +2,10 @@
 #include "Cbt.h"
 
 void blacs_gridinit_(ConTxt, order, nprow, npcol)
-int *ConTxt;
+Int *ConTxt;
 char *order;
-int *nprow;
-int  *npcol;
+Int *nprow;
+Int  *npcol;
 {
    void Cblacs_gridinit();
 
@@ -13,113 +13,113 @@ int  *npcol;
 }
 
 void blacs_setup_(mypnum, nprocs)
-int *mypnum;
-int  *nprocs;
+Int *mypnum;
+Int  *nprocs;
 {
    void Cblacs_setup();
    Cblacs_setup(mypnum, nprocs);
 }
 
 void blacs_pinfo_(mypnum, nprocs)
-int *mypnum;
-int  *nprocs;
+Int *mypnum;
+Int  *nprocs;
 {
    void Cblacs_pinfo();
    Cblacs_pinfo(mypnum, nprocs);
 }
 
 void blacs_gridmap_(ConTxt, usermap, ldup, nprow, npcol)
-int *ConTxt;
-int *usermap;
-int *ldup;
-int *nprow;
-int  *npcol;
+Int *ConTxt;
+Int *usermap;
+Int *ldup;
+Int *nprow;
+Int  *npcol;
 {
    void Cblacs_gridmap();
    Cblacs_gridmap(ConTxt, usermap, *ldup, *nprow, *npcol);
 }
 
 void blacs_gridexit_(ConTxt)
-int  *ConTxt;
+Int  *ConTxt;
 {
    void Cblacs_gridexit();
    Cblacs_gridexit(*ConTxt);
 }
 
 void blacs_abort_(ConTxt, ErrNo)
-int *ConTxt;
-int  *ErrNo;
+Int *ConTxt;
+Int  *ErrNo;
 {
    void Cblacs_abort();
    Cblacs_abort(*ConTxt, *ErrNo);
 }
 
 void blacs_exit_(NotDone)
-int  *NotDone;
+Int  *NotDone;
 {
    void Cblacs_exit();
    Cblacs_exit(*NotDone);
 }
 
 void blacs_freebuff_(ConTxt, Wait)
-int *ConTxt;
-int  *Wait;
+Int *ConTxt;
+Int  *Wait;
 {
    void Cblacs_freebuff();
    Cblacs_freebuff(*ConTxt, *Wait);
 }
 
 void blacs_gridinfo_(ConTxt, nprow, npcol, myrow, mycol)
-int *ConTxt;
-int *nprow;
-int *npcol;
-int *myrow;
-int  *mycol;
+Int *ConTxt;
+Int *nprow;
+Int *npcol;
+Int *myrow;
+Int  *mycol;
 {
    void Cblacs_gridinfo();
    Cblacs_gridinfo(*ConTxt, nprow, npcol, myrow, mycol);
 }
 
 void blacs_barrier_(ConTxt, scope)
-int *ConTxt;
+Int *ConTxt;
 char  *scope;
 {
    void Cblacs_barrier();
    Cblacs_barrier(*ConTxt, scope);
 }
 
-int blacs_pnum_(ConTxt, prow, pcol)
-int *ConTxt;
-int *prow;
-int  *pcol;
+Int blacs_pnum_(ConTxt, prow, pcol)
+Int *ConTxt;
+Int *prow;
+Int  *pcol;
 {
-   int Cblacs_pnum();
+   Int Cblacs_pnum();
    return( Cblacs_pnum(*ConTxt, *prow, *pcol) );
 }
 
 void blacs_pcoord_(ConTxt, nodenum, prow, pcol)
-int *ConTxt;
-int *nodenum;
-int *prow;
-int  *pcol;
+Int *ConTxt;
+Int *nodenum;
+Int *prow;
+Int  *pcol;
 {
    void Cblacs_pcoord();
    Cblacs_pcoord(*ConTxt, *nodenum, prow, pcol);
 }
 
 void blacs_get_(ConTxt, what, I)
-int *ConTxt;
-int *what;
-int  *I;
+Int *ConTxt;
+Int *what;
+Int  *I;
 {
    void Cblacs_get();
    Cblacs_get(*ConTxt, *what, I);
 }
 
 void blacs_set_(ConTxt, what, I)
-int *ConTxt;
-int *what;
-int  *I;
+Int *ConTxt;
+Int *what;
+Int  *I;
 {
    void Cblacs_set();
    Cblacs_set(*ConTxt, *what, I);
@@ -127,149 +127,149 @@ int  *I;
 
 
 void igesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-int *ConTxt;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *ConTxt;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cigesd2d();
    Cigesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void igerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *ConTxt;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cigerv2d();
    Cigerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void igebs2d_(ConTxt, scope, top, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
-int *A;
-int  *lda;
+Int *m;
+Int *n;
+Int *A;
+Int  *lda;
 {
    void Cigebs2d();
    Cigebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
 void igebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cigebr2d();
    Cigebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void itrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Citrsd2d();
    Citrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void itrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Citrrv2d();
    Citrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void itrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
-int *A;
-int  *lda;
+Int *m;
+Int *n;
+Int *A;
+Int  *lda;
 {
    void Citrbs2d();
    Citrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
 void itrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Citrbr2d();
    Citrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void igsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cigsum2d();
    Cigsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void igamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Cigamx2d();
    Cigamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
@@ -277,18 +277,18 @@ int  *cdest;
 }
 
 void igamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
-int *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *m;
+Int *n;
+Int *A;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Cigamn2d();
    Cigamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
@@ -296,149 +296,149 @@ int  *cdest;
 }
 
 void dgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cdgesd2d();
    Cdgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void dgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cdgerv2d();
    Cdgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void dgebs2d_(ConTxt, scope, top, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int  *lda;
+Int  *lda;
 {
    void Cdgebs2d();
    Cdgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
 void dgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cdgebr2d();
    Cdgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void dtrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cdtrsd2d();
    Cdtrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void dtrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cdtrrv2d();
    Cdtrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void dtrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int  *lda;
+Int  *lda;
 {
    void Cdtrbs2d();
    Cdtrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
 void dtrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cdtrbr2d();
    Cdtrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void dgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cdgsum2d();
    Cdgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void dgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Cdgamx2d();
    Cdgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
@@ -446,18 +446,18 @@ int  *cdest;
 }
 
 void dgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Cdgamn2d();
    Cdgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
@@ -465,149 +465,149 @@ int  *cdest;
 }
 
 void sgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Csgesd2d();
    Csgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void sgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Csgerv2d();
    Csgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void sgebs2d_(ConTxt, scope, top, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int  *lda;
+Int  *lda;
 {
    void Csgebs2d();
    Csgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
 void sgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Csgebr2d();
    Csgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void strsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cstrsd2d();
    Cstrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void strrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cstrrv2d();
    Cstrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void strbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int  *lda;
+Int  *lda;
 {
    void Cstrbs2d();
    Cstrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
 void strbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cstrbr2d();
    Cstrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void sgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Csgsum2d();
    Csgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void sgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Csgamx2d();
    Csgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
@@ -615,18 +615,18 @@ int  *cdest;
 }
 
 void sgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Csgamn2d();
    Csgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
@@ -634,149 +634,149 @@ int  *cdest;
 }
 
 void cgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Ccgesd2d();
    Ccgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void cgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Ccgerv2d();
    Ccgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void cgebs2d_(ConTxt, scope, top, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int  *lda;
+Int  *lda;
 {
    void Ccgebs2d();
    Ccgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
 void cgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Ccgebr2d();
    Ccgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void ctrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cctrsd2d();
    Cctrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void ctrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cctrrv2d();
    Cctrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void ctrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int  *lda;
+Int  *lda;
 {
    void Cctrbs2d();
    Cctrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
 void ctrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cctrbr2d();
    Cctrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void cgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Ccgsum2d();
    Ccgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void cgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Ccgamx2d();
    Ccgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
@@ -784,18 +784,18 @@ int  *cdest;
 }
 
 void cgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 float *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Ccgamn2d();
    Ccgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
@@ -803,149 +803,149 @@ int  *cdest;
 }
 
 void zgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Czgesd2d();
    Czgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void zgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
-int *m;
-int *n;
+Int *ConTxt;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Czgerv2d();
    Czgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void zgebs2d_(ConTxt, scope, top, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int  *lda;
+Int  *lda;
 {
    void Czgebs2d();
    Czgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
 void zgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Czgebr2d();
    Czgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void ztrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Cztrsd2d();
    Cztrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void ztrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cztrrv2d();
    Cztrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void ztrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int  *lda;
+Int  *lda;
 {
    void Cztrbs2d();
    Cztrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
 void ztrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
 char *uplo;
 char *diag;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rsrc;
-int  *csrc;
+Int *lda;
+Int *rsrc;
+Int  *csrc;
 {
    void Cztrbr2d();
    Cztrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
 void zgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rdest;
+Int  *cdest;
 {
    void Czgsum2d();
    Czgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
 void zgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Czgamx2d();
    Czgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
@@ -953,18 +953,18 @@ int  *cdest;
 }
 
 void zgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-int *ConTxt;
+Int *ConTxt;
 char *scope;
 char *top;
-int *m;
-int *n;
+Int *m;
+Int *n;
 double *A;
-int *lda;
-int *rA;
-int *cA;
-int *ldia;
-int *rdest;
-int  *cdest;
+Int *lda;
+Int *rA;
+Int *cA;
+Int *ldia;
+Int *rdest;
+Int  *cdest;
 {
    void Czgamn2d();
    Czgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,

--- a/BLACS/TESTING/Cbt.h
+++ b/BLACS/TESTING/Cbt.h
@@ -2,6 +2,10 @@
 #define NOCHANGE 1
 #define UPCASE   2
 
+#ifndef Int
+#define Int int
+#endif
+
 #ifdef UpCase
 #define F77_CALL_C UPCASE
 #endif

--- a/BLACS/TESTING/blacstest.f
+++ b/BLACS/TESTING/blacstest.f
@@ -1775,7 +1775,7 @@
       MEMUSED = MEMUSED + 3
       CMEMUSED = CMEMUSED - 1
 *
- 1000 FORMAT('Mem too short (',I4,') to handle',I4,' ',A20)
+ 1000 FORMAT('Mem too short (',I8,') to handle',I4,' ',A20)
  2000 FORMAT('Must have at least one ',A20)
  3000 FORMAT('UNRECOGNIZABLE ',A5,' ''', A1, '''.')
  4000 FORMAT('Illegal process grid: {',I3,',',I3,'}.')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH "${SCALAPACK_SOURCE_DIR}/CMAKE" ${CMAKE_MODULE_PATH})
 
 if (UNIX)
    if ( "${CMAKE_Fortran_COMPILER}" MATCHES "ifort" )
-  set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
+#   set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
    endif ()
 endif ()
 
@@ -77,7 +77,7 @@ endif()
 
 if (UNIX)
    if ( "${CMAKE_Fortran_COMPILER}" MATCHES "ifort" )
-  set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
+#   set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
    endif ()
 endif ()
 

--- a/PBLAS/SRC/PBblacs.h
+++ b/PBLAS/SRC/PBblacs.h
@@ -73,222 +73,222 @@
 */
 #ifdef __STDC__
                                               /* BLACS Initialization */
-void           Cblacs_pinfo    ( int *,     int * );
-void           Cblacs_setup    ( int *,     int * );
-void           Cblacs_get      ( int,       int,       int * );
-void           Cblacs_set      ( int,       int,       int * );
-void           Cblacs_gridinit ( int *,     char *,    int,
-                                 int );
-void           Cblacs_gridmap  ( int *,     int *,     int,
-                                 int,       int );
+void           Cblacs_pinfo    ( Int *,     Int * );
+void           Cblacs_setup    ( Int *,     Int * );
+void           Cblacs_get      ( Int,       Int,       Int * );
+void           Cblacs_set      ( Int,       Int,       Int * );
+void           Cblacs_gridinit ( Int *,     char *,    Int,
+                                 Int );
+void           Cblacs_gridmap  ( Int *,     Int *,     Int,
+                                 Int,       Int );
 
                                                  /* BLACS Destruction */
-void           Cblacs_freebuff ( int,       int );
-void           Cblacs_gridexit ( int );
-void           Cblacs_abort    ( int,       int );
-void           Cblacs_exit     ( int );
+void           Cblacs_freebuff ( Int,       Int );
+void           Cblacs_gridexit ( Int );
+void           Cblacs_abort    ( Int,       Int );
+void           Cblacs_exit     ( Int );
 
                              /* BLACS Informational and Miscellaneous */
-void           Cblacs_gridinfo ( int,       int *,     int *,
-                                 int *,     int * );
-int            Cblacs_pnum     ( int,       int,       int );
-void           Cblacs_pcoord   ( int,       int,       int *,
-                                 int * );
-void           Cblacs_barrier  ( int,       char * );
+void           Cblacs_gridinfo ( Int,       Int *,     Int *,
+                                 Int *,     Int * );
+Int            Cblacs_pnum     ( Int,       Int,       Int );
+void           Cblacs_pcoord   ( Int,       Int,       Int *,
+                                 Int * );
+void           Cblacs_barrier  ( Int,       char * );
 
                                                      /* BLACS Sending */
-void           Cigesd2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Csgesd2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Cdgesd2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Ccgesd2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Czgesd2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
+void           Cigesd2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Csgesd2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Cdgesd2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Ccgesd2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Czgesd2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
 
-void           Citrsd2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cstrsd2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cdtrsd2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cctrsd2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cztrsd2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
+void           Citrsd2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cstrsd2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cdtrsd2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cctrsd2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cztrsd2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
 
-void           Cigebs2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int );
-void           Csgebs2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int );
-void           Cdgebs2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int );
-void           Ccgebs2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int );
-void           Czgebs2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int );
+void           Cigebs2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int );
+void           Csgebs2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int );
+void           Cdgebs2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int );
+void           Ccgebs2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int );
+void           Czgebs2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int );
 
-void           Citrbs2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int );
-void           Cstrbs2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int );
-void           Cdtrbs2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int );
-void           Cctrbs2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int );
-void           Cztrbs2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int );
+void           Citrbs2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int );
+void           Cstrbs2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int );
+void           Cdtrbs2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int );
+void           Cctrbs2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int );
+void           Cztrbs2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int );
 
                                                    /* BLACS Receiving */
-void           Cigerv2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Csgerv2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Cdgerv2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Ccgerv2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
-void           Czgerv2d        ( int,       int,       int,
-                                 char *,    int,       int,
-                                 int );
+void           Cigerv2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Csgerv2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Cdgerv2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Ccgerv2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
+void           Czgerv2d        ( Int,       Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int );
 
-void           Citrrv2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cstrrv2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cdtrrv2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cctrrv2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cztrrv2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
+void           Citrrv2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cstrrv2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cdtrrv2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cctrrv2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cztrrv2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
 
-void           Cigebr2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Csgebr2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cdgebr2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Ccgebr2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Czgebr2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
+void           Cigebr2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Csgebr2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cdgebr2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Ccgebr2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Czgebr2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
 
-void           Citrbr2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int,
-                                 int,       int );
-void           Cstrbr2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int,
-                                 int,       int );
-void           Cdtrbr2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int,
-                                 int,       int );
-void           Cctrbr2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int,
-                                 int,       int );
-void           Cztrbr2d        ( int,       char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    int,
-                                 int,       int );
+void           Citrbr2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int,
+                                 Int,       Int );
+void           Cstrbr2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int,
+                                 Int,       Int );
+void           Cdtrbr2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int,
+                                 Int,       Int );
+void           Cctrbr2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int,
+                                 Int,       Int );
+void           Cztrbr2d        ( Int,       char *,    char *,
+                                 char *,    char *,    Int,
+                                 Int,       char *,    Int,
+                                 Int,       Int );
 
                                           /* BLACS Combine Operations */
-void           Cigamx2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Csgamx2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Cdgamx2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Ccgamx2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Czgamx2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
+void           Cigamx2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Csgamx2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Cdgamx2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Ccgamx2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Czgamx2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
 
-void           Cigamn2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Csgamn2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Cdgamn2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Ccgamn2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
-void           Czgamn2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int *,     int *,
-                                 int,       int,       int );
+void           Cigamn2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Csgamn2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Cdgamn2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Ccgamn2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
+void           Czgamn2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int *,     Int *,
+                                 Int,       Int,       Int );
 
-void           Cigsum2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Csgsum2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Cdgsum2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Ccgsum2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
-void           Czgsum2d        ( int,       char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int );
+void           Cigsum2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Csgsum2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Cdgsum2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Ccgsum2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
+void           Czgsum2d        ( Int,       char *,    char *,
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int );
 
 #else
                                               /* BLACS Initialization */
@@ -307,7 +307,7 @@ void           Cblacs_exit     ();
 
                              /* BLACS Informational and Miscellaneous */
 void           Cblacs_gridinfo ();
-int            Cblacs_pnum     ();
+Int            Cblacs_pnum     ();
 void           Cblacs_pcoord   ();
 void           Cblacs_barrier  ();
 

--- a/PBLAS/SRC/PBblas.h
+++ b/PBLAS/SRC/PBblas.h
@@ -348,292 +348,292 @@
 */
 #ifdef __STDC__
 
-int            isamax_         ( int *,     char *,    int * );
-int            idamax_         ( int *,     char *,    int * );
-int            icamax_         ( int *,     char *,    int * );
-int            izamax_         ( int *,     char *,    int * );
+Int            isamax_         ( Int *,     char *,    Int * );
+Int            idamax_         ( Int *,     char *,    Int * );
+Int            icamax_         ( Int *,     char *,    Int * );
+Int            izamax_         ( Int *,     char *,    Int * );
 
-F_VOID_FCT     saxpy_          ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     daxpy_          ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     caxpy_          ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zaxpy_          ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
+F_VOID_FCT     saxpy_          ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     daxpy_          ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     caxpy_          ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zaxpy_          ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
 
-F_VOID_FCT     scopy_          ( int *,     char *,    int *,
-                                 char *,    int * );
-F_VOID_FCT     dcopy_          ( int *,     char *,    int *,
-                                 char *,    int * );
-F_VOID_FCT     ccopy_          ( int *,     char *,    int *,
-                                 char *,    int * );
-F_VOID_FCT     zcopy_          ( int *,     char *,    int *,
-                                 char *,    int * );
+F_VOID_FCT     scopy_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
+F_VOID_FCT     dcopy_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
+F_VOID_FCT     ccopy_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
+F_VOID_FCT     zcopy_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
 
-F_VOID_FCT     sscal_          ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dscal_          ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     cscal_          ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     csscal_         ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zdscal_         ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zscal_          ( int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     sscal_          ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dscal_          ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     cscal_          ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     csscal_         ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zdscal_         ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zscal_          ( Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     sswap_          ( int *,     char *,    int *,
-                                 char *,    int * );
-F_VOID_FCT     dswap_          ( int *,     char *,    int *,
-                                 char *,    int * );
-F_VOID_FCT     cswap_          ( int *,     char *,    int *,
-                                 char *,    int * );
-F_VOID_FCT     zswap_          ( int *,     char *,    int *,
-                                 char *,    int * );
+F_VOID_FCT     sswap_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
+F_VOID_FCT     dswap_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
+F_VOID_FCT     cswap_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
+F_VOID_FCT     zswap_          ( Int *,     char *,    Int *,
+                                 char *,    Int * );
 
-F_VOID_FCT     sgemv_          ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dgemv_          ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cgemv_          ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zgemv_          ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     sgemv_          ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dgemv_          ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cgemv_          ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zgemv_          ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     ssymv_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dsymv_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     chemv_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zhemv_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     ssymv_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dsymv_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     chemv_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zhemv_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
 F_VOID_FCT     strmv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     dtrmv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ctrmv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ztrmv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 
 F_VOID_FCT     strsv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     dtrsv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ctrsv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ztrsv_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    int *,
-                                 char *,    int * );
+                                 Int *,     char *,    Int *,
+                                 char *,    Int * );
 
-F_VOID_FCT     sger_           ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     dger_           ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     cgerc_          ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     cgeru_          ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zgerc_          ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zgeru_          ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
+F_VOID_FCT     sger_           ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     dger_           ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     cgerc_          ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     cgeru_          ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zgerc_          ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zgeru_          ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
 
-F_VOID_FCT     ssyr_           ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int * );
-F_VOID_FCT     dsyr_           ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int * );
-F_VOID_FCT     cher_           ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int * );
-F_VOID_FCT     zher_           ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int * );
+F_VOID_FCT     ssyr_           ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int * );
+F_VOID_FCT     dsyr_           ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int * );
+F_VOID_FCT     cher_           ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int * );
+F_VOID_FCT     zher_           ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int * );
 
-F_VOID_FCT     ssyr2_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     dsyr2_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     cher2_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zher2_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
+F_VOID_FCT     ssyr2_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     dsyr2_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     cher2_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zher2_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
 
-F_VOID_FCT     sgemm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dgemm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     cgemm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zgemm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     sgemm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dgemm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     cgemm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zgemm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     ssymm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     dsymm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     csymm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     zsymm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     chemm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     zhemm_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
+F_VOID_FCT     ssymm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     dsymm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     csymm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     zsymm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     chemm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     zhemm_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
 
-F_VOID_FCT     ssyrk_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dsyrk_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     csyrk_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zsyrk_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     cherk_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zherk_          ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     ssyrk_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dsyrk_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     csyrk_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zsyrk_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     cherk_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zherk_          ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     ssyr2k_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     dsyr2k_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     csyr2k_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     zsyr2k_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     cher2k_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     zher2k_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
+F_VOID_FCT     ssyr2k_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     dsyr2k_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     csyr2k_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     zsyr2k_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     cher2k_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     zher2k_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
 
 F_VOID_FCT     strmm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     dtrmm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ctrmm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ztrmm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 
 F_VOID_FCT     strsm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     dtrsm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ctrsm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 F_VOID_FCT     ztrsm_          ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int * );
 
 #else
 
-int            isamax_         ();
-int            idamax_         ();
-int            icamax_         ();
-int            izamax_         ();
+Int            isamax_         ();
+Int            idamax_         ();
+Int            icamax_         ();
+Int            izamax_         ();
 
 F_VOID_FCT     saxpy_          ();
 F_VOID_FCT     daxpy_          ();

--- a/PBLAS/SRC/PBpblas.h
+++ b/PBLAS/SRC/PBpblas.h
@@ -379,650 +379,650 @@
 
 void           PB_freebuf_     ( void );
 
-void           PB_topget_      ( int *,     F_CHAR_T,  F_CHAR_T,
+void           PB_topget_      ( Int *,     F_CHAR_T,  F_CHAR_T,
                                  F_CHAR_T );
 
-void           PB_topset_      ( int *,     F_CHAR_T,  F_CHAR_T,
+void           PB_topset_      ( Int *,     F_CHAR_T,  F_CHAR_T,
                                  F_CHAR_T );
 
-void           picopy_         ( int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int *,     int * );
-void           pscopy_         ( int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
-void           pdcopy_         ( int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
-void           pccopy_         ( int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
-void           pzcopy_         ( int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
+void           picopy_         ( Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int * );
+void           pscopy_         ( Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
+void           pdcopy_         ( Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
+void           pccopy_         ( Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
+void           pzcopy_         ( Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
 
-void           psswap_         ( int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
-void           pdswap_         ( int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
-void           pcswap_         ( int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
-void           pzswap_         ( int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
+void           psswap_         ( Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
+void           pdswap_         ( Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
+void           pcswap_         ( Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
+void           pzswap_         ( Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
 
-void           psaxpy_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int * );
-void           pdaxpy_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int * );
-void           pcaxpy_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int * );
-void           pzaxpy_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int * );
+void           psaxpy_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pdaxpy_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int * );
+void           pcaxpy_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pzaxpy_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int * );
 
-void           psscal_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdscal_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pcscal_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pcsscal_        ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pzscal_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pzdscal_        ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
+void           psscal_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdscal_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pcscal_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pcsscal_        ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pzscal_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pzdscal_        ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
-void           psasum_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdasum_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pscasum_        ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdzasum_        ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
+void           psasum_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdasum_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pscasum_        ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdzasum_        ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
-void           psnrm2_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdnrm2_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pscnrm2_        ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdznrm2_        ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
+void           psnrm2_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdnrm2_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pscnrm2_        ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdznrm2_        ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
-void           psdot_          ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int * );
-void           pddot_          ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int * );
-void           pcdotc_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int * );
-void           pcdotu_         ( int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int * );
-void           pzdotc_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int * );
-void           pzdotu_         ( int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int * );
+void           psdot_          ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pddot_          ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int * );
+void           pcdotc_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pcdotu_         ( Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pzdotc_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int * );
+void           pzdotu_         ( Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int * );
 
-void           psamax_         ( int *,     float *,   int *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
-void           pdamax_         ( int *,     double *,  int *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
-void           pcamax_         ( int *,     float *,   int *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
-void           pzamax_         ( int *,     double *,  int *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
+void           psamax_         ( Int *,     float *,   Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
+void           pdamax_         ( Int *,     double *,  Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
+void           pcamax_         ( Int *,     float *,   Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
+void           pzamax_         ( Int *,     double *,  Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
 
-void           psgemv_         ( F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdgemv_         ( F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pcgemv_         ( F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pzgemv_         ( F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
+void           psgemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdgemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pcgemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pzgemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
-void           psagemv_        ( F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pdagemv_        ( F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pcagemv_        ( F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           pzagemv_        ( F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 int * );
+void           psagemv_        ( F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pdagemv_        ( F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pcagemv_        ( F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           pzagemv_        ( F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
-void           psger_          ( int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int * );
-void           pdger_          ( int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int * );
-void           pcgerc_         ( int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int * );
-void           pcgeru_         ( int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int * );
-void           pzgerc_         ( int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int * );
-void           pzgeru_         ( int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int * );
+void           psger_          ( Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int * );
+void           pdger_          ( Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int * );
+void           pcgerc_         ( Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int * );
+void           pcgeru_         ( Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int * );
+void           pzgerc_         ( Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int * );
+void           pzgeru_         ( Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int * );
 
-void           pssymv_         ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     int * );
-void           pdsymv_         ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     int * );
-void           pchemv_         ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     int * );
-void           pzhemv_         ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     int * );
+void           pssymv_         ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pdsymv_         ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     Int * );
+void           pchemv_         ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pzhemv_         ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     Int * );
 
-void           psasymv_        ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     int * );
-void           pdasymv_        ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     int * );
-void           pcahemv_        ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     int * );
-void           pzahemv_        ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     int * );
+void           psasymv_        ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pdasymv_        ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     Int * );
+void           pcahemv_        ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     Int * );
+void           pzahemv_        ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     Int * );
 
-void           pssyr_          ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int * );
-void           pdsyr_          ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int * );
-void           pcher_          ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int * );
-void           pzher_          ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int * );
+void           pssyr_          ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int * );
+void           pdsyr_          ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int * );
+void           pcher_          ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int * );
+void           pzher_          ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int * );
 
-void           pssyr2_         ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int * );
-void           pdsyr2_         ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int * );
-void           pcher2_         ( F_CHAR_T,  int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int * );
-void           pzher2_         ( F_CHAR_T,  int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int * );
+void           pssyr2_         ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int * );
+void           pdsyr2_         ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int * );
+void           pcher2_         ( F_CHAR_T,  Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int * );
+void           pzher2_         ( F_CHAR_T,  Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int * );
 
 void           pstrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 void           pdtrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 void           pctrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 void           pztrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
 void           psatrmv_        ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
 void           pdatrmv_        ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
 void           pcatrmv_        ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     int * );
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     Int * );
 void           pzatrmv_        ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     int * );
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     Int * );
 
 void           pstrsv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 void           pdtrsv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 void           pctrsv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 void           pztrsv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int *,
-                                 int * );
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
 
-void           psgeadd_        ( F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int * );
-void           pdgeadd_        ( F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int * );
-void           pcgeadd_        ( F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int * );
-void           pzgeadd_        ( F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int * );
+void           psgeadd_        ( F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int * );
+void           pdgeadd_        ( F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int * );
+void           pcgeadd_        ( F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int * );
+void           pzgeadd_        ( F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int * );
 
-void           psgemm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int * );
-void           pdgemm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int * );
-void           pcgemm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   int *,
-                                 int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int * );
-void           pzgemm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  int *,
-                                 int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int * );
+void           psgemm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int * );
+void           pdgemm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int * );
+void           pcgemm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int * );
+void           pzgemm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int * );
 
-void           pssymm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pdsymm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
-void           pcsymm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pzsymm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
-void           pchemm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pzhemm_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
+void           pssymm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pdsymm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
+void           pcsymm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pzsymm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
+void           pchemm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pzhemm_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
 
-void           pssyr2k_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pdsyr2k_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
-void           pcsyr2k_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pzsyr2k_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
-void           pcher2k_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pzher2k_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
+void           pssyr2k_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pdsyr2k_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
+void           pcsyr2k_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pzsyr2k_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
+void           pcher2k_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pzher2k_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
 
-void           pssyrk_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int * );
-void           pdsyrk_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int * );
-void           pcsyrk_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int * );
-void           pzsyrk_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int * );
-void           pcherk_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int * );
-void           pzherk_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int * );
+void           pssyrk_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int * );
+void           pdsyrk_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int * );
+void           pcsyrk_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int * );
+void           pzsyrk_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int * );
+void           pcherk_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int * );
+void           pzherk_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int * );
 
-void           pstradd_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int * );
-void           pdtradd_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int * );
-void           pctradd_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int * );
-void           pztradd_        ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int * );
+void           pstradd_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int * );
+void           pdtradd_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int * );
+void           pctradd_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int * );
+void           pztradd_        ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int * );
 
-void           pstran_         ( int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pdtran_         ( int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
-void           pctranc_        ( int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pztranc_        ( int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
-void           pctranu_        ( int *,     int *,     float *,
-                                 float *,   int *,     int *,
-                                 int *,     float *,   float *,
-                                 int *,     int *,     int * );
-void           pztranu_        ( int *,     int *,     double *,
-                                 double *,  int *,     int *,
-                                 int *,     double *,  double *,
-                                 int *,     int *,     int * );
+void           pstran_         ( Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pdtran_         ( Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
+void           pctranc_        ( Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pztranc_        ( Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
+void           pctranu_        ( Int *,     Int *,     float *,
+                                 float *,   Int *,     Int *,
+                                 Int *,     float *,   float *,
+                                 Int *,     Int *,     Int * );
+void           pztranu_        ( Int *,     Int *,     double *,
+                                 double *,  Int *,     Int *,
+                                 Int *,     double *,  double *,
+                                 Int *,     Int *,     Int * );
 
 void           pstrmm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int * );
 void           pdtrmm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int * );
 void           pctrmm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int * );
 void           pztrmm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int * );
 
 void           pstrsm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int * );
 void           pdtrsm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int * );
 void           pctrsm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 float *,   float *,   int *,
-                                 int *,     int *,     float *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 float *,   float *,   Int *,
+                                 Int *,     Int *,     float *,
+                                 Int *,     Int *,     Int * );
 void           pztrsm_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 F_CHAR_T,  int *,     int *,
-                                 double *,  double *,  int *,
-                                 int *,     int *,     double *,
-                                 int *,     int *,     int * );
+                                 F_CHAR_T,  Int *,     Int *,
+                                 double *,  double *,  Int *,
+                                 Int *,     Int *,     double *,
+                                 Int *,     Int *,     Int * );
 #else
 
 void           PB_freebuf_     ();

--- a/PBLAS/SRC/PBtools.h
+++ b/PBLAS/SRC/PBtools.h
@@ -223,7 +223,7 @@
            { \
               if( ( (srcproc_) >= 0 ) && ( (nprocs_) > 1 ) ) \
               { \
-                 int inb__, mydist__, n__, nblk__, quot__, src__; \
+                 Int inb__, mydist__, n__, nblk__, quot__, src__; \
                  if( ( inb__ = (inb_) - (i_) ) <= 0 ) \
                  { \
                     src__  = (srcproc_) + ( nblk__ = (-inb__) / (nb_) + 1 ); \
@@ -300,7 +300,7 @@
            { \
               if( ( (srcproc_) >= 0 ) && ( (nprocs_) > 1 ) ) \
               { \
-                 int inb__, mydist__, n__, nblk__, quot__, rem__, src__; \
+                 Int inb__, mydist__, n__, nblk__, quot__, rem__, src__; \
                  if( ( inb__ = (inb_) - (i_) ) <= 0 ) \
                  { \
                     src__  = (srcproc_) + ( nblk__ = (-inb__) / (nb_) + 1 ); \
@@ -373,7 +373,7 @@
            { \
               if( ( (srcproc_) >= 0 ) && ( (nprocs_) > 1 ) ) \
               { \
-                 int inb__, mydist__, n__, nblk__, quot__, rem__, src__; \
+                 Int inb__, mydist__, n__, nblk__, quot__, rem__, src__; \
                  if( ( inb__ = (inb_) - (i_) ) <= 0 ) \
                  { \
                     src__  = (srcproc_) + ( nblk__ = (-inb__) / (nb_) + 1 ); \
@@ -427,7 +427,7 @@
 
 #define    Minfog2l( i_, j_, desc_, nr_, nc_, r_, c_, ii_, jj_, pr_, pc_ ) \
            { \
-              int quot__, i__, imb__, inb__, j__, mb__, mydist__, \
+              Int quot__, i__, imb__, inb__, j__, mb__, mydist__, \
                   nb__, nblk__, src__; \
               imb__ = desc_[IMB_]; mb__ = desc_[MB_]; pr_ = desc_[RSRC_]; \
               if( ( pr_ >= 0 ) && ( nr_ > 1 ) ) \
@@ -880,615 +880,615 @@
 */
 #ifdef __STDC__
 
-F_VOID_FCT     immadd_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     smmadd_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmadd_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmadd_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmadd_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     immadd_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     smmadd_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmadd_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmadd_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmadd_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     smmcadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmcadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmcadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmcadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     smmcadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmcadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmcadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmcadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     immtadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     smmtadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmtadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmtadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmtadd_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     immtadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     smmtadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmtadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmtadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmtadd_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     smmtcadd_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmtcadd_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmtcadd_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmtcadd_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     smmtcadd_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmtcadd_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmtcadd_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmtcadd_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     immdda_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     smmdda_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmdda_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmdda_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmdda_         ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     immdda_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     smmdda_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmdda_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmdda_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmdda_         ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     smmddac_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmddac_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmddac_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmddac_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     smmddac_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmddac_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmddac_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmddac_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     immddat_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     smmddat_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmddat_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmddat_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmddat_        ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     immddat_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     smmddat_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmddat_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmddat_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmddat_        ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     smmddact_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dmmddact_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cmmddact_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zmmddact_       ( int *,     int *,     char *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     smmddact_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dmmddact_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cmmddact_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zmmddact_       ( Int *,     Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
 F_VOID_FCT     sasqrtb_        ( float *,   float *,   float * );
 F_VOID_FCT     dasqrtb_        ( double *,  double *,  double * );
 
-F_VOID_FCT     sset_           ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dset_           ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     cset_           ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zset_           ( int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     sset_           ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dset_           ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     cset_           ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zset_           ( Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     svasum_         ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dvasum_         ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     scvasum_        ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dzvasum_        ( int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     svasum_         ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dvasum_         ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     scvasum_        ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dzvasum_        ( Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     sascal_         ( int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dascal_         ( int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     sascal_         ( Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dascal_         ( Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     scshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
-F_VOID_FCT     dcshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
-F_VOID_FCT     ccshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
-F_VOID_FCT     zcshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
+F_VOID_FCT     scshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
+F_VOID_FCT     dcshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
+F_VOID_FCT     ccshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
+F_VOID_FCT     zcshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
 
-F_VOID_FCT     srshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
-F_VOID_FCT     drshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
-F_VOID_FCT     crshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
-F_VOID_FCT     zrshft_         ( int *,     int *,     int *,
-                                 char *,    int * );
+F_VOID_FCT     srshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
+F_VOID_FCT     drshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
+F_VOID_FCT     crshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
+F_VOID_FCT     zrshft_         ( Int *,     Int *,     Int *,
+                                 char *,    Int * );
 
-F_VOID_FCT     svvdot_         ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     dvvdot_         ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     cvvdotu_        ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     cvvdotc_        ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zvvdotu_        ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zvvdotc_        ( int *,     char *,    char *,
-                                 int *,     char *,    int * );
+F_VOID_FCT     svvdot_         ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     dvvdot_         ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     cvvdotu_        ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     cvvdotc_        ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zvvdotu_        ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zvvdotc_        ( Int *,     char *,    char *,
+                                 Int *,     char *,    Int * );
 
-F_VOID_FCT     stzpad_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     dtzpad_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     ctzpad_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    char *,    int * );
-F_VOID_FCT     ztzpad_         ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 char *,    char *,    int * );
+F_VOID_FCT     stzpad_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     dtzpad_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     ctzpad_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    char *,    Int * );
+F_VOID_FCT     ztzpad_         ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 char *,    char *,    Int * );
 
-F_VOID_FCT     stzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     dtzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     ctzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     ztzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  int *,
-                                 int *,     int *,     char *,
-                                 int *,     char *,    int * );
+F_VOID_FCT     stzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     dtzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     ctzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     ztzpadcpy_      ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                 Int *,     Int *,     char *,
+                                 Int *,     char *,    Int * );
 
-F_VOID_FCT     stzscal_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dtzscal_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     ctzscal_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     ztzscal_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     stzscal_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dtzscal_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     ctzscal_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     ztzscal_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     chescal_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zhescal_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     chescal_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zhescal_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     ctzcnjg_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     ztzcnjg_        ( F_CHAR_T,  int *,     int *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     ctzcnjg_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     ztzcnjg_        ( F_CHAR_T,  Int *,     Int *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     sagemv_         ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     dagemv_         ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     cagemv_         ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
-F_VOID_FCT     zagemv_         ( F_CHAR_T,  int *,     int *,
-                                 char *,    char *,    int *,
-                                 char *,    int *,     char *,
-                                 char *,    int * );
+F_VOID_FCT     sagemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     dagemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     cagemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
+F_VOID_FCT     zagemv_         ( F_CHAR_T,  Int *,     Int *,
+                                 char *,    char *,    Int *,
+                                 char *,    Int *,     char *,
+                                 char *,    Int * );
 
-F_VOID_FCT     sasymv_         ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     dasymv_         ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     casymv_         ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zasymv_         ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     cahemv_         ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zahemv_         ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     sasymv_         ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     dasymv_         ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     casymv_         ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zasymv_         ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     cahemv_         ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zahemv_         ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
 F_VOID_FCT     satrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
 F_VOID_FCT     datrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
 F_VOID_FCT     catrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
 F_VOID_FCT     zatrmv_         ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                 int *,     char *,    char *,
-                                 int *,     char *,    int *,
-                                 char *,    char *,    int * );
+                                 Int *,     char *,    char *,
+                                 Int *,     char *,    Int *,
+                                 char *,    char *,    Int * );
 
-F_VOID_FCT     csymv_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
-F_VOID_FCT     zsymv_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    char *,
-                                 int * );
+F_VOID_FCT     csymv_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
+F_VOID_FCT     zsymv_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    char *,
+                                 Int * );
 
-F_VOID_FCT     csyr_           ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int * );
-F_VOID_FCT     zsyr_           ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int * );
+F_VOID_FCT     csyr_           ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int * );
+F_VOID_FCT     zsyr_           ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int * );
 
-F_VOID_FCT     csyr2_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
-F_VOID_FCT     zsyr2_          ( F_CHAR_T,  int *,     char *,
-                                 char *,    int *,     char *,
-                                 int *,     char *,    int * );
+F_VOID_FCT     csyr2_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
+F_VOID_FCT     zsyr2_          ( F_CHAR_T,  Int *,     char *,
+                                 char *,    Int *,     char *,
+                                 Int *,     char *,    Int * );
 
-void           PB_Ctzsyr       ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
-void           PB_Ctzher       ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
-void           PB_Ctzsyr2      ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int,
-                                 char *,    int );
-void           PB_Ctzher2      ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int,
-                                 char *,    int );
+void           PB_Ctzsyr       ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
+void           PB_Ctzher       ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
+void           PB_Ctzsyr2      ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int );
+void           PB_Ctzher2      ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int );
 void           PB_Ctztrmv      ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
+                                 char *,    char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
 void           PB_Ctzatrmv     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
+                                 char *,    char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
 void           PB_Ctzsymv      ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int );
+                                 Int,       Int,       Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int );
 void           PB_Ctzhemv      ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int );
+                                 Int,       Int,       Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int );
 void           PB_Ctzasymv     ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int );
+                                 Int,       Int,       Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int );
 void           PB_Ctzahemv     ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int );
+                                 Int,       Int,       Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int );
 
-void           PB_Ctzsyrk      ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
-void           PB_Ctzherk      ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
-void           PB_Ctzsyr2k     ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int,
-                                 char *,    int );
-void           PB_Ctzher2k     ( PBTYP_T *, char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int,
-                                 char *,    int );
+void           PB_Ctzsyrk      ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
+void           PB_Ctzherk      ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
+void           PB_Ctzsyr2k     ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int );
+void           PB_Ctzher2k     ( PBTYP_T *, char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int );
 void           PB_Ctztrmm      ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       int,       int,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
+                                 char *,    char *,    Int,
+                                 Int,       Int,       Int,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
 void           PB_Ctzsymm      ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int );
+                                 Int,       Int,       Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int );
 void           PB_Ctzhemm      ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int );
+                                 Int,       Int,       Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int );
 
-void           PB_CpswapNN     ( PBTYP_T *, int,       char *,
-                                 int,       int,       int *,
-                                 int,       char *,    int,
-                                 int,       int *,     int );
-void           PB_CpswapND     ( PBTYP_T *, int,       char *,
-                                 int,       int,       int *,
-                                 int,       char *,    int,
-                                 int,       int *,     int );
-void           PB_Cpdot11      ( PBTYP_T *, int,       char *,
-                                 char *,    int,       int,
-                                 int *,     int,       char *,
-                                 int,       int,       int *,
-                                 int,       VVDOT_T );
-void           PB_CpdotNN      ( PBTYP_T *, int,       char *,
-                                 char *,    int,       int,
-                                 int *,     int,       char *,
-                                 int,       int,       int *,
-                                 int,       VVDOT_T );
-void           PB_CpdotND      ( PBTYP_T *, int,       char *,
-                                 char *,    int,       int,
-                                 int *,     int,       char *,
-                                 int,       int,       int *,
-                                 int,       VVDOT_T );
-void           PB_CpaxpbyNN    ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
+void           PB_CpswapNN     ( PBTYP_T *, Int,       char *,
+                                 Int,       Int,       Int *,
+                                 Int,       char *,    Int,
+                                 Int,       Int *,     Int );
+void           PB_CpswapND     ( PBTYP_T *, Int,       char *,
+                                 Int,       Int,       Int *,
+                                 Int,       char *,    Int,
+                                 Int,       Int *,     Int );
+void           PB_Cpdot11      ( PBTYP_T *, Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     Int,       char *,
+                                 Int,       Int,       Int *,
+                                 Int,       VVDOT_T );
+void           PB_CpdotNN      ( PBTYP_T *, Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     Int,       char *,
+                                 Int,       Int,       Int *,
+                                 Int,       VVDOT_T );
+void           PB_CpdotND      ( PBTYP_T *, Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     Int,       char *,
+                                 Int,       Int,       Int *,
+                                 Int,       VVDOT_T );
+void           PB_CpaxpbyNN    ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
                                  char *,    char *,    char *,
-                                 int,       int,       int *,
+                                 Int,       Int,       Int *,
                                  char * );
-void           PB_CpaxpbyND    ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
+void           PB_CpaxpbyND    ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
                                  char *,    char *,    char *,
-                                 int,       int,       int *,
+                                 Int,       Int,       Int *,
                                  char * );
-void           PB_CpaxpbyDN    ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
+void           PB_CpaxpbyDN    ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
                                  char *,    char *,    char *,
-                                 int,       int,       int *,
+                                 Int,       Int,       Int *,
                                  char * );
-void           PB_Cpaxpby      ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
+void           PB_Cpaxpby      ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
                                  char *,    char *,    char *,
-                                 int,       int,       int *,
+                                 Int,       Int,       Int *,
                                  char * );
 
-void           PB_Cpsyr        ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       int,
-                                 int *,     TZSYR_T );
-void           PB_Cpsyr2       ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       char *,    int,
-                                 int,       int *,     TZSYR2_T );
+void           PB_Cpsyr        ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       Int,
+                                 Int *,     TZSYR_T );
+void           PB_Cpsyr2       ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       char *,    Int,
+                                 Int,       Int *,     TZSYR2_T );
 void           PB_Cptrm        ( PBTYP_T *, PBTYP_T *, char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 char *,    int,       TZTRM_T );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 char *,    Int,       TZTRM_T );
 void           PB_Cpsym        ( PBTYP_T *, PBTYP_T *, char *,
-                                 char *,    int,       int,
-                                 char *,    char *,    int,
-                                 int,       int *,     char *,
-                                 int,       char *,    int,
-                                 char *,    int,       char *,
-                                 int,       TZSYM_T );
+                                 char *,    Int,       Int,
+                                 char *,    char *,    Int,
+                                 Int,       Int *,     char *,
+                                 Int,       char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int,       TZSYM_T );
 void           PB_Cpgeadd      ( PBTYP_T *, char *,    char *,
-                                 char *,    int,       int,
-                                 char *,    char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    int,       int,
-                                 int * );
+                                 char *,    Int,       Int,
+                                 char *,    char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    Int,       Int,
+                                 Int * );
 void           PB_Cptradd      ( PBTYP_T *, char *,    char *,
-                                 char *,    int,       int,
-                                 char *,    char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    int,       int,
-                                 int * );
-void           PB_Cptran       ( PBTYP_T *, char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    char *,    int,
-                                 int,       int * );
-void           PB_Cptrsv       ( PBTYP_T *, int,       char *,
-                                 char *,    char *,    int,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 char *,    int );
-void           PB_Cptrsm       ( PBTYP_T *, int,       char *,
+                                 char *,    Int,       Int,
+                                 char *,    char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    Int,       Int,
+                                 Int * );
+void           PB_Cptran       ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    char *,    Int,
+                                 Int,       Int * );
+void           PB_Cptrsv       ( PBTYP_T *, Int,       char *,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 char *,    Int );
+void           PB_Cptrsm       ( PBTYP_T *, Int,       char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 char *,    int );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 char *,    Int );
 
 void           PB_CpgemmAB     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    int,       int,
-                                 int * );
+                                 char *,    char *,    Int,
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    Int,       Int,
+                                 Int * );
 void           PB_CpgemmAC     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    int,       int,
-                                 int * );
+                                 char *,    char *,    Int,
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    Int,       Int,
+                                 Int * );
 void           PB_CpgemmBC     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    int,       int,
-                                 int * );
+                                 char *,    char *,    Int,
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    Int,       Int,
+                                 Int * );
 void           PB_CpsymmAB     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    int,       int,
-                                 int *,     char *,    char *,
-                                 int,       int,       int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    char *,
+                                 Int,       Int,       Int * );
 void           PB_CpsymmBC     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    int,       int,
-                                 int *,     char *,    char *,
-                                 int,       int,       int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    char *,
+                                 Int,       Int,       Int * );
 void           PB_CpsyrkA      ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    char *,    int,
-                                 int,       int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    char *,    Int,
+                                 Int,       Int * );
 void           PB_CpsyrkAC     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    char *,    int,
-                                 int,       int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    char *,    Int,
+                                 Int,       Int * );
 void           PB_Cpsyr2kA     ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    int,       int,
-                                 int *,     char *,    char *,
-                                 int,       int,       int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    char *,
+                                 Int,       Int,       Int * );
 void           PB_Cpsyr2kAC    ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    int,       int,
-                                 int *,     char *,    char *,
-                                 int,       int,       int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    char *,
+                                 Int,       Int,       Int * );
 void           PB_CptrmmAB     ( PBTYP_T *, char *,    char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int * );
 void           PB_CptrmmB      ( PBTYP_T *, char *,    char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int * );
 void           PB_CptrsmAB     ( PBTYP_T *, char *,    char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int * );
 void           PB_CptrsmAB0    ( PBTYP_T *, char *,    char *,
-                                 char *,    int,       int,
-                                 char *,    char *,    int,
-                                 int,       int *,     char *,
-                                 int,       int,       int *,
-                                 char * *,  int *,     int * );
+                                 char *,    Int,       Int,
+                                 char *,    char *,    Int,
+                                 Int,       Int *,     char *,
+                                 Int,       Int,       Int *,
+                                 char * *,  Int *,     Int * );
 void           PB_CptrsmAB1    ( PBTYP_T *, char *,    char *,
-                                 char *,    char *,    int,
-                                 int,       char *,    char *,
-                                 int,       int,       int *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int * );
+                                 char *,    char *,    Int,
+                                 Int,       char *,    char *,
+                                 Int,       Int,       Int *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int * );
 void           PB_CptrsmB      ( PBTYP_T *, char *,    char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int *,     char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int *,     char *,    Int,
+                                 Int,       Int * );
 #else
 
 F_VOID_FCT     immadd_         ();
@@ -1673,71 +1673,71 @@ void           PB_CptrsmB      ();
                                                              /* TOOLS */
 #ifdef __STDC__
 
-int            PB_Cgcd         ( int,       int );
-int            PB_Clcm         ( int,       int );
+Int            PB_Cgcd         ( Int,       Int );
+Int            PB_Clcm         ( Int,       Int );
 
-void           PB_Cdescset     ( int *,     int,       int,
-                                 int,       int,       int,
-                                 int,       int,       int,
-                                 int,       int );
-void           PB_Cdescribe    ( int,       int,       int,
-                                 int,       int *,     int,
-                                 int,       int,       int,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           PB_CargFtoC     ( int,       int,       int *,
-                                 int *,     int *,     int * );
-int            PB_Cfirstnb     ( int,       int,       int,
-                                 int );
-int            PB_Clastnb      ( int,       int,       int,
-                                 int );
-int            PB_Cspan        ( int,       int,       int,
-                                 int,       int,       int );
+void           PB_Cdescset     ( Int *,     Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int,       Int );
+void           PB_Cdescribe    ( Int,       Int,       Int,
+                                 Int,       Int *,     Int,
+                                 Int,       Int,       Int,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           PB_CargFtoC     ( Int,       Int,       Int *,
+                                 Int *,     Int *,     Int * );
+Int            PB_Cfirstnb     ( Int,       Int,       Int,
+                                 Int );
+Int            PB_Clastnb      ( Int,       Int,       Int,
+                                 Int );
+Int            PB_Cspan        ( Int,       Int,       Int,
+                                 Int,       Int,       Int );
 
-void           PB_Cainfog2l    ( int,       int,       int,
-                                 int,       int *,     int,
-                                 int,       int,       int,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int * );
-void           PB_Cinfog2l     ( int,       int,       int *,
-                                 int,       int,       int,
-                                 int,       int *,     int *,
-                                 int *,     int * );
-int            PB_Cg2lrem      ( int,       int,       int,
-                                 int,       int,       int );
-int            PB_Cindxg2p     ( int,       int,       int,
-                                 int,       int,       int );
-int            PB_Cnumroc      ( int,       int,       int,
-                                 int,       int,       int,
-                                 int );
-int            PB_Cnpreroc     ( int,       int,       int,
-                                 int,       int,       int,
-                                 int );
-int            PB_Cnnxtroc     ( int,       int,       int,
-                                 int,       int,       int,
-                                 int );
+void           PB_Cainfog2l    ( Int,       Int,       Int,
+                                 Int,       Int *,     Int,
+                                 Int,       Int,       Int,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int * );
+void           PB_Cinfog2l     ( Int,       Int,       Int *,
+                                 Int,       Int,       Int,
+                                 Int,       Int *,     Int *,
+                                 Int *,     Int * );
+Int            PB_Cg2lrem      ( Int,       Int,       Int,
+                                 Int,       Int,       Int );
+Int            PB_Cindxg2p     ( Int,       Int,       Int,
+                                 Int,       Int,       Int );
+Int            PB_Cnumroc      ( Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int );
+Int            PB_Cnpreroc     ( Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int );
+Int            PB_Cnnxtroc     ( Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int );
 
 void           PB_Cconjg       ( PBTYP_T *, char *,    char * );
 
 
-void           PB_Cwarn        ( int,       int,       char *,
+void           PB_Cwarn        ( Int,       Int,       char *,
                                  char *,    ... );
-void           PB_Cabort       ( int,       char *,    int );
-void           PB_Cchkmat      ( int,       char *,    char *,
-                                 int,       int,       int,
-                                 int,       int,       int,
-                                 int *,     int,       int * );
-void           PB_Cchkvec      ( int,       char *,    char *,
-                                 int,       int,       int,
-                                 int,       int *,     int,
-                                 int,       int * );
+void           PB_Cabort       ( Int,       char *,    Int );
+void           PB_Cchkmat      ( Int,       char *,    char *,
+                                 Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int *,     Int,       Int * );
+void           PB_Cchkvec      ( Int,       char *,    char *,
+                                 Int,       Int ,       Int ,
+                                 Int,       Int *,     Int,
+                                 Int,       Int * );
 
-char *         PB_Cmalloc      ( int );
-char *         PB_Cgetbuf      ( char *,    int );
+char *         PB_Cmalloc      ( Int );
+char *         PB_Cgetbuf      ( char *,    Int );
 
 PBTYP_T *      PB_Citypeset    ( void );
 PBTYP_T *      PB_Cstypeset    ( void );
@@ -1745,130 +1745,130 @@ PBTYP_T *      PB_Cdtypeset    ( void );
 PBTYP_T *      PB_Cctypeset    ( void );
 PBTYP_T *      PB_Cztypeset    ( void );
 
-int            pilaenv_        ( int *,     F_CHAR_T );
-char *         PB_Ctop         ( int *,     char *,    char *,
+Int            pilaenv_        ( Int *,     F_CHAR_T );
+char *         PB_Ctop         ( Int *,     char *,    char *,
                                  char * );
 
-void           PB_CVMinit      ( PB_VM_T *, int,       int,
-                                 int,       int,       int,
-                                 int,       int,       int,
-                                 int,       int,       int,
-                                 int );
-int            PB_CVMnpq       ( PB_VM_T * );
-void           PB_CVMcontig    ( PB_VM_T *, int *,     int *,
-                                 int *,     int * );
-int            PB_CVMloc       ( PBTYP_T *, PB_VM_T *, char *,
+void           PB_CVMinit      ( PB_VM_T *, Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int );
+Int            PB_CVMnpq       ( PB_VM_T * );
+void           PB_CVMcontig    ( PB_VM_T *, Int *,     Int *,
+                                 Int *,     Int * );
+Int            PB_CVMloc       ( PBTYP_T *, PB_VM_T *, char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       char *,
-                                 char *,    int );
-int            PB_CVMswp       ( PBTYP_T *, PB_VM_T *, char *,
-                                 char *,    char *,    int,
-                                 char *,    int,       char *,
-                                 int );
-int            PB_CVMpack      ( PBTYP_T *, PB_VM_T *, char *,
+                                 Int,       Int,       char *,
+                                 char *,    Int,       char *,
+                                 char *,    Int );
+Int            PB_CVMswp       ( PBTYP_T *, PB_VM_T *, char *,
+                                 char *,    char *,    Int,
+                                 char *,    Int,       char *,
+                                 Int );
+Int            PB_CVMpack      ( PBTYP_T *, PB_VM_T *, char *,
                                  char *,    char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       char *,
-                                 char *,    int );
-void           PB_CVMupdate    ( PB_VM_T *, int,       int *,
-                                 int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       char *,
+                                 char *,    Int );
+void           PB_CVMupdate    ( PB_VM_T *, Int,       Int *,
+                                 Int * );
 
-void           PB_Cbinfo       ( int,       int,       int,
-                                 int,       int,       int,
-                                 int,       int,       int,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int *,     int *,     int *,
-                                 int *,     int * );
+void           PB_Cbinfo       ( Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int,       Int,       Int,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int *,     Int *,
+                                 Int *,     Int * );
 
-void           PB_Cplaprnt     ( PBTYP_T *, int,       int,
-                                 char *,    int,       int,
-                                 int *,     int,       int,
+void           PB_Cplaprnt     ( PBTYP_T *, Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int *,     Int,       Int,
                                  char * );
-void           PB_Cplaprn2     ( PBTYP_T *, int,       int,
-                                 char *,    int,       int,
-                                 int *,     int,       int,
-                                 char *,    int,       int );
-void           PB_Cprnt        ( char,      int,       int,
-                                 int,       char *,    int,
-                                 int,       char * );
+void           PB_Cplaprn2     ( PBTYP_T *, Int,       Int,
+                                 char *,    Int,       Int,
+                                 Int *,     Int,       Int,
+                                 char *,    Int,       Int );
+void           PB_Cprnt        ( char,      Int,       Int,
+                                 Int,       char *,    Int,
+                                 Int,       char * );
 
 void           PB_Cplapad      ( PBTYP_T *, char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    char *,    Int,
+                                 Int,       Int * );
 void           PB_Cplapd2      ( PBTYP_T *, char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    char *,    Int,
+                                 Int,       Int * );
 void           PB_Cplascal     ( PBTYP_T *, char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int * );
 void           PB_Cplasca2     ( PBTYP_T *, char *,    char *,
-                                 int,       int,       char *,
-                                 char *,    int,       int,
-                                 int * );
-void           PB_Cplacnjg     ( PBTYP_T *, int,       int,
-                                 char *,    char *,    int,
-                                 int,       int * );
+                                 Int,       Int,       char *,
+                                 char *,    Int,       Int,
+                                 Int * );
+void           PB_Cplacnjg     ( PBTYP_T *, Int,       Int,
+                                 char *,    char *,    Int,
+                                 Int,       Int * );
 
 void           PB_CInV         ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int *,
-                                 int,       char *,    int,
-                                 int,       int *,     char *,
-                                 char * *,  int *,     int * );
+                                 Int,       Int,       Int *,
+                                 Int,       char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char * *,  Int *,     Int * );
 void           PB_CInV2        ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int *,
-                                 int,       char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    int,       int * );
-void           PB_CInOutV      ( PBTYP_T *, char *,    int,
-                                 int,       int *,     int,
-                                 char *,    char *,    int,
-                                 int,       int *,     char *,
-                                 char * *,  char * *,  int *,
-                                 int *,     int *,     int * );
+                                 Int,       Int,       Int *,
+                                 Int,       char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    Int,       Int * );
+void           PB_CInOutV      ( PBTYP_T *, char *,    Int,
+                                 Int,       Int *,     Int,
+                                 char *,    char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char * *,  char * *,  Int *,
+                                 Int *,     Int *,     Int * );
 void           PB_CInOutV2     ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int,
-                                 int *,     int,       char *,
-                                 int,       int,       int *,
-                                 char *,    char * *,  int *,
-                                 int *,     int *,     int * );
+                                 Int,       Int,       Int,
+                                 Int *,     Int,       char *,
+                                 Int,       Int,       Int *,
+                                 char *,    char * *,  Int *,
+                                 Int *,     Int *,     Int * );
 void           PB_COutV        ( PBTYP_T *, char *,    char *,
-                                 int,       int,       int *,
-                                 int,       char * *,  int *,
-                                 int *,     int * );
+                                 Int,       Int,       Int *,
+                                 Int,       char * *,  Int *,
+                                 Int *,     Int * );
 void           PB_CGatherV     ( PBTYP_T *, char *,    char *,
-                                 int,       int,       char *,
-                                 int,       int,       int *,
-                                 char *,    char * *,  int *,
-                                 int * );
-void           PB_CScatterV    ( PBTYP_T *, char *,    int,
-                                 int,       char *,    int,
-                                 int,       int *,     char *,
-                                 char *,    char *,    int,
-                                 int,       int *,     char * );
+                                 Int,       Int,       char *,
+                                 Int,       Int,       Int *,
+                                 char *,    char * *,  Int *,
+                                 Int * );
+void           PB_CScatterV    ( PBTYP_T *, char *,    Int,
+                                 Int,       char *,    Int,
+                                 Int,       Int *,     char *,
+                                 char *,    char *,    Int,
+                                 Int,       Int *,     char * );
 #else
 
-int            PB_Cgcd         ();
-int            PB_Clcm         ();
+Int            PB_Cgcd         ();
+Int            PB_Clcm         ();
 
 void           PB_Cdescset     ();
 void           PB_Cdescribe    ();
 void           PB_CargFtoC     ();
-int            PB_Cfirstnb     ();
-int            PB_Clastnb      ();
-int            PB_Cspan        ();
+Int            PB_Cfirstnb     ();
+Int            PB_Clastnb      ();
+Int            PB_Cspan        ();
 
 void           PB_Cainfog2l    ();
 void           PB_Cinfog2l     ();
-int            PB_Cg2lrem      ();
-int            PB_Cindxg2p     ();
-int            PB_Cnumroc      ();
-int            PB_Cnpreroc     ();
-int            PB_Cnnxtroc     ();
+Int            PB_Cg2lrem      ();
+Int            PB_Cindxg2p     ();
+Int            PB_Cnumroc      ();
+Int            PB_Cnpreroc     ();
+Int            PB_Cnnxtroc     ();
 
 void           PB_Cconjg       ();
 
@@ -1886,15 +1886,15 @@ PBTYP_T *      PB_Cdtypeset    ();
 PBTYP_T *      PB_Cctypeset    ();
 PBTYP_T *      PB_Cztypeset    ();
 
-int            pilaenv_        ();
+Int            pilaenv_        ();
 char *         PB_Ctop         ();
 
 void           PB_CVMinit      ();
-int            PB_CVMnpq       ();
+Int            PB_CVMnpq       ();
 void           PB_CVMcontig    ();
-int            PB_CVMloc       ();
-int            PB_CVMswp       ();
-int            PB_CVMpack      ();
+Int            PB_CVMloc       ();
+Int            PB_CVMswp       ();
+Int            PB_CVMpack      ();
 void           PB_CVMupdate    ();
 
 void           PB_Cbinfo       ();

--- a/PBLAS/SRC/PTOOLS/PB_CGatherV.c
+++ b/PBLAS/SRC/PTOOLS/PB_CGatherV.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CGatherV( PBTYP_T * TYPE, char * ALLOC, char * DIRECA, int M, int N,
-                  char * A, int IA, int JA, int * DESCA, char * AROC,
-                  char * * B, int * DESCB, int * BFREE )
+void PB_CGatherV( PBTYP_T * TYPE, char * ALLOC, char * DIRECA, Int M, Int N,
+                  char * A, Int IA, Int JA, Int * DESCA, char * AROC,
+                  char * * B, Int * DESCB, Int * BFREE )
 #else
 void PB_CGatherV( TYPE, ALLOC, DIRECA, M, N, A, IA, JA, DESCA, AROC, B,
                   DESCB, BFREE )
@@ -27,12 +27,12 @@ void PB_CGatherV( TYPE, ALLOC, DIRECA, M, N, A, IA, JA, DESCA, AROC, B,
 *  .. Scalar Arguments ..
 */
    char           * ALLOC, * AROC, * DIRECA;
-   int            * BFREE, IA, JA, M, N;
+   Int            * BFREE, IA, JA, M, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * * B;
 #endif
 {
@@ -186,7 +186,7 @@ void PB_CGatherV( TYPE, ALLOC, DIRECA, M, N, A, IA, JA, DESCA, AROC, B,
 *  .. Local Scalars ..
 */
    char           * one, * zero;
-   int            Afwd, AggRow, AiiD, AiiR, Ainb1D, Ainb1R, Ald, AmyprocD,
+   Int            Afwd, AggRow, AiiD, AiiR, Ainb1D, Ainb1R, Ald, AmyprocD,
                   AmyprocR, AnR, AnbD, AnbR, AnnxtL, AnnxtR, AnpD, AnpR, AnpreR,
                   AnprocsR, ArocR, AsrcD, AsrcR, Bld, Bsrc_, ctxt, k, kb, kblks,
                   kn, ktmp, mycol, mydist, mydistnb, myrow, nlen, npcol, nprow,

--- a/PBLAS/SRC/PTOOLS/PB_CInOutV.c
+++ b/PBLAS/SRC/PTOOLS/PB_CInOutV.c
@@ -17,11 +17,11 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CInOutV( PBTYP_T * TYPE, char * ROWCOL, int M, int N, int * DESCA,
-                 int K, char * BETA,
-                 char * Y, int IY, int JY, int * DESCY, char * YROC,
-                 char * * TBETA, char * * YAPTR, int * DYA,
-                 int * YAFREE, int * YASUM, int * YAPBY )
+void PB_CInOutV( PBTYP_T * TYPE, char * ROWCOL, Int M, Int N, Int * DESCA,
+                 Int K, char * BETA,
+                 char * Y, Int IY, Int JY, Int * DESCY, char * YROC,
+                 char * * TBETA, char * * YAPTR, Int * DYA,
+                 Int * YAFREE, Int * YASUM, Int * YAPBY )
 #else
 void PB_CInOutV( TYPE, ROWCOL, M, N, DESCA, K,
                  BETA, Y, IY, JY, DESCY, YROC,
@@ -30,12 +30,12 @@ void PB_CInOutV( TYPE, ROWCOL, M, N, DESCA, K,
 *  .. Scalar Arguments ..
 */
    char           * BETA, * ROWCOL, * * TBETA, * YROC;
-   int            * YAPBY, * YAFREE, IY, JY, K, M, N, * YASUM;
+   Int            * YAPBY, * YAFREE, IY, JY, K, M, N, * YASUM;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCY, * DYA;
+   Int            * DESCA, * DESCY, * DYA;
    char           * Y, * * YAPTR;
 #endif
 {
@@ -225,7 +225,7 @@ void PB_CInOutV( TYPE, ROWCOL, M, N, DESCA, K,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Aimb, Ainb, AisD, AisR, Amb, Amp, Anb, Anq, Arow, Ycol,
+   Int            Acol, Aimb, Ainb, AisD, AisR, Amb, Amp, Anb, Anq, Arow, Ycol,
                   Yii, Yimb, Yimb1, Yinb, Yinb1, YisD, YisR, YisRow, Yjj, Yld,
                   Ymb, Ymp, Ynb, Ynq, Yrow, ctxt, izero=0, nprow, myrow, npcol,
                   mycol;

--- a/PBLAS/SRC/PTOOLS/PB_CInOutV2.c
+++ b/PBLAS/SRC/PTOOLS/PB_CInOutV2.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CInOutV2( PBTYP_T * TYPE, char * CONJUG, char * ROWCOL, int M,
-                  int N, int KA, int * DESCA, int K, char * Y, int IY,
-                  int JY, int * DESCY, char * YROC, char * * YAPTR,
-                  int * DYA, int * YAFREE, int * YASUM, int * YAPBY )
+void PB_CInOutV2( PBTYP_T * TYPE, char * CONJUG, char * ROWCOL, Int M,
+                  Int N, Int KA, Int * DESCA, Int K, char * Y, Int IY,
+                  Int JY, Int * DESCY, char * YROC, char * * YAPTR,
+                  Int * DYA, Int * YAFREE, Int * YASUM, Int * YAPBY )
 #else
 void PB_CInOutV2( TYPE, CONJUG, ROWCOL, M, N, KA, DESCA, K, Y, IY, JY,
                   DESCY, YROC, YAPTR, DYA, YAFREE, YASUM, YAPBY )
@@ -28,12 +28,12 @@ void PB_CInOutV2( TYPE, CONJUG, ROWCOL, M, N, KA, DESCA, K, Y, IY, JY,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * ROWCOL, * YROC;
-   int            * YAPBY, * YAFREE, IY, JY, K, KA, M, N, * YASUM;
+   Int            * YAPBY, * YAFREE, IY, JY, K, KA, M, N, * YASUM;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCY, * DYA;
+   Int            * DESCA, * DESCY, * DYA;
    char           * Y, * * YAPTR;
 #endif
 {
@@ -226,7 +226,7 @@ void PB_CInOutV2( TYPE, CONJUG, ROWCOL, M, N, KA, DESCA, K, Y, IY, JY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Acoldst, Aimb, Ainb, AisD, AisR, Amb, Amp, Anb, Anq,
+   Int            Acol, Acoldst, Aimb, Ainb, AisD, AisR, Amb, Amp, Anb, Anq,
                   Arow, Arowdst, Ycol, Yii, Yimb, Yimb1, Yinb, Yinb1, YisD,
                   YisR, YisRow, Yjj, Yld, Ymb, Ymp, Ynb, Ynq, Yrow, ctxt,
                   izero=0, nprow, myrow, npcol, mycol;

--- a/PBLAS/SRC/PTOOLS/PB_CInV.c
+++ b/PBLAS/SRC/PTOOLS/PB_CInV.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CInV( PBTYP_T * TYPE, char * CONJUG, char * ROWCOL, int M,
-              int N, int * DESCA, int K, char * X, int IX, int JX,
-              int * DESCX, char * XROC, char * * XAPTR, int * DXA,
-              int * XAFREE )
+void PB_CInV( PBTYP_T * TYPE, char * CONJUG, char * ROWCOL, Int M,
+              Int N, Int * DESCA, Int K, char * X, Int IX, Int JX,
+              Int * DESCX, char * XROC, char * * XAPTR, Int * DXA,
+              Int * XAFREE )
 #else
 void PB_CInV( TYPE, CONJUG, ROWCOL, M, N, DESCA, K, X, IX, JX, DESCX,
               XROC, XAPTR, DXA, XAFREE )
@@ -28,12 +28,12 @@ void PB_CInV( TYPE, CONJUG, ROWCOL, M, N, DESCA, K, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * ROWCOL, * XROC;
-   int            * XAFREE, IX, JX, K, M, N;
+   Int            * XAFREE, IX, JX, K, M, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DXA;
+   Int            * DESCA, * DESCX, * DXA;
    char           * X, * * XAPTR;
 #endif
 {
@@ -202,7 +202,7 @@ void PB_CInV( TYPE, CONJUG, ROWCOL, M, N, DESCA, K, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           * top;
-   int            AColSpan, ARowSpan, Acol, Aimb, Ainb, AisD, Amb, Amp, Anb,
+   Int            AColSpan, ARowSpan, Acol, Aimb, Ainb, AisD, Amb, Amp, Anb,
                   Anq, Arow, Xcol, Xii, Ximb, Ximb1, Xinb, Xinb1, XisD, XisR,
                   XisRow, Xjj, Xld=1, Xmb, Xmp, Xnb, Xnq, Xrow, ctxt, mycol,
                   myrow, npcol, nprow;

--- a/PBLAS/SRC/PTOOLS/PB_CInV2.c
+++ b/PBLAS/SRC/PTOOLS/PB_CInV2.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CInV2( PBTYP_T * TYPE, char * CONJUG, char * ROWCOL, int M,
-               int N, int * DESCA, int K, char * X, int IX, int JX,
-               int * DESCX, char * XROC, char * XAPTR, int IJXA,
-               int * DXA )
+void PB_CInV2( PBTYP_T * TYPE, char * CONJUG, char * ROWCOL, Int M,
+               Int N, Int * DESCA, Int K, char * X, Int IX, Int JX,
+               Int * DESCX, char * XROC, char * XAPTR, Int IJXA,
+               Int * DXA )
 #else
 void PB_CInV2( TYPE, CONJUG, ROWCOL, M, N, DESCA, K, X, IX, JX, DESCX,
                XROC, XAPTR, IJXA, DXA )
@@ -28,12 +28,12 @@ void PB_CInV2( TYPE, CONJUG, ROWCOL, M, N, DESCA, K, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * ROWCOL, * XROC;
-   int            IJXA, IX, JX, K, M, N;
+   Int            IJXA, IX, JX, K, M, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DXA;
+   Int            * DESCA, * DESCX, * DXA;
    char           * X, * XAPTR;
 #endif
 {
@@ -195,7 +195,7 @@ void PB_CInV2( TYPE, CONJUG, ROWCOL, M, N, DESCA, K, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           * Xptr = NULL, * top;
-   int            AColSpan, ARowSpan, Acol, Aimb, Ainb, AisD, Amb, Amp, Anb,
+   Int            AColSpan, ARowSpan, Acol, Aimb, Ainb, AisD, Amb, Amp, Anb,
                   Anq, Arow, XAld, Xcol, Xii, Ximb1, Xinb1, XisD, XisR, XisRow,
                   Xjj, Xld=1, Xmb, Xnb, Xrow, ctxt, mycol, myrow, npcol, nprow,
                   size;

--- a/PBLAS/SRC/PTOOLS/PB_COutV.c
+++ b/PBLAS/SRC/PTOOLS/PB_COutV.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_COutV( PBTYP_T * TYPE, char * ROWCOL, char * ZEROIT, int M,
-               int N, int * DESCA, int K, char * * YAPTR, int * DYA,
-               int * YAFREE, int * YASUM )
+void PB_COutV( PBTYP_T * TYPE, char * ROWCOL, char * ZEROIT, Int M,
+               Int N, Int * DESCA, Int K, char * * YAPTR, Int * DYA,
+               Int * YAFREE, Int * YASUM )
 #else
 void PB_COutV( TYPE, ROWCOL, ZEROIT, M, N, DESCA, K, YAPTR, DYA,
                YAFREE, YASUM )
@@ -27,12 +27,12 @@ void PB_COutV( TYPE, ROWCOL, ZEROIT, M, N, DESCA, K, YAPTR, DYA,
 *  .. Scalar Arguments ..
 */
    char           * ROWCOL, * ZEROIT;
-   int            * YAFREE, K, M, N, * YASUM;
+   Int            * YAFREE, K, M, N, * YASUM;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DYA;
+   Int            * DESCA, * DYA;
    char           * * YAPTR;
 #endif
 {
@@ -175,7 +175,7 @@ void PB_COutV( TYPE, ROWCOL, ZEROIT, M, N, DESCA, K, YAPTR, DYA,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Aimb, Ainb, Amb, Amp, Anb, Anq, Arow, Yld, ctxt,
+   Int            Acol, Aimb, Ainb, Amb, Amp, Anb, Anq, Arow, Yld, ctxt,
                   izero=0, nprow, myrow, npcol, mycol;
    char           * zero;
 /* ..

--- a/PBLAS/SRC/PTOOLS/PB_CScatterV.c
+++ b/PBLAS/SRC/PTOOLS/PB_CScatterV.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CScatterV( PBTYP_T * TYPE, char * DIRECA, int M, int N,
-                   char * A, int IA, int JA, int * DESCA, char * AROC,
-                   char * ALPHA, char * B, int IB, int JB, int * DESCB,
+void PB_CScatterV( PBTYP_T * TYPE, char * DIRECA, Int M, Int N,
+                   char * A, Int IA, Int JA, Int * DESCA, char * AROC,
+                   char * ALPHA, char * B, Int IB, Int JB, Int * DESCB,
                    char * BROC )
 #else
 void PB_CScatterV( TYPE, DIRECA, M, N, A, IA, JA, DESCA, AROC,
@@ -28,12 +28,12 @@ void PB_CScatterV( TYPE, DIRECA, M, N, A, IA, JA, DESCA, AROC,
 *  .. Scalar Arguments ..
 */
    char           * ALPHA, * AROC, * BROC, * DIRECA;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -192,7 +192,7 @@ void PB_CScatterV( TYPE, DIRECA, M, N, A, IA, JA, DESCA, AROC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            Afwd, Bbufld, Bcol, Bcurcol, Bcurrow, Bii, Bimb, Bimb1, Binb,
+   Int            Afwd, Bbufld, Bcol, Bcurcol, Bcurrow, Bii, Bimb, Bimb1, Binb,
                   Binb1, BisRow, Bjj, Bld, Bm, Bmb, Bmp, Bn, Bnb, Bnnxt, BnnxtL,
                   Bnpre, Bnq, Brow, WAfr, ctxt, kb, mycol, mydist, mydistnb,
                   myrow, nlen, npcol, nprow, offset, size, srcdist, stride,
@@ -202,7 +202,7 @@ void PB_CScatterV( TYPE, DIRECA, M, N, A, IA, JA, DESCA, AROC,
 /*
 *  .. Local Arrays ..
 */
-   int            Bd0[DLEN_], WAd[DLEN_];
+   Int            Bd0[DLEN_], WAd[DLEN_];
    char           * Bptr = NULL, * Bbuf = NULL, * Bbufptr = NULL, * WA = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_CVMcontig.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMcontig.c
@@ -17,14 +17,14 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CVMcontig( PB_VM_T * VM, int * NRPQ, int * NCPQ, int * IOFF,
-                   int * JOFF )
+void PB_CVMcontig( PB_VM_T * VM, Int * NRPQ, Int * NCPQ, Int * IOFF,
+                   Int * JOFF )
 #else
 void PB_CVMcontig( VM, NRPQ, NCPQ, IOFF, JOFF )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IOFF, * JOFF, * NCPQ, * NRPQ;
+   Int            * IOFF, * JOFF, * NCPQ, * NRPQ;
    PB_VM_T        * VM;
 #endif
 {
@@ -74,7 +74,7 @@ void PB_CVMcontig( VM, NRPQ, NCPQ, IOFF, JOFF )
 /*
 *  .. Local Scalars ..
 */
-   int            ColCont=1, FirstD=0, GoSouth, GoEast, RowCont=1, ilow, imbloc,
+   Int            ColCont=1, FirstD=0, GoSouth, GoEast, RowCont=1, ilow, imbloc,
                   inbloc, iupp, lcmt, lcmtnn=0, lcmt00, lmbloc, lnbloc, low, mb,
                   mblks, mbloc, mcur=0, mcurd, md=0, nb, nblks, nbloc, ncur=0,
                   ncurd, nd=0, npq=0, pmb, qnb, tmp1, tmp2, upp;

--- a/PBLAS/SRC/PTOOLS/PB_CVMinit.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMinit.c
@@ -17,16 +17,16 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CVMinit( PB_VM_T * VM, int OFFD, int M, int N, int IMB1, int INB1,
-                 int MB, int NB, int MRROW, int MRCOL, int NPROW,
-                 int NPCOL, int LCMB )
+void PB_CVMinit( PB_VM_T * VM, Int OFFD, Int M, Int N, Int IMB1, Int INB1,
+                 Int MB, Int NB, Int MRROW, Int MRCOL, Int NPROW,
+                 Int NPCOL, Int LCMB )
 #else
 void PB_CVMinit( VM, OFFD, M, N, IMB1, INB1, MB, NB, MRROW, MRCOL, NPROW,
                  NPCOL, LCMB )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IMB1, INB1, LCMB, M, MB, MRCOL, MRROW, N, NB, NPCOL,
+   Int            IMB1, INB1, LCMB, M, MB, MRCOL, MRROW, N, NB, NPCOL,
                   NPROW, OFFD;
 /*
 *  .. Array Arguments ..
@@ -117,7 +117,7 @@ void PB_CVMinit( VM, OFFD, M, N, IMB1, INB1, MB, NB, MRROW, MRCOL, NPROW,
 /*
 *  .. Local Scalars ..
 */
-   int            tmp1;
+   Int            tmp1;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_CVMloc.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMloc.c
@@ -17,17 +17,17 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_CVMloc( PBTYP_T * TYPE, PB_VM_T * VM,
+Int PB_CVMloc( PBTYP_T * TYPE, PB_VM_T * VM,
                char * VROCS, char * ROCS, char * UNPA, char * TRANS,
-               int MN, int K, char * ALPHA, char * A, int LDA,
-               char * BETA,  char * B, int LDB )
+               Int MN, Int K, char * ALPHA, char * A, Int LDA,
+               char * BETA,  char * B, Int LDB )
 #else
-int PB_CVMloc( TYPE, VM, VROCS, ROCS, UNPA, TRANS, MN, K, ALPHA, A,
+Int PB_CVMloc( TYPE, VM, VROCS, ROCS, UNPA, TRANS, MN, K, ALPHA, A,
                LDA, BETA,  B, LDB )
 /*
 *  .. Scalar Arguments ..
 */
-   int            K, LDA, LDB, MN;
+   Int            K, LDA, LDB, MN;
    char           * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
@@ -136,7 +136,7 @@ int PB_CVMloc( TYPE, VM, VROCS, ROCS, UNPA, TRANS, MN, K, ALPHA, A,
 /*
 *  .. Local Scalars ..
 */
-   int            GoEast, GoSouth, ilow, imbloc, inbloc, inca, incb, iupp, kb,
+   Int            GoEast, GoSouth, ilow, imbloc, inbloc, inca, incb, iupp, kb,
                   lcmt, lcmt00, lmbloc, lnbloc, low, mb, mblkd, mblks, mbloc,
                   * m, * n, nb, nblkd, nblks, nbloc, notran, npcol, npq=0,
                   nprow, pmb, qnb, rows, size, tmp1, tmp2, upp;

--- a/PBLAS/SRC/PTOOLS/PB_CVMnpq.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMnpq.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_CVMnpq( PB_VM_T * VM )
+Int PB_CVMnpq( PB_VM_T * VM )
 #else
-int PB_CVMnpq( VM )
+Int PB_CVMnpq( VM )
 /*
 *  .. Array Arguments ..
 */
@@ -48,7 +48,7 @@ int PB_CVMnpq( VM )
 /*
 *  .. Local Scalars ..
 */
-   int            GoEast, GoSouth, Pmb, Qnb, gcdb, ilow, imbloc, inbloc, iupp,
+   Int            GoEast, GoSouth, Pmb, Qnb, gcdb, ilow, imbloc, inbloc, iupp,
                   kmax, kmin, k1, k2, k3, lcmb, lcmp, lcmq, lcmt, lcmt00,
                   lmbloc, lnbloc, low, l1, l2, l3, m, mb, mblkd, mblks, mbloc,
                   n, nb, nblkd, nblks, nbloc, nlcmblks, npcol, npq=0, nprow,

--- a/PBLAS/SRC/PTOOLS/PB_CVMpack.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMpack.c
@@ -17,17 +17,17 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_CVMpack( PBTYP_T * TYPE, PB_VM_T * VM, char * VROCS, char * ROCS,
-                char * UNPA, char * TRANS, int MN, int K,
-                char * ALPHA, char * A, int LDA,
-                char * BETA,  char * B, int LDB )
+Int PB_CVMpack( PBTYP_T * TYPE, PB_VM_T * VM, char * VROCS, char * ROCS,
+                char * UNPA, char * TRANS, Int MN, Int K,
+                char * ALPHA, char * A, Int LDA,
+                char * BETA,  char * B, Int LDB )
 #else
-int PB_CVMpack( TYPE, VM, VROCS, ROCS, UNPA, TRANS, MN, K, ALPHA, A,
+Int PB_CVMpack( TYPE, VM, VROCS, ROCS, UNPA, TRANS, MN, K, ALPHA, A,
                 LDA, BETA,  B, LDB )
 /*
 *  .. Scalar Arguments ..
 */
-   int            K, LDA, LDB, MN;
+   Int            K, LDA, LDB, MN;
    char           * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
@@ -133,7 +133,7 @@ int PB_CVMpack( TYPE, VM, VROCS, ROCS, UNPA, TRANS, MN, K, ALPHA, A,
 /*
 *  .. Local Scalars ..
 */
-   int            GoEast, GoSouth, ilow, imbloc, inbloc, inca, incb, iupp, kb,
+   Int            GoEast, GoSouth, ilow, imbloc, inbloc, inca, incb, iupp, kb,
                   lcmt, lcmt00, lmbloc, lnbloc, low, mb, mblkd, mblks, mbloc,
                   * m, * n, nb, nblkd, nblks, nbloc, notran, npcol, npq=0,
                   nprow, pmb, qnb, rows, size, tmp1, tmp2, upp;

--- a/PBLAS/SRC/PTOOLS/PB_CVMswp.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMswp.c
@@ -17,15 +17,15 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_CVMswp( PBTYP_T * TYPE, PB_VM_T * VM, char * VROCS, char * ROCS,
-               char * TRANS, int MN, char * X, int INCX, char * Y,
-               int INCY )
+Int PB_CVMswp( PBTYP_T * TYPE, PB_VM_T * VM, char * VROCS, char * ROCS,
+               char * TRANS, Int MN, char * X, Int INCX, char * Y,
+               Int INCY )
 #else
-int PB_CVMswp( TYPE, VM, VROCS, ROCS, TRANS, MN, X, INCX, Y, INCY )
+Int PB_CVMswp( TYPE, VM, VROCS, ROCS, TRANS, MN, X, INCX, Y, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            INCX, INCY, MN;
+   Int            INCX, INCY, MN;
 /*
 *  .. Array Arguments ..
 */
@@ -109,7 +109,7 @@ int PB_CVMswp( TYPE, VM, VROCS, ROCS, TRANS, MN, X, INCX, Y, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            GoEast, GoSouth, Xinc, Yinc, ilow, imbloc, inbloc, iupp, kb,
+   Int            GoEast, GoSouth, Xinc, Yinc, ilow, imbloc, inbloc, iupp, kb,
                   lcmt, lcmt00, lmbloc, lnbloc, low, mb, mblkd, mblks, mbloc,
                   nb, nblkd, nblks, nbloc, notran, npcol, npq=0, nprow, pmb,
                   qnb, rows, size, tmp1, tmp2, upp;

--- a/PBLAS/SRC/PTOOLS/PB_CVMupdate.c
+++ b/PBLAS/SRC/PTOOLS/PB_CVMupdate.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CVMupdate( PB_VM_T * VM, int K, int * II, int * JJ )
+void PB_CVMupdate( PB_VM_T * VM, Int K, Int * II, Int * JJ )
 #else
 void PB_CVMupdate( VM, K, II, JJ )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * II, * JJ, K;
+   Int            * II, * JJ, K;
    PB_VM_T        * VM;
 #endif
 {
@@ -67,7 +67,7 @@ void PB_CVMupdate( VM, K, II, JJ )
 /*
 *  .. Local Scalars ..
 */
-   int            GoEast, GoSouth, ilow, imbloc, inbloc, ioff, ioffd, iupp,
+   Int            GoEast, GoSouth, ilow, imbloc, inbloc, ioff, ioffd, iupp,
                   joff, joffd, lcmt, lcmt00, lmbloc, lnbloc, low, mb, mblkd,
                   mblks, mbloc, nb, nblkd, nblks, nbloc, npq=0, pmb, qnb,
                   tmp1, tmp2, upp;

--- a/PBLAS/SRC/PTOOLS/PB_Cabort.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cabort.c
@@ -58,13 +58,13 @@
 #endif
 
 #ifdef __STDC__
-void PB_Cabort( int ICTXT, char * ROUT, int INFO )
+void PB_Cabort( Int ICTXT, char * ROUT, Int INFO )
 #else
 void PB_Cabort( ICTXT, ROUT, INFO )
 /*
 *  .. Scalar Arguments ..
 */
-   int            ICTXT, INFO;
+   Int            ICTXT, INFO;
 /*
 *  .. Array Arguments ..
 */
@@ -107,15 +107,15 @@ void PB_Cabort( ICTXT, ROUT, INFO )
 /*
 *  .. Local Scalars ..
 */
-   int            mycol, myrow, npcol, nprow;
+   Int            mycol, myrow, npcol, nprow;
 /* ..
 *  .. External Functions ..
 */
 #ifdef TestingPblas
 #ifdef __STDC__
-   int            PB_NoAbort( int * );
+   Int            PB_NoAbort( Int * );
 #else
-   int            PB_NoAbort();
+   Int            PB_NoAbort();
 #endif
 #endif
 /* ..

--- a/PBLAS/SRC/PTOOLS/PB_Cainfog2l.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cainfog2l.c
@@ -17,23 +17,23 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cainfog2l( int M, int N, int I, int J, int * DESC, int NPROW,
-                   int NPCOL, int MYROW, int MYCOL, int * IMB1,
-                   int * INB1, int * MP, int * NQ, int * II, int * JJ,
-                   int * PROW, int * PCOL, int * RPROW, int * RPCOL )
+void PB_Cainfog2l( Int M, Int N, Int I, Int J, Int * DESC, Int NPROW,
+                   Int NPCOL, Int MYROW, Int MYCOL, Int * IMB1,
+                   Int * INB1, Int * MP, Int * NQ, Int * II, Int * JJ,
+                   Int * PROW, Int * PCOL, Int * RPROW, Int * RPCOL )
 #else
 void PB_Cainfog2l( M, N, I, J, DESC, NPROW, NPCOL, MYROW, MYCOL, IMB1,
                    INB1, MP, NQ, II, JJ, PROW, PCOL, RPROW, RPCOL )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, * II, * IMB1, * INB1, J, * JJ, M, * MP, MYCOL,
+   Int            I, * II, * IMB1, * INB1, J, * JJ, M, * MP, MYCOL,
                   MYROW, N, NPCOL, NPROW, * NQ, * PCOL, * PROW, * RPCOL,
                   * RPROW;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESC;
+   Int            * DESC;
 #endif
 {
 /*
@@ -217,7 +217,7 @@ void PB_Cainfog2l( M, N, I, J, DESC, NPROW, NPCOL, MYROW, MYCOL, IMB1,
 /*
 *  .. Local Scalars ..
 */
-   int            i1, ilocblk, j1, mb, mydist, nb, nblocks, csrc, rsrc;
+   Int            i1, ilocblk, j1, mb, mydist, nb, nblocks, csrc, rsrc;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_CargFtoC.c
+++ b/PBLAS/SRC/PTOOLS/PB_CargFtoC.c
@@ -17,18 +17,18 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CargFtoC( int IF, int JF, int * DESCIN, int * IC, int * JC,
-                    int * DESCOUT )
+void PB_CargFtoC( Int IF, Int JF, Int * DESCIN, Int * IC, Int * JC,
+                    Int * DESCOUT )
 #else
 void PB_CargFtoC( IF, JF, DESCIN, IC, JC, DESCOUT )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IF, JF, * IC, * JC;
+   Int            IF, JF, * IC, * JC;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCIN, * DESCOUT;
+   Int            * DESCIN, * DESCOUT;
 #endif
 {
 /*

--- a/PBLAS/SRC/PTOOLS/PB_Cbinfo.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cbinfo.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cbinfo( int OFFD, int M, int N, int IMB1, int INB1, int MB,
-                int NB, int MRROW, int MRCOL, int * LCMT00, int * MBLKS,
-                int * NBLKS, int * IMBLOC, int * INBLOC, int * LMBLOC,
-                int * LNBLOC, int * ILOW, int * LOW, int * IUPP, int * UPP )
+void PB_Cbinfo( Int OFFD, Int M, Int N, Int IMB1, Int INB1, Int MB,
+                Int NB, Int MRROW, Int MRCOL, Int * LCMT00, Int * MBLKS,
+                Int * NBLKS, Int * IMBLOC, Int * INBLOC, Int * LMBLOC,
+                Int * LNBLOC, Int * ILOW, Int * LOW, Int * IUPP, Int * UPP )
 #else
 void PB_Cbinfo( OFFD, M, N, IMB1, INB1, MB, NB, MRROW, MRCOL, LCMT00,
                 MBLKS, NBLKS, IMBLOC, INBLOC, LMBLOC, LNBLOC, ILOW, LOW,
@@ -28,7 +28,7 @@ void PB_Cbinfo( OFFD, M, N, IMB1, INB1, MB, NB, MRROW, MRCOL, LCMT00,
 /*
 *  .. Scalar Arguments ..
 */
-   int            * ILOW, IMB1, * IMBLOC, INB1, * INBLOC, * IUPP,
+   Int            * ILOW, IMB1, * IMBLOC, INB1, * INBLOC, * IUPP,
                   * LCMT00, * LMBLOC, * LNBLOC, * LOW, M, MB, * MBLKS,
                   MRCOL, MRROW, N, NB, * NBLKS, OFFD, * UPP;
 #endif
@@ -158,7 +158,7 @@ void PB_Cbinfo( OFFD, M, N, IMB1, INB1, MB, NB, MRROW, MRCOL, LCMT00,
 /*
 *  .. Local Scalars ..
 */
-   int            tmp1;
+   Int            tmp1;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cchkmat.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cchkmat.c
@@ -17,21 +17,21 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cchkmat( int ICTXT, char * ROUT, char * MNAME, int M, int MPOS0,
-                 int N, int NPOS0, int IA, int JA, int * DESCA, int DPOS0,
-                 int * INFO )
+void PB_Cchkmat( Int ICTXT, char * ROUT, char * MNAME, Int M, Int MPOS0,
+                 Int N, Int NPOS0, Int IA, Int JA, Int * DESCA, Int DPOS0,
+                 Int * INFO )
 #else
 void PB_Cchkmat( ICTXT, ROUT, MNAME, M, MPOS0, N, NPOS0, IA, JA, DESCA,
                  DPOS0, INFO )
 /*
 *  .. Scalar Arguments ..
 */
-   int            DPOS0, IA, ICTXT, * INFO, JA, M, MPOS0, N, NPOS0;
+   Int            DPOS0, IA, ICTXT, * INFO, JA, M, MPOS0, N, NPOS0;
 /*
 *  .. Array Arguments ..
 */
    char           * MNAME, * ROUT;
-   int            * DESCA;
+   Int            * DESCA;
 #endif
 {
 /*
@@ -108,7 +108,7 @@ void PB_Cchkmat( ICTXT, ROUT, MNAME, M, MPOS0, N, NPOS0, IA, JA, DESCA,
 /*
 *  .. Local Scalars ..
 */
-   int            dpos, iapos, japos, mpos, mycol, myrow, np, npcol, nprow,
+   Int            dpos, iapos, japos, mpos, mycol, myrow, np, npcol, nprow,
                   npos, nq;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cchkvec.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cchkvec.c
@@ -17,21 +17,21 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cchkvec( int ICTXT, char * ROUT, char * VNAME, int N, int NPOS0,
-                 int IX, int JX, int * DESCX, int INCX, int DPOS0,
-                 int * INFO )
+void PB_Cchkvec( Int ICTXT, char * ROUT, char * VNAME, Int N, Int NPOS0,
+                 Int IX, Int JX, Int * DESCX, Int INCX, Int DPOS0,
+                 Int * INFO )
 #else
 void PB_Cchkvec( ICTXT, ROUT, VNAME, N, NPOS0, IX, JX, DESCX, INCX,
                  DPOS0, INFO )
 /*
 *  .. Scalar Arguments ..
 */
-   int            DPOS0, ICTXT, IX, * INFO, INCX, JX, N, NPOS0;
+   Int            DPOS0, ICTXT, IX, * INFO, INCX, JX, N, NPOS0;
 /*
 *  .. Array Arguments ..
 */
    char           * ROUT, * VNAME;
-   int            * DESCX;
+   Int            * DESCX;
 #endif
 {
 /*
@@ -105,7 +105,7 @@ void PB_Cchkvec( ICTXT, ROUT, VNAME, N, NPOS0, IX, JX, DESCX, INCX,
 /*
 *  .. Local Scalars ..
 */
-   int            dpos, icpos, ixpos, jxpos, mycol, myrow, np, npcol, npos,
+   Int            dpos, icpos, ixpos, jxpos, mycol, myrow, np, npcol, npos,
                   nprow, nq;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cconjg.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cconjg.c
@@ -72,7 +72,7 @@ void PB_Cconjg( TYPE, ALPHA, CALPHA )
         ((double*)(CALPHA))[REAL_PART] =  ((double*)(ALPHA))[REAL_PART];
         break;
      case INT:
-        *((int*)(CALPHA))              = *((int*)(ALPHA));
+        *((Int*)(CALPHA))              = *((Int*)(ALPHA));
         break;
      default: ;
   }

--- a/PBLAS/SRC/PTOOLS/PB_Cctypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cctypeset.c
@@ -34,7 +34,7 @@ PBTYP_T * PB_Cctypeset()
 /*
 *  .. Local Scalars ..
 */
-   static int     setup=0;
+   static Int     setup=0;
    static PBTYP_T TypeStruct;
    static cmplx   zero, one, negone;
 /* ..

--- a/PBLAS/SRC/PTOOLS/PB_Cdescribe.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cdescribe.c
@@ -17,22 +17,22 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cdescribe( int M, int N, int IA, int JA, int * DA, int NPROW,
-                   int NPCOL, int MYROW, int MYCOL, int * II, int * JJ,
-                   int * LDA, int * IMB, int * INB, int * MB, int * NB,
-                   int * PROW, int * PCOL, int * DA0 )
+void PB_Cdescribe( Int M, Int N, Int IA, Int JA, Int * DA, Int NPROW,
+                   Int NPCOL, Int MYROW, Int MYCOL, Int * II, Int * JJ,
+                   Int * LDA, Int * IMB, Int * INB, Int * MB, Int * NB,
+                   Int * PROW, Int * PCOL, Int * DA0 )
 #else
 void PB_Cdescribe( M, N, IA, JA, DA, NPROW, NPCOL, MYROW, MYCOL, II, JJ,
                    LDA, IMB, INB, MB, NB, PROW, PCOL, DA0 )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IA, *II, * IMB, * INB, JA, * JJ, * LDA, M, * MB, MYCOL,
+   Int            IA, *II, * IMB, * INB, JA, * JJ, * LDA, M, * MB, MYCOL,
                   MYROW, N, * NB, NPCOL, NPROW, * PCOL, * PROW;
 /*
 *  .. Array Arguments ..
 */
-   int            * DA, * DA0;
+   Int            * DA, * DA0;
 #endif
 {
 /*

--- a/PBLAS/SRC/PTOOLS/PB_Cdescset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cdescset.c
@@ -17,18 +17,18 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cdescset( int * DESC, int M, int N, int IMB, int INB, int MB, int NB,
-                  int RSRC, int CSRC, int CTXT, int LLD )
+void PB_Cdescset( Int * DESC, Int M, Int N, Int IMB, Int INB, Int MB, Int NB,
+                  Int RSRC, Int CSRC, Int CTXT, Int LLD )
 #else
 void PB_Cdescset( DESC, M, N, IMB, INB, MB, NB, RSRC, CSRC, CTXT, LLD )
 /*
 *  .. Scalar Arguments ..
 */
-   int            CSRC, CTXT, IMB, INB, LLD, M, MB, N, NB, RSRC;
+   Int            CSRC, CTXT, IMB, INB, LLD, M, MB, N, NB, RSRC;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESC;
+   Int            * DESC;
 #endif
 {
 /*

--- a/PBLAS/SRC/PTOOLS/PB_Cdtypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cdtypeset.c
@@ -34,7 +34,7 @@ PBTYP_T * PB_Cdtypeset()
 /*
 *  .. Local Scalars ..
 */
-   static int     setup=0;
+   static Int     setup=0;
    static PBTYP_T TypeStruct;
    static double  zero, one, negone;
 /* ..

--- a/PBLAS/SRC/PTOOLS/PB_Cfirstnb.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cfirstnb.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cfirstnb( int N, int I, int INB, int NB )
+Int PB_Cfirstnb( Int N, Int I, Int INB, Int NB )
 #else
-int PB_Cfirstnb( N, I, INB, NB )
+Int PB_Cfirstnb( N, I, INB, NB )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, INB, N, NB;
+   Int            I, INB, N, NB;
 #endif
 {
 /*
@@ -61,7 +61,7 @@ int PB_Cfirstnb( N, I, INB, NB )
 /*
 *  .. Local Scalars ..
 */
-   int            inbt;
+   Int            inbt;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cg2lrem.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cg2lrem.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cg2lrem( int IG, int INB, int NB, int MYPROC, int SRCPROC, int NPROCS )
+Int PB_Cg2lrem( Int IG, Int INB, Int NB, Int MYPROC, Int SRCPROC, Int NPROCS )
 #else
-int PB_Cg2lrem( IG, INB, NB, MYPROC, SRCPROC, NPROCS )
+Int PB_Cg2lrem( IG, INB, NB, MYPROC, SRCPROC, NPROCS )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IG, INB, NB, NPROCS, MYPROC, SRCPROC;
+   Int            IG, INB, NB, NPROCS, MYPROC, SRCPROC;
 #endif
 {
 /*
@@ -73,7 +73,7 @@ int PB_Cg2lrem( IG, INB, NB, MYPROC, SRCPROC, NPROCS )
 /*
 *  .. Local Scalars ..
 */
-   int            ilocblk, mydist, nblocks, proc;
+   Int            ilocblk, mydist, nblocks, proc;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cgcd.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cgcd.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cgcd( int M, int N )
+Int PB_Cgcd( Int M, Int N )
 #else
-int PB_Cgcd( M, N )
+Int PB_Cgcd( M, N )
 /*
 *  .. Scalar Arguments ..
 */
-   int            M, N;
+   Int            M, N;
 #endif
 {
 /*
@@ -50,7 +50,7 @@ int PB_Cgcd( M, N )
 /*
 *  .. Local Scalars ..
 */
-   int            gcd=1, m_val, n_val, t;
+   Int            gcd=1, m_val, n_val, t;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cgetbuf.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cgetbuf.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-char * PB_Cgetbuf( char * MESS, int LENGTH )
+char * PB_Cgetbuf( char * MESS, Int LENGTH )
 #else
 char * PB_Cgetbuf( MESS, LENGTH )
 /*
 *  .. Scalar Arguments ..
 */
-   int            LENGTH;
+   Int            LENGTH;
 /*
 *  .. Array Arguments ..
 */
@@ -63,7 +63,7 @@ char * PB_Cgetbuf( MESS, LENGTH )
 *  .. Local Scalars ..
 */
    static char    * pblasbuf = NULL;
-   static int     pbbuflen = 0;
+   static Int     pbbuflen = 0;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cindxg2p.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cindxg2p.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cindxg2p( int IG, int INB, int NB, int PROC, int SRCPROC, int NPROCS )
+Int PB_Cindxg2p( Int IG, Int INB, Int NB, Int PROC, Int SRCPROC, Int NPROCS )
 #else
-int PB_Cindxg2p( IG, INB, NB, PROC, SRCPROC, NPROCS )
+Int PB_Cindxg2p( IG, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IG, INB, NB, NPROCS, PROC, SRCPROC;
+   Int            IG, INB, NB, NPROCS, PROC, SRCPROC;
 #endif
 {
 /*

--- a/PBLAS/SRC/PTOOLS/PB_Cinfog2l.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cinfog2l.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cinfog2l( int I, int J, int * DESC, int NPROW, int NPCOL,
-                  int MYROW, int MYCOL, int * II, int * JJ,
-                  int * PROW, int * PCOL )
+void PB_Cinfog2l( Int I, Int J, Int * DESC, Int NPROW, Int NPCOL,
+                  Int MYROW, Int MYCOL, Int * II, Int * JJ,
+                  Int * PROW, Int * PCOL )
 #else
 void PB_Cinfog2l( I, J, DESC, NPROW, NPCOL, MYROW, MYCOL, II, JJ,
                   PROW, PCOL )
-   int            I, * II, J, * JJ, MYCOL, MYROW, NPCOL, NPROW, * PCOL,
+   Int            I, * II, J, * JJ, MYCOL, MYROW, NPCOL, NPROW, * PCOL,
                   * PROW;
 /*
 *  .. Scalar Arguments ..
@@ -31,7 +31,7 @@ void PB_Cinfog2l( I, J, DESC, NPROW, NPCOL, MYROW, MYCOL, II, JJ,
 /*
 *  .. Array Arguments ..
 */
-   int            * DESC;
+   Int            * DESC;
 #endif
 {
 /*
@@ -169,7 +169,7 @@ void PB_Cinfog2l( I, J, DESC, NPROW, NPCOL, MYROW, MYCOL, II, JJ,
 /*
 *  .. Local Scalars ..
 */
-   int            ilocblk, imb, inb, mb, mydist, nb, nblocks, csrc, rsrc;
+   Int            ilocblk, imb, inb, mb, mydist, nb, nblocks, csrc, rsrc;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Citypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Citypeset.c
@@ -34,9 +34,9 @@ PBTYP_T * PB_Citypeset()
 /*
 *  .. Local Scalars ..
 */
-   static int     setup=0;
+   static Int     setup=0;
    static PBTYP_T TypeStruct;
-   static int     zero, one, negone;
+   static Int     zero, one, negone;
 /* ..
 *  .. Executable Statements ..
 *
@@ -46,8 +46,8 @@ PBTYP_T * PB_Citypeset()
    setup = 1;
 
    TypeStruct.type = INT;
-   TypeStruct.usiz = sizeof( int );
-   TypeStruct.size = sizeof( int );
+   TypeStruct.usiz = sizeof( Int );
+   TypeStruct.size = sizeof( Int );
    zero   =  0;
    one    =  1;
    negone = -1;

--- a/PBLAS/SRC/PTOOLS/PB_Clastnb.c
+++ b/PBLAS/SRC/PTOOLS/PB_Clastnb.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Clastnb( int N, int I, int INB, int NB )
+Int PB_Clastnb( Int N, Int I, Int INB, Int NB )
 #else
-int PB_Clastnb( N, I, INB, NB )
+Int PB_Clastnb( N, I, INB, NB )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, INB, N, NB;
+   Int            I, INB, N, NB;
 #endif
 {
 /*
@@ -61,7 +61,7 @@ int PB_Clastnb( N, I, INB, NB )
 /*
 *  .. Local Scalars ..
 */
-   int            lnbt;
+   Int            lnbt;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Clcm.c
+++ b/PBLAS/SRC/PTOOLS/PB_Clcm.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Clcm( int M, int N )
+Int PB_Clcm( Int M, Int N )
 #else
-int PB_Clcm( M, N )
+Int PB_Clcm( M, N )
 /*
 *  .. Scalar Arguments ..
 */
-   int            M, N;
+   Int            M, N;
 #endif
 {
 /*
@@ -51,7 +51,7 @@ int PB_Clcm( M, N )
 /*
 *  .. Local Scalars ..
 */
-   int            gcd=1, m_val, n_val, t;
+   Int            gcd=1, m_val, n_val, t;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cmalloc.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cmalloc.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-char * PB_Cmalloc( int LENGTH )
+char * PB_Cmalloc( Int LENGTH )
 #else
 char * PB_Cmalloc( LENGTH )
 /*
 *  .. Scalar Arguments ..
 */
-   int            LENGTH;
+   Int            LENGTH;
 #endif
 {
 /*

--- a/PBLAS/SRC/PTOOLS/PB_Cnnxtroc.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cnnxtroc.c
@@ -17,14 +17,14 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cnnxtroc( int N, int I, int INB, int NB, int PROC, int SRCPROC,
-                 int NPROCS )
+Int PB_Cnnxtroc( Int N, Int I, Int INB, Int NB, Int PROC, Int SRCPROC,
+                 Int NPROCS )
 #else
-int PB_Cnnxtroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
+Int PB_Cnnxtroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, INB, N, NB, NPROCS, PROC, SRCPROC;
+   Int            I, INB, N, NB, NPROCS, PROC, SRCPROC;
 #endif
 {
 /*
@@ -88,7 +88,7 @@ int PB_Cnnxtroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Local Scalars ..
 */
-   int            ilocblk, mydist, nblocks;
+   Int            ilocblk, mydist, nblocks;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cnpreroc.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cnpreroc.c
@@ -17,14 +17,14 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cnpreroc( int N, int I, int INB, int NB, int PROC, int SRCPROC,
-                 int NPROCS )
+Int PB_Cnpreroc( Int N, Int I, Int INB, Int NB, Int PROC, Int SRCPROC,
+                 Int NPROCS )
 #else
-int PB_Cnpreroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
+Int PB_Cnpreroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, INB, N, NB, NPROCS, PROC, SRCPROC;
+   Int            I, INB, N, NB, NPROCS, PROC, SRCPROC;
 #endif
 {
 /*
@@ -83,7 +83,7 @@ int PB_Cnpreroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Local Scalars ..
 */
-   int            ilocblk, mydist, nblocks;
+   Int            ilocblk, mydist, nblocks;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cnumroc.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cnumroc.c
@@ -17,14 +17,14 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cnumroc( int N, int I, int INB, int NB, int PROC, int SRCPROC,
-                int NPROCS )
+Int PB_Cnumroc( Int N, Int I, Int INB, Int NB, Int PROC, Int SRCPROC,
+                Int NPROCS )
 #else
-int PB_Cnumroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
+Int PB_Cnumroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, INB, N, NB, NPROCS, PROC, SRCPROC;
+   Int            I, INB, N, NB, NPROCS, PROC, SRCPROC;
 #endif
 {
 /*
@@ -79,7 +79,7 @@ int PB_Cnumroc( N, I, INB, NB, PROC, SRCPROC, NPROCS )
 /*
 *  .. Local Scalars ..
 */
-   int            ilocblk, mydist, nblocks;
+   Int            ilocblk, mydist, nblocks;
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cpaxpby.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpaxpby.c
@@ -17,11 +17,11 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cpaxpby( PBTYP_T * TYPE, char * CONJUG, int M, int N,
+void PB_Cpaxpby( PBTYP_T * TYPE, char * CONJUG, Int M, Int N,
                  char * ALPHA,
-                 char * A, int IA, int JA, int * DESCA, char * AROC,
+                 char * A, Int IA, Int JA, Int * DESCA, char * AROC,
                  char * BETA,
-                 char * B, int IB, int JB, int * DESCB, char * BROC )
+                 char * B, Int IB, Int JB, Int * DESCB, char * BROC )
 #else
 void PB_Cpaxpby( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
                 BETA, B, IB, JB, DESCB, BROC )
@@ -29,13 +29,13 @@ void PB_Cpaxpby( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Scalar Arguments ..
 */
    char           * AROC, * BROC, * CONJUG;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -214,7 +214,7 @@ void PB_Cpaxpby( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Local Scalars ..
 */
    char           ascope, bscope, * buf = NULL, * one, * top, tran, * zero;
-   int            Acol, Aii, AinbD, Ainb1D, AisD, AisR, AisRow, AiD, Ajj, Ald,
+   Int            Acol, Aii, AinbD, Ainb1D, AisD, AisR, AisRow, AiD, Ajj, Ald,
                   AmyprocD, AmyprocR, AnbD, AnD, AnR, AnpD, AnprocsD, AnprocsR,
                   AprocD, AprocR, Aroc, Arow, Bcol, Bii, BinbD, Binb1D, BisD,
                   BisR, BisRow, BiD, Bjj, Bld, BmyprocD, BmyprocR, BnbD, BnD,

--- a/PBLAS/SRC/PTOOLS/PB_CpaxpbyDN.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpaxpbyDN.c
@@ -17,11 +17,11 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpaxpbyDN( PBTYP_T * TYPE, char * CONJUG, int M, int N,
+void PB_CpaxpbyDN( PBTYP_T * TYPE, char * CONJUG, Int M, Int N,
                    char * ALPHA,
-                   char * A, int IA, int JA, int * DESCA, char * AROC,
+                   char * A, Int IA, Int JA, Int * DESCA, char * AROC,
                    char * BETA,
-                   char * B, int IB, int JB, int * DESCB, char * BROC )
+                   char * B, Int IB, Int JB, Int * DESCB, char * BROC )
 #else
 void PB_CpaxpbyDN( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
                    BETA, B, IB, JB, DESCB, BROC )
@@ -29,13 +29,13 @@ void PB_CpaxpbyDN( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Scalar Arguments ..
 */
    char           * AROC, * BROC, * CONJUG;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -216,7 +216,7 @@ void PB_CpaxpbyDN( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Local Scalars ..
 */
    char           scope, * top, * zero;
-   int            Acol, Aii, Ainb1D, AisR, AisRow, Ajj, Ald, AmyprocD, AmyprocR,
+   Int            Acol, Aii, Ainb1D, AisR, AisRow, Ajj, Ald, AmyprocD, AmyprocR,
                   AnD, AnbD, AnpD, AnprocsD, AprocD, AprocR, Aroc, Arow, Bcol,
                   Bii, BisR, BisRow, Bjj, Bld, Bm, BmyprocD, BmyprocR, Bn,
                   BnprocsD, BprocR, Broc, Brow, RRorCC, ctxt, izero=0, k, kbb,

--- a/PBLAS/SRC/PTOOLS/PB_CpaxpbyND.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpaxpbyND.c
@@ -17,11 +17,11 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpaxpbyND( PBTYP_T * TYPE, char * CONJUG, int M, int N,
+void PB_CpaxpbyND( PBTYP_T * TYPE, char * CONJUG, Int M, Int N,
                    char * ALPHA,
-                   char * A, int IA, int JA, int * DESCA, char * AROC,
+                   char * A, Int IA, Int JA, Int * DESCA, char * AROC,
                    char * BETA,
-                   char * B, int IB, int JB, int * DESCB, char * BROC )
+                   char * B, Int IB, Int JB, Int * DESCB, char * BROC )
 #else
 void PB_CpaxpbyND( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
                    BETA, B, IB, JB, DESCB, BROC )
@@ -29,13 +29,13 @@ void PB_CpaxpbyND( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Scalar Arguments ..
 */
    char           * AROC, * BROC, * CONJUG;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -216,7 +216,7 @@ void PB_CpaxpbyND( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Local Scalars ..
 */
    char           * one, * top, * zero;
-   int            Acol, Aii, AisR, AisRow, Ajj, Ald, AmyprocD, AmyprocR,
+   Int            Acol, Aii, AisR, AisRow, Ajj, Ald, AmyprocD, AmyprocR,
                   AnprocsD, AprocR, Aroc, Arow, Bcol, Bii, Binb1D, BisR, BisRow,
                   Bjj, Bld, BmyprocD, BmyprocR, BnD, BnbD, BnpD, BnprocsD,
                   BprocD,  BprocR, Broc, Brow, RRorCC, ctxt, k, kbb, kk, kn,

--- a/PBLAS/SRC/PTOOLS/PB_CpaxpbyNN.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpaxpbyNN.c
@@ -17,11 +17,11 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpaxpbyNN( PBTYP_T * TYPE, char * CONJUG, int M, int N,
+void PB_CpaxpbyNN( PBTYP_T * TYPE, char * CONJUG, Int M, Int N,
                    char * ALPHA,
-                   char * A, int IA, int JA, int * DESCA, char * AROC,
+                   char * A, Int IA, Int JA, Int * DESCA, char * AROC,
                    char * BETA,
-                   char * B, int IB, int JB, int * DESCB, char * BROC )
+                   char * B, Int IB, Int JB, Int * DESCB, char * BROC )
 #else
 void PB_CpaxpbyNN( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
                    BETA, B, IB, JB, DESCB, BROC )
@@ -29,13 +29,13 @@ void PB_CpaxpbyNN( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Scalar Arguments ..
 */
    char           * AROC, * BROC, * CONJUG;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -214,7 +214,7 @@ void PB_CpaxpbyNN( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, AROC,
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            Acol, Aii, AisR, AisRow, Ajj, Ald, AmyprocD, AmyprocR,
+   Int            Acol, Aii, AisR, AisRow, Ajj, Ald, AmyprocD, AmyprocR,
                   AnprocsD, AnprocsR, AprocR, Arow, Bcol, Bii, BisR, BisRow,
                   Bjj, Bld, BmyprocD, BmyprocR, BnprocsD, BnprocsR, BprocR,
                   Brow, RRorCC, csrc, ctxt, iroca, mycol, myrow, npcol, nprow,

--- a/PBLAS/SRC/PTOOLS/PB_Cpdot11.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpdot11.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cpdot11( PBTYP_T * TYPE, int N, char * DOT,
-                 char * X, int IX, int JX, int * DESCX, int INCX,
-                 char * Y, int IY, int JY, int * DESCY, int INCY,
+void PB_Cpdot11( PBTYP_T * TYPE, Int N, char * DOT,
+                 char * X, Int IX, Int JX, Int * DESCX, Int INCX,
+                 char * Y, Int IY, Int JY, Int * DESCY, Int INCY,
                  VVDOT_T FDOT )
 #else
 void PB_Cpdot11( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
@@ -27,14 +27,14 @@ void PB_Cpdot11( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Scalar Arguments ..
 */
-   int            INCX, INCY, IX, IY, JX, JY, N;
+   Int            INCX, INCY, IX, IY, JX, JY, N;
    char           * DOT;
    PBTYP_T        * TYPE;
    VVDOT_T        FDOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    char           * X, * Y;
 #endif
 {
@@ -219,7 +219,7 @@ void PB_Cpdot11( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * top;
-   int            RRorCC, Xcol, Xii, XisD, XisOne, XisR, XisRow, Xjj, Xld,
+   Int            RRorCC, Xcol, Xii, XisD, XisOne, XisR, XisRow, Xjj, Xld,
                   Xlinc, XmyprocD, XmyprocR, XprocD, XprocR, Xrow, Ycol, Yii,
                   YisD, YisOne, YisR, YisRow, Yjj, YmyprocD, YmyprocR, YprocD,
                   YprocR, Yrow, cdst, ctxt, ione=1, mycol, myrow, npcol, nprow,
@@ -227,7 +227,7 @@ void PB_Cpdot11( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Arrays ..
 */
-   int            dbuf[DLEN_];
+   Int            dbuf[DLEN_];
    char           * buf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_CpdotND.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpdotND.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpdotND( PBTYP_T * TYPE, int N, char * DOT,
-                 char * X, int IX, int JX, int * DESCX, int INCX,
-                 char * Y, int IY, int JY, int * DESCY, int INCY,
+void PB_CpdotND( PBTYP_T * TYPE, Int N, char * DOT,
+                 char * X, Int IX, Int JX, Int * DESCX, Int INCX,
+                 char * Y, Int IY, Int JY, Int * DESCY, Int INCY,
                  VVDOT_T FDOT )
 #else
 void PB_CpdotND( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
@@ -27,14 +27,14 @@ void PB_CpdotND( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Scalar Arguments ..
 */
-   int            INCX, INCY, IX, IY, JX, JY, N;
+   Int            INCX, INCY, IX, IY, JX, JY, N;
    char           * DOT;
    PBTYP_T        * TYPE;
    VVDOT_T        FDOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    char           * X, * Y;
 #endif
 {
@@ -220,7 +220,7 @@ void PB_CpdotND( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 *  .. Local Scalars ..
 */
    char           * top;
-   int            RRorCC, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc, XmyprocD,
+   Int            RRorCC, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnprocsD, XnprocsR, XprocR, Xroc, Xrow, Ycol, Yii,
                   Yinb1D, YisR, YisRow, Yjj, Yld, Ylinc, YmyprocD, YmyprocR,
                   YnbD, YnpD, YnprocsD, YnprocsR, YprocD, YprocR, Yroc, Yrow,

--- a/PBLAS/SRC/PTOOLS/PB_CpdotNN.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpdotNN.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpdotNN( PBTYP_T * TYPE, int N, char * DOT,
-                 char * X, int IX, int JX, int * DESCX, int INCX,
-                 char * Y, int IY, int JY, int * DESCY, int INCY,
+void PB_CpdotNN( PBTYP_T * TYPE, Int N, char * DOT,
+                 char * X, Int IX, Int JX, Int * DESCX, Int INCX,
+                 char * Y, Int IY, Int JY, Int * DESCY, Int INCY,
                  VVDOT_T FDOT )
 #else
 void PB_CpdotNN( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
@@ -27,14 +27,14 @@ void PB_CpdotNN( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Scalar Arguments ..
 */
-   int            INCX, INCY, IX, IY, JX, JY, N;
+   Int            INCX, INCY, IX, IY, JX, JY, N;
    char           * DOT;
    PBTYP_T        * TYPE;
    VVDOT_T        FDOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    char           * X, * Y;
 #endif
 {
@@ -219,7 +219,7 @@ void PB_CpdotNN( TYPE, N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * top;
-   int            RRorCC, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc, XmyprocD,
+   Int            RRorCC, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnprocsR, XprocR, Xrow, Ycol, Yii, YisR, YisRow,
                   Yjj, Yld, Ylinc, YmyprocD, YmyprocR, YnprocsR, YprocR, Yrow,
                   csrc, ctxt, ione=1, mycol, myrow, npcol, nprow, rsrc, size;

--- a/PBLAS/SRC/PTOOLS/PB_Cpgeadd.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpgeadd.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_Cpgeadd( PBTYP_T * TYPE, char * DIRECA, char * DIRECC,
-                 char * CONJUG, int M, int N, char * ALPHA, char * A,
-                 int IA, int JA, int * DESCA, char * BETA,  char * C,
-                 int IC, int JC, int * DESCC )
+                 char * CONJUG, Int M, Int N, char * ALPHA, char * A,
+                 Int IA, Int JA, Int * DESCA, char * BETA,  char * C,
+                 Int IC, Int JC, Int * DESCC )
 #else
 void PB_Cpgeadd( TYPE, DIRECA, DIRECC, CONJUG, M, N, ALPHA, A, IA, JA,
                  DESCA, BETA, C, IC, JC, DESCC )
@@ -28,13 +28,13 @@ void PB_Cpgeadd( TYPE, DIRECA, DIRECC, CONJUG, M, N, ALPHA, A, IA, JA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECA, * DIRECC;
-   int            IA, IC, JA, JC, M, N;
+   Int            IA, IC, JA, JC, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    char           * A, * C;
 #endif
 {
@@ -214,7 +214,7 @@ void PB_Cpgeadd( TYPE, DIRECA, DIRECC, CONJUG, M, N, ALPHA, A, IA, JA,
 *  .. Local Scalars ..
 */
    char           ACroc, * one, * talpha, * tbeta, * zero;
-   int            ACmyprocD, ACmyprocR, ACnD, ACnR, ACnprocsD, ACnprocsR,
+   Int            ACmyprocD, ACmyprocR, ACnD, ACnR, ACnprocsD, ACnprocsR,
                   Abufld, AcurrocR, Afr, Afwd, AiD, AiR, AiiD, AiiR, AinbD,
                   AinbR, Ainb1D, Ainb1R, AisR, Akk, Ald, AnbD, AnbR, AnpD,
                   AnpR, Aoff, ArocD, ArocR, AsrcR, Cbufld, CcurrocR, Cfr,
@@ -227,7 +227,7 @@ void PB_Cpgeadd( TYPE, DIRECA, DIRECC, CONJUG, M, N, ALPHA, A, IA, JA,
 /*
 *  .. Local Arrays ..
 */
-   int            DBUFA[DLEN_], DBUFC[DLEN_];
+   Int            DBUFA[DLEN_], DBUFC[DLEN_];
    char           * Abuf = NULL, * Cbuf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_CpgemmAB.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpgemmAB.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_CpgemmAB( PBTYP_T * TYPE, char * DIRECA, char * DIRECB,
-                  char * TRANSA, char * TRANSB, int M, int N, int K,
-                  char * ALPHA, char * A, int IA, int JA, int * DESCA,
-                  char * B, int IB, int JB, int * DESCB, char * BETA,
-                  char * C, int IC, int JC, int * DESCC )
+                  char * TRANSA, char * TRANSB, Int M, Int N, Int K,
+                  char * ALPHA, char * A, Int IA, Int JA, Int * DESCA,
+                  char * B, Int IB, Int JB, Int * DESCB, char * BETA,
+                  char * C, Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpgemmAB( TYPE, DIRECA, DIRECB, TRANSA, TRANSB, M, N, K, ALPHA,
                   A, IA, JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC,
@@ -30,13 +30,13 @@ void PB_CpgemmAB( TYPE, DIRECA, DIRECB, TRANSA, TRANSB, M, N, K, ALPHA,
 *  .. Scalar Arguments ..
 */
    char           * DIRECA, * DIRECB, * TRANSA, * TRANSB;
-   int            IA, IB, IC, JA, JB, JC, K, M, N;
+   Int            IA, IB, IC, JA, JB, JC, K, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -259,7 +259,7 @@ void PB_CpgemmAB( TYPE, DIRECA, DIRECB, TRANSA, TRANSB, M, N, K, ALPHA,
 *  .. Local Scalars ..
 */
    char           Aroc, Broc, TrA, TrB, * one, * tbeta, * zero;
-   int            ABrocs, Abufld, AcurrocR, Afr, Afwd, AiD, AiR, AiiD, AiiR,
+   Int            ABrocs, Abufld, AcurrocR, Afr, Afwd, AiD, AiR, AiiD, AiiR,
                   AinbD, AinbR, Ainb1D, Ainb1R, AisR, AkkR, Ald, AmyprocD,
                   AmyprocR, AnbD, AnbR, AnpD, AnpR, AnprocsD, AnprocsR, Aoff,
                   ArocD, ArocR, AsrcR, Bbufld, BcurrocR, Bfr, Bfwd, BiD, BiR,
@@ -275,7 +275,7 @@ void PB_CpgemmAB( TYPE, DIRECA, DIRECB, TRANSA, TRANSB, M, N, K, ALPHA,
 *  .. Local Arrays ..
 */
    PB_VM_T        VM;
-   int            Cd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WAd0[DLEN_],
+   Int            Cd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WAd0[DLEN_],
                   WBd0[DLEN_];
    char           * Abuf = NULL, * Bbuf = NULL, * Cptr = NULL, * WA = NULL,
                   * WB   = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_CpgemmAC.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpgemmAC.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_CpgemmAC( PBTYP_T * TYPE, char * DIRECA, char * DIRECC,
-                  char * TRANSA, char * TRANSB, int M, int N, int K,
-                  char * ALPHA, char * A, int IA, int JA, int * DESCA,
-                  char * B, int IB, int JB, int * DESCB, char * BETA,
-                  char * C, int IC, int JC, int * DESCC )
+                  char * TRANSA, char * TRANSB, Int M, Int N, Int K,
+                  char * ALPHA, char * A, Int IA, Int JA, Int * DESCA,
+                  char * B, Int IB, Int JB, Int * DESCB, char * BETA,
+                  char * C, Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpgemmAC( TYPE, DIRECA, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
                   A, IA, JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC,
@@ -30,13 +30,13 @@ void PB_CpgemmAC( TYPE, DIRECA, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
 *  .. Scalar Arguments ..
 */
    char           * DIRECA, * DIRECC, * TRANSA, * TRANSB;
-   int            IA, IB, IC, JA, JB, JC, K, M, N;
+   Int            IA, IB, IC, JA, JB, JC, K, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -259,7 +259,7 @@ void PB_CpgemmAC( TYPE, DIRECA, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
 */
    char           Aroc, GemmTa, GemmTb, TrA, TrB, * one, * talpha, * tbeta,
                   top, * zero;
-   int            Abufld, AcurrocR, Afr, Afwd, AiD, AiR, AiiD, AiiR, AinbD,
+   Int            Abufld, AcurrocR, Afr, Afwd, AiD, AiR, AiiD, AiiR, AinbD,
                   AinbR, Ainb1D, Ainb1R, AisR, Akk, Ald, AmyprocD, AmyprocR,
                   AnbD, AnbR, AnpD, AnpR, AnprocsD, AnprocsR, Aoff, ArocD,
                   ArocR, AsrcR, Asrc_, Bcol, Bii, Bimb1, Binb1, Bjj, Bld, Bm,
@@ -275,7 +275,7 @@ void PB_CpgemmAC( TYPE, DIRECA, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
 *  .. Local Arrays ..
 */
    PB_VM_T        VM;
-   int            Bd0[DLEN_], DBUFA[DLEN_], DBUFC[DLEN_], WAd[DLEN_],
+   Int            Bd0[DLEN_], DBUFA[DLEN_], DBUFC[DLEN_], WAd[DLEN_],
                   WCd[DLEN_];
    char           * Abuf = NULL, * Bptr = NULL, * Cbuf = NULL, * WA = NULL,
                   * WC   = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_CpgemmBC.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpgemmBC.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_CpgemmBC( PBTYP_T * TYPE, char * DIRECB, char * DIRECC,
-                  char * TRANSA, char * TRANSB, int M, int N, int K,
-                  char * ALPHA, char * A, int IA, int JA, int * DESCA,
-                  char * B, int IB, int JB, int * DESCB, char * BETA,
-                  char * C, int IC, int JC, int * DESCC )
+                  char * TRANSA, char * TRANSB, Int M, Int N, Int K,
+                  char * ALPHA, char * A, Int IA, Int JA, Int * DESCA,
+                  char * B, Int IB, Int JB, Int * DESCB, char * BETA,
+                  char * C, Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpgemmBC( TYPE, DIRECB, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
                   A, IA, JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC,
@@ -30,13 +30,13 @@ void PB_CpgemmBC( TYPE, DIRECB, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
 *  .. Scalar Arguments ..
 */
    char           * DIRECB, * DIRECC, * TRANSA, * TRANSB;
-   int            IA, IB, IC, JA, JB, JC, K, M, N;
+   Int            IA, IB, IC, JA, JB, JC, K, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -259,7 +259,7 @@ void PB_CpgemmBC( TYPE, DIRECB, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
 */
    char           Broc, GemmTa, GemmTb, TrA, TrB, * one, * talpha, * tbeta,
                   top, * zero;
-   int            Acol, Aii, Aimb1, Ainb1, Ajj, Ald, Am, Amb, Amp, An, Anb,
+   Int            Acol, Aii, Aimb1, Ainb1, Ajj, Ald, Am, Amb, Amp, An, Anb,
                   Anq, Arow, Bbufld, BcurrocR, Bfr, Bfwd, BiD, BiR, BiiD, BiiR,
                   BinbD, BinbR, Binb1D, Binb1R, BisR, Bkk, Bld, BmyprocD,
                   BmyprocR, BnbD, BnbR, BnpD, BnpR, BnprocsD, BnprocsR, Boff,
@@ -273,7 +273,7 @@ void PB_CpgemmBC( TYPE, DIRECB, DIRECC, TRANSA, TRANSB, M, N, K, ALPHA,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_], DBUFB[DLEN_], DBUFC[DLEN_], WBd[DLEN_],
+   Int            Ad0[DLEN_], DBUFB[DLEN_], DBUFC[DLEN_], WBd[DLEN_],
                   WCd[DLEN_];
    PB_VM_T        VM;
    char           * Aptr = NULL, * Bbuf = NULL, * Cbuf = NULL, * WB   = NULL,

--- a/PBLAS/SRC/PTOOLS/PB_Cplacnjg.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cplacnjg.c
@@ -17,20 +17,20 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cplacnjg( PBTYP_T * TYPE, int M, int N, char * ALPHA, char * A,
-                  int IA, int JA, int * DESCA )
+void PB_Cplacnjg( PBTYP_T * TYPE, Int M, Int N, char * ALPHA, char * A,
+                  Int IA, Int JA, Int * DESCA )
 #else
 void PB_Cplacnjg( TYPE, M, N, ALPHA, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IA, JA, M, N;
+   Int            IA, JA, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A;
 #endif
 {
@@ -151,12 +151,12 @@ void PB_Cplacnjg( TYPE, M, N, ALPHA, A, IA, JA, DESCA )
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amb, Amp, Anb, Anq,
+   Int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amb, Amp, Anb, Anq,
                   izero=0, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_];
+   Int            Ad0[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/PTOOLS/PB_Cplapad.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cplapad.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cplapad( PBTYP_T * TYPE, char * UPLO, char * CONJUG, int M,
-                 int N, char * ALPHA, char * BETA, char * A, int IA,
-                 int JA, int * DESCA )
+void PB_Cplapad( PBTYP_T * TYPE, char * UPLO, char * CONJUG, Int M,
+                 Int N, char * ALPHA, char * BETA, char * A, Int IA,
+                 Int JA, Int * DESCA )
 #else
 void PB_Cplapad( TYPE, UPLO, CONJUG, M, N, ALPHA, BETA, A, IA, JA,
                  DESCA )
@@ -27,13 +27,13 @@ void PB_Cplapad( TYPE, UPLO, CONJUG, M, N, ALPHA, BETA, A, IA, JA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * UPLO;
-   int            IA, JA, M, N;
+   Int            IA, JA, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A;
 #endif
 {
@@ -180,14 +180,14 @@ void PB_Cplapad( TYPE, UPLO, CONJUG, M, N, ALPHA, BETA, A, IA, JA,
 *  .. Local Scalars ..
 */
    char           type;
-   int            Acol, Aii, Aimb1, Ainb1, Ajj, Akp, Akq, Ald, Amb, Amp, Amp0,
+   Int            Acol, Aii, Aimb1, Ainb1, Ajj, Akp, Akq, Ald, Amb, Amp, Amp0,
                   Anb, Anq, Anq0, Arow, ctxt, izero=0, k, kb, ktmp, mn, mycol,
                   myrow, nb, npcol, nprow, size;
    TZPAD_T        pad;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_];
+   Int            Ad0[DLEN_];
    char           * Aptr = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cplapd2.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cplapd2.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cplapd2( PBTYP_T * TYPE, char * UPLO, char * CONJUG, int M,
-                 int N, char * ALPHA, char * BETA, char * A, int IA,
-                 int JA, int * DESCA )
+void PB_Cplapd2( PBTYP_T * TYPE, char * UPLO, char * CONJUG, Int M,
+                 Int N, char * ALPHA, char * BETA, char * A, Int IA,
+                 Int JA, Int * DESCA )
 #else
 void PB_Cplapd2( TYPE, UPLO, CONJUG, M, N, ALPHA, BETA, A, IA, JA,
                  DESCA )
@@ -27,13 +27,13 @@ void PB_Cplapd2( TYPE, UPLO, CONJUG, M, N, ALPHA, BETA, A, IA, JA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * UPLO;
-   int            IA, JA, M, N;
+   Int            IA, JA, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A;
 #endif
 {
@@ -41,7 +41,7 @@ void PB_Cplapd2( TYPE, UPLO, CONJUG, M, N, ALPHA, BETA, A, IA, JA,
 *  .. Local Scalars ..
 */
    char           UploA, herm;
-   int            Acol, Aii, Aimb1, Ainb1, Aoffi, Ajj, Ald, Amb, Amp, Anb, Anq,
+   Int            Acol, Aii, Aimb1, Ainb1, Aoffi, Ajj, Ald, Amb, Amp, Anb, Anq,
                   Aoffj, Arcol, Arow, Arrow, GoEast, GoSouth, iimax, ilow,
                   imbloc, inbloc, ioffd, iupp, izero=0, jjmax, joffd, lcmt,
                   lcmt00, lmbloc, lnbloc, low, lower, m1, mbloc, mblkd, mblks,

--- a/PBLAS/SRC/PTOOLS/PB_Cplaprnt.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cplaprnt.c
@@ -17,20 +17,20 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cplaprnt( PBTYP_T * TYPE, int M, int N,
-                  char * A, int IA, int JA, int * DESCA,
-                  int IRPRNT, int ICPRNT, char * CMATNM )
+void PB_Cplaprnt( PBTYP_T * TYPE, Int M, Int N,
+                  char * A, Int IA, Int JA, Int * DESCA,
+                  Int IRPRNT, Int ICPRNT, char * CMATNM )
 #else
 void PB_Cplaprnt( TYPE, M, N, A, IA, JA, DESCA, IRPRNT, ICPRNT, CMATNM )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IA, ICPRNT, IRPRNT, JA, M, N;
+   Int            IA, ICPRNT, IRPRNT, JA, M, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * CMATNM;
 #endif
 {
@@ -156,7 +156,7 @@ void PB_Cplaprnt( TYPE, M, N, A, IA, JA, DESCA, IRPRNT, ICPRNT, CMATNM )
 /*
 *  .. Local Scalars ..
 */
-   int            mycol, myrow, npcol, nprow, pcol, prow;
+   Int            mycol, myrow, npcol, nprow, pcol, prow;
 /* ..
 *  .. Executable Statements ..
 *
@@ -239,21 +239,21 @@ void PB_Cplaprnt( TYPE, M, N, A, IA, JA, DESCA, IRPRNT, ICPRNT, CMATNM )
 }
 
 #ifdef __STDC__
-void PB_Cplaprn2( PBTYP_T * TYPE, int M, int N, char * A, int IA,
-                  int JA, int * DESCA, int IRPRNT, int ICPRNT,
-                  char * CMATNM, int PROW, int PCOL )
+void PB_Cplaprn2( PBTYP_T * TYPE, Int M, Int N, char * A, Int IA,
+                  Int JA, Int * DESCA, Int IRPRNT, Int ICPRNT,
+                  char * CMATNM, Int PROW, Int PCOL )
 #else
 void PB_Cplaprn2( TYPE, M, N, A, IA, JA, DESCA, IRPRNT, ICPRNT, CMATNM,
                   PROW, PCOL )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IA, ICPRNT, IRPRNT, JA, M, N, PCOL, PROW;
+   Int            IA, ICPRNT, IRPRNT, JA, M, N, PCOL, PROW;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * CMATNM;
 #endif
 {
@@ -261,7 +261,7 @@ void PB_Cplaprn2( TYPE, M, N, A, IA, JA, DESCA, IRPRNT, ICPRNT, CMATNM,
 *  .. Local Scalars ..
 */
    char           type;
-   int            Acol, Aii, AisColRep, AisRowRep, Ajj, Ald, Arow, ctxt, h, i,
+   Int            Acol, Aii, AisColRep, AisRowRep, Ajj, Ald, Arow, ctxt, h, i,
                   ib, icurcol, icurrow, ii, in, j, jb, jj, jn, ldw, mycol,
                   myrow, npcol, nprow, size, usiz;
 /*
@@ -491,14 +491,14 @@ void PB_Cplaprn2( TYPE, M, N, A, IA, JA, DESCA, IRPRNT, ICPRNT, CMATNM,
 }
 
 #ifdef __STDC__
-void PB_Cprnt( char TYPE, int SIZE, int USIZ, int N, char * A, int IA,
-               int JA, char * CMATNM )
+void PB_Cprnt( char TYPE, Int SIZE, Int USIZ, Int N, char * A, Int IA,
+               Int JA, char * CMATNM )
 #else
 void PB_Cprnt( TYPE, SIZE, USIZ, N, A, IA, JA, CMATNM )
 /*
 *  .. Scalar Arguments ..
 */
-   int            IA, JA, N, SIZE, TYPE, USIZ;
+   Int            IA, JA, N, SIZE, TYPE, USIZ;
 /*
 *  .. Array Arguments ..
 */
@@ -508,7 +508,7 @@ void PB_Cprnt( TYPE, SIZE, USIZ, N, A, IA, JA, CMATNM )
 /*
 *  .. Local Scalars ..
 */
-   int            k;
+   Int            k;
 /* ..
 *  .. Executable Statements ..
 *
@@ -516,7 +516,7 @@ void PB_Cprnt( TYPE, SIZE, USIZ, N, A, IA, JA, CMATNM )
    if( TYPE == INT )
       for( k = 0; k < N; k++ )
          (void) fprintf( stdout, "%s(%6d,%6d)=%8d\n",      CMATNM, IA+k, JA,
-                         *((int *)(&A[k*SIZE])) );
+                         *((Int *)(&A[k*SIZE])) );
    else if( TYPE == SREAL )
       for( k = 0; k < N; k++ )
          (void) fprintf( stdout, "%s(%6d,%6d)=%16.8f\n",   CMATNM, IA+k, JA,

--- a/PBLAS/SRC/PTOOLS/PB_Cplasca2.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cplasca2.c
@@ -17,22 +17,22 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cplasca2( PBTYP_T * TYPE, char * UPLO, char * CONJUG, int M,
-                  int N, char * ALPHA, char * A, int IA, int JA,
-                  int * DESCA )
+void PB_Cplasca2( PBTYP_T * TYPE, char * UPLO, char * CONJUG, Int M,
+                  Int N, char * ALPHA, char * A, Int IA, Int JA,
+                  Int * DESCA )
 #else
 void PB_Cplasca2( TYPE, UPLO, CONJUG, M, N, ALPHA, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * UPLO;
-   int            IA, JA, M, N;
+   Int            IA, JA, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A;
 #endif
 {
@@ -40,7 +40,7 @@ void PB_Cplasca2( TYPE, UPLO, CONJUG, M, N, ALPHA, A, IA, JA, DESCA )
 *  .. Local Scalars ..
 */
    char           UploA, herm;
-   int            Acol, Arow, Aii, iimax, ilow, imbloc, Aimb1, inbloc, Ainb1,
+   Int            Acol, Arow, Aii, iimax, ilow, imbloc, Aimb1, inbloc, Ainb1,
                   Aoffi, GoEast, GoSouth, ioffd, iupp, izero=0, Ajj, jjmax,
                   Aoffj, joffd, lcmt, lcmt00, Ald, lmbloc, lnbloc, low, lower,
                   m1, Amb, mbloc, mblkd, mblks, Amp, Arcol, Arrow, mycol, myrow,

--- a/PBLAS/SRC/PTOOLS/PB_Cplascal.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cplascal.c
@@ -17,22 +17,22 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cplascal( PBTYP_T * TYPE, char * UPLO, char * CONJUG, int M,
-                  int N, char * ALPHA, char * A, int IA, int JA,
-                  int * DESCA )
+void PB_Cplascal( PBTYP_T * TYPE, char * UPLO, char * CONJUG, Int M,
+                  Int N, char * ALPHA, char * A, Int IA, Int JA,
+                  Int * DESCA )
 #else
 void PB_Cplascal( TYPE, UPLO, CONJUG, M, N, ALPHA, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * UPLO;
-   int            IA, JA, M, N;
+   Int            IA, JA, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A;
 #endif
 {
@@ -171,14 +171,14 @@ void PB_Cplascal( TYPE, UPLO, CONJUG, M, N, ALPHA, A, IA, JA, DESCA )
 *  .. Local Scalars ..
 */
    char           UploA, herm, type;
-   int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Akp, Akq, Ald, Amb, Amp,
+   Int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Akp, Akq, Ald, Amb, Amp,
                   Amp0, Anb, Anq, Anq0, ctxt, izero=0, k, kb, ktmp, mn, mycol,
                   myrow, nb, npcol, nprow, size;
    TZSCAL_T       scal;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_];
+   Int            Ad0[DLEN_];
    char           * Aptr = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_CpswapND.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpswapND.c
@@ -17,20 +17,20 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpswapND( PBTYP_T * TYPE, int N,
-                  char * X, int IX, int JX, int * DESCX, int INCX,
-                  char * Y, int IY, int JY, int * DESCY, int INCY )
+void PB_CpswapND( PBTYP_T * TYPE, Int N,
+                  char * X, Int IX, Int JX, Int * DESCX, Int INCX,
+                  char * Y, Int IY, Int JY, Int * DESCY, Int INCY )
 #else
 void PB_CpswapND( TYPE, N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            INCX, INCY, IX, IY, JX, JY, N;
+   Int            INCX, INCY, IX, IY, JX, JY, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    char           * X, * Y;
 #endif
 {
@@ -184,7 +184,7 @@ void PB_CpswapND( TYPE, N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top, * zero;
-   int            RRorCC, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc, Xm,
+   Int            RRorCC, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc, Xm,
                   XmyprocD, XmyprocR, Xn, XnprocsD, XnprocsR, XprocR, Xroc,
                   Xrow, Ycol, Yii, Yinb1D, YisR, YisRow, Yjj, Yld, Ylinc,
                   YmyprocD, YmyprocR, YnbD, YnpD, YnprocsD, YnprocsR, YprocD,

--- a/PBLAS/SRC/PTOOLS/PB_CpswapNN.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpswapNN.c
@@ -17,20 +17,20 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_CpswapNN( PBTYP_T * TYPE, int N,
-                  char * X, int IX, int JX, int * DESCX, int INCX,
-                  char * Y, int IY, int JY, int * DESCY, int INCY )
+void PB_CpswapNN( PBTYP_T * TYPE, Int N,
+                  char * X, Int IX, Int JX, Int * DESCX, Int INCX,
+                  char * Y, Int IY, Int JY, Int * DESCY, Int INCY )
 #else
 void PB_CpswapNN( TYPE, N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            INCX, INCY, IX, IY, JX, JY, N;
+   Int            INCX, INCY, IX, IY, JX, JY, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    char           * X, * Y;
 #endif
 {
@@ -183,7 +183,7 @@ void PB_CpswapNN( TYPE, N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * top;
-   int            RRorCC, XYm, XYn, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc,
+   Int            RRorCC, XYm, XYn, Xcol, Xii, XisR, XisRow, Xjj, Xld, Xlinc,
                   XmyprocD, XmyprocR, XnprocsR, XprocR, Xrow, Ycol, Yii, YisR,
                   YisRow, Yjj, Yld, Ylinc, YmyprocD, YmyprocR, YnprocsR, YprocR,
                   Yrow, csrc, ctxt, mycol, myrow, npcol, nprow, rsrc, size;

--- a/PBLAS/SRC/PTOOLS/PB_Cpsym.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpsym.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_Cpsym( PBTYP_T * TYPE, PBTYP_T * UTYP, char * SIDE,
-               char * UPLO, int N, int K, char * ALPHA, char * A,
-               int IA, int JA, int * DESCA, char * XC, int LDXC,
-               char * XR, int LDXR, char * YC, int LDYC, char * YR,
-               int LDYR, TZSYM_T SYM )
+               char * UPLO, Int N, Int K, char * ALPHA, char * A,
+               Int IA, Int JA, Int * DESCA, char * XC, Int LDXC,
+               char * XR, Int LDXR, char * YC, Int LDYC, char * YR,
+               Int LDYR, TZSYM_T SYM )
 #else
 void PB_Cpsym( TYPE, UTYP, SIDE, UPLO, N, K, ALPHA, A, IA, JA, DESCA,
                XC, LDXC, XR, LDXR, YC, LDYC, YR, LDYR, SYM )
@@ -29,14 +29,14 @@ void PB_Cpsym( TYPE, UTYP, SIDE, UPLO, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IA, JA, K, LDXC, LDXR, LDYC, LDYR, N;
+   Int            IA, JA, K, LDXC, LDXR, LDYC, LDYR, N;
    char           * ALPHA;
    PBTYP_T        * TYPE, * UTYP;
    TZSYM_T        SYM;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * XC, * XR, * YC, * YR;
 #endif
 {
@@ -234,7 +234,7 @@ void PB_Cpsym( TYPE, UTYP, SIDE, UPLO, N, K, ALPHA, A, IA, JA, DESCA,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
+   Int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
                   Aoffi, Aoffj, Arcol, Arrow, GoEast, GoSouth, IsColRepl,
                   IsRowRepl, XCinc, XRinc, Xii=0, Xjj=0, Xoffi=-1, Xoffj=-1,
                   YCinc, YRinc, iimax, ilow, imbloc, inbloc, ioffd, ioffx, iupp,

--- a/PBLAS/SRC/PTOOLS/PB_CpsymmAB.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpsymmAB.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_CpsymmAB( PBTYP_T * TYPE, char * DIRECAB, char * CONJUG,
-                  char * SIDE, char * UPLO, int M, int N, char * ALPHA,
-                  char * A, int IA, int JA, int * DESCA, char * B,
-                  int IB, int JB, int * DESCB, char * BETA, char * C,
-                  int IC, int JC, int * DESCC )
+                  char * SIDE, char * UPLO, Int M, Int N, char * ALPHA,
+                  char * A, Int IA, Int JA, Int * DESCA, char * B,
+                  Int IB, Int JB, Int * DESCB, char * BETA, char * C,
+                  Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpsymmAB( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
                   JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -29,13 +29,13 @@ void PB_CpsymmAB( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECAB, * SIDE, * UPLO;
-   int            IA, IB, IC, JA, JB, JC, M, N;
+   Int            IA, IB, IC, JA, JB, JC, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -280,7 +280,7 @@ void PB_CpsymmAB( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
 *  .. Local Scalars ..
 */
    char           GatherDir, ScatterDir, * one, top, tran, * zero;
-   int            Afr, An, Bcol, Bcurcol, Bcurimb1, Bcurinb1, Bcurrow, Bfr, Bii,
+   Int            Afr, An, Bcol, Bcurcol, Bcurimb1, Bcurinb1, Bcurrow, Bfr, Bii,
                   Bimb, Bimb1, Binb, Binb1, Bjj, Bld, Bmb, Bmp, Bmp0, Bnb, Bnq,
                   Bnq0, Brow, Ccol, Ccurcol, Ccurimb1, Ccurinb1, Ccurrow, Cii,
                   Cimb, Cimb1, Cinb, Cinb1, Cjj, Cld, Cmb, Cmp, Cmp0, Cnb, Cnq,
@@ -292,7 +292,7 @@ void PB_CpsymmAB( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
 /*
 *  .. Local Arrays ..
 */
-   int            Bd0 [DLEN_], Cd0 [DLEN_], DBUFA[DLEN_], DBUFB[DLEN_],
+   Int            Bd0 [DLEN_], Cd0 [DLEN_], DBUFA[DLEN_], DBUFB[DLEN_],
                   WABd[DLEN_], WACd[DLEN_], WBCd [DLEN_];
    char           * Aptr = NULL, * Bptr = NULL, * Bptr0 = NULL, * Cptr0 = NULL,
                   * WAB  = NULL, * WAC  = NULL, * WBC   = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_CpsymmBC.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpsymmBC.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_CpsymmBC( PBTYP_T * TYPE, char * DIRECAB, char * CONJUG,
-                  char * SIDE, char * UPLO, int M, int N, char * ALPHA,
-                  char * A, int IA, int JA, int * DESCA, char * B,
-                  int IB, int JB, int * DESCB, char * BETA, char * C,
-                  int IC, int JC, int * DESCC )
+                  char * SIDE, char * UPLO, Int M, Int N, char * ALPHA,
+                  char * A, Int IA, Int JA, Int * DESCA, char * B,
+                  Int IB, Int JB, Int * DESCB, char * BETA, char * C,
+                  Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpsymmBC( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
                   JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -29,13 +29,13 @@ void PB_CpsymmBC( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECAB, * SIDE, * UPLO;
-   int            IA, IB, IC, JA, JB, JC, M, N;
+   Int            IA, IB, IC, JA, JB, JC, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -281,7 +281,7 @@ void PB_CpsymmBC( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
 */
    char           GemmTa, GemmTb, cctop, * one, rctop, * talphaCR, * talphaRC,
                   * tbeta, * zero;
-   int            Acol, Aii, Aimb1, Ainb1, Ajj, Alcmb, Ald, Alp, Alp0, Alq,
+   Int            Acol, Aii, Aimb1, Ainb1, Ajj, Alcmb, Ald, Alp, Alp0, Alq,
                   Alq0, Amb, Amp, An, Anb, Anq, Arow, BCfwd, BCmyprocD,
                   BCmyprocR, BCnD, BCnR, BCnprocsD, BCnprocsR, Bbufld, BcurrocR,
                   Bfr, BiD, BiR, BiiD, BiiR, BinbD, BinbR, Binb1D, Binb1R, BisR,
@@ -299,7 +299,7 @@ void PB_CpsymmBC( TYPE, DIRECAB, CONJUG, SIDE, UPLO, M, N, ALPHA, A, IA,
 *  .. Local Arrays ..
 */
    PB_VM_T        VM;
-   int            Ad0 [DLEN_], DBUFB[DLEN_], DBUFC[DLEN_], WBCd[DLEN_],
+   Int            Ad0 [DLEN_], DBUFB[DLEN_], DBUFC[DLEN_], WBCd[DLEN_],
                   WBRd[DLEN_], WCCd [DLEN_], WCRd [DLEN_];
    char           * Aptr = NULL, * Bbuf = NULL, * Cbuf = NULL, * WBC  = NULL,
                   * WBR  = NULL, * WCC  = NULL, * WCR  = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_Cpsyr.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpsyr.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cpsyr( PBTYP_T * TYPE, char * UPLO, int N, int K,
-               char * ALPHA, char * XC, int LDXC, char * XR, int LDXR,
-               char * A, int IA, int JA, int * DESCA, TZSYR_T SYR )
+void PB_Cpsyr( PBTYP_T * TYPE, char * UPLO, Int N, Int K,
+               char * ALPHA, char * XC, Int LDXC, char * XR, Int LDXR,
+               char * A, Int IA, Int JA, Int * DESCA, TZSYR_T SYR )
 #else
 void PB_Cpsyr( TYPE, UPLO, N, K, ALPHA, XC, LDXC, XR, LDXR, A, IA,
                JA, DESCA, SYR )
@@ -27,14 +27,14 @@ void PB_Cpsyr( TYPE, UPLO, N, K, ALPHA, XC, LDXC, XR, LDXR, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IA, JA, K, LDXC, LDXR, N;
+   Int            IA, JA, K, LDXC, LDXR, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
    TZSYR_T        SYR;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * XC, * XR;
 #endif
 {
@@ -203,7 +203,7 @@ void PB_Cpsyr( TYPE, UPLO, N, K, ALPHA, XC, LDXC, XR, LDXR, A, IA,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
+   Int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
                   Aoffi, Aoffj, Arcol, Arrow, GoEast, GoSouth, IsColRepl,
                   IsRowRepl, XCinc, XRinc, Xii=0, Xjj=0, Xoffi=-1, Xoffj=-1,
                   iimax, ilow, imbloc, inbloc, ioffd, ioffx, iupp, jjmax, joffd,

--- a/PBLAS/SRC/PTOOLS/PB_Cpsyr2.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpsyr2.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cpsyr2( PBTYP_T * TYPE, char * UPLO, int N, int K,
-                char * ALPHA, char * XC, int LDXC, char * XR, int LDXR,
-                char * YC, int LDYC, char * YR, int LDYR, char * A,
-                int IA, int JA, int * DESCA, TZSYR2_T SYR2 )
+void PB_Cpsyr2( PBTYP_T * TYPE, char * UPLO, Int N, Int K,
+                char * ALPHA, char * XC, Int LDXC, char * XR, Int LDXR,
+                char * YC, Int LDYC, char * YR, Int LDYR, char * A,
+                Int IA, Int JA, Int * DESCA, TZSYR2_T SYR2 )
 #else
 void PB_Cpsyr2( TYPE, UPLO, N, K, ALPHA, XC, LDXC, XR, LDXR,
                 YC, LDYC, YR, LDYR, A, IA, JA, DESCA, SYR2 )
@@ -28,14 +28,14 @@ void PB_Cpsyr2( TYPE, UPLO, N, K, ALPHA, XC, LDXC, XR, LDXR,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IA, JA, K, LDXC, LDXR, LDYC, LDYR, N;
+   Int            IA, JA, K, LDXC, LDXR, LDYC, LDYR, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
    TZSYR2_T       SYR2;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * XC, * XR, * YC, * YR;
 #endif
 {
@@ -221,7 +221,7 @@ void PB_Cpsyr2( TYPE, UPLO, N, K, ALPHA, XC, LDXC, XR, LDXR,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
+   Int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
                   Aoffi, Aoffj, Arcol, Arrow, GoEast, GoSouth, IsColRepl,
                   IsRowRepl, XCinc, XRinc, Xii=0, Xjj=0, Xoffi=-1, Xoffj=-1,
                   YCinc, YRinc, iimax, ilow, imbloc, inbloc, ioffd, ioffx, iupp,

--- a/PBLAS/SRC/PTOOLS/PB_Cpsyr2kA.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpsyr2kA.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_Cpsyr2kA( PBTYP_T * TYPE, char * DIRECAB, char * CONJUG,
-                  char * UPLO, char * TRANS, int N, int K, char * ALPHA,
-                  char * A, int IA, int JA, int * DESCA, char * B,
-                  int IB, int JB, int * DESCB, char * BETA, char * C,
-                  int IC, int JC, int * DESCC )
+                  char * UPLO, char * TRANS, Int N, Int K, char * ALPHA,
+                  char * A, Int IA, Int JA, Int * DESCA, char * B,
+                  Int IB, Int JB, Int * DESCB, char * BETA, char * C,
+                  Int IC, Int JC, Int * DESCC )
 #else
 void PB_Cpsyr2kA( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
                   JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -29,13 +29,13 @@ void PB_Cpsyr2kA( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECAB, * TRANS, * UPLO;
-   int            IA, IB, IC, JA, JB, JC, K, N;
+   Int            IA, IB, IC, JA, JB, JC, K, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -318,7 +318,7 @@ void PB_Cpsyr2kA( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Local Scalars ..
 */
    char           * one, * talpha, * zero;
-   int            ABfwd, ABmyprocD, ABmyprocR, ABnprocsD, ABnprocsR, ABrocs,
+   Int            ABfwd, ABmyprocD, ABmyprocR, ABnprocsD, ABnprocsR, ABrocs,
                   Abufld, AcurrocR, Afr, AiD, AiR, AiiD, AiiR, AinbD, AinbR,
                   Ainb1D, Ainb1R, AisR, AkkR, Ald, AnbD, AnbR, AnpD, AnpR,
                   Aoff, ArocD, ArocR, AsrcR, Bbufld, BcurrocR, Bfr, BiD, BiR,
@@ -338,7 +338,7 @@ void PB_Cpsyr2kA( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Local Arrays ..
 */
    PB_VM_T        VM;
-   int            Cd0  [DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WACd0[DLEN_],
+   Int            Cd0  [DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WACd0[DLEN_],
                   WARd0[DLEN_], WBCd0[DLEN_], WBRd0[DLEN_];
    char           * Abuf = NULL, * Bbuf = NULL, * Cptr = NULL, * WAC = NULL,
                   * WAR  = NULL, * WBC  = NULL, * WBR  = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_Cpsyr2kAC.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cpsyr2kAC.c
@@ -18,10 +18,10 @@
 
 #ifdef __STDC__
 void PB_Cpsyr2kAC( PBTYP_T * TYPE, char * DIRECAB, char * CONJUG,
-                   char * UPLO, char * TRANS, int N, int K, char * ALPHA,
-                   char * A, int IA, int JA, int * DESCA, char * B,
-                   int IB, int JB, int * DESCB, char * BETA, char * C,
-                   int IC, int JC, int * DESCC )
+                   char * UPLO, char * TRANS, Int N, Int K, char * ALPHA,
+                   char * A, Int IA, Int JA, Int * DESCA, char * B,
+                   Int IB, Int JB, Int * DESCB, char * BETA, char * C,
+                   Int IC, Int JC, Int * DESCC )
 #else
 void PB_Cpsyr2kAC( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
                    JA, DESCA, B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -29,13 +29,13 @@ void PB_Cpsyr2kAC( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECAB, * TRANS, * UPLO;
-   int            IA, IB, IC, JA, JB, JC, K, N;
+   Int            IA, IB, IC, JA, JB, JC, K, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -318,7 +318,7 @@ void PB_Cpsyr2kAC( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 */
    char           GatherDir, ScatterDir, * one, top, * talpha, * tbeta, tran,
                   * zero;
-   int            ABm, ABn, Acol, Acurcol, Acurrow, Acurimb1, Acurinb1, Afr,
+   Int            ABm, ABn, Acol, Acurcol, Acurrow, Acurimb1, Acurinb1, Afr,
                   Aii, Aimb, Aimb1, Ainb, Ainb1, AisD, AisR, Ajj, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, Aspan, Bcol, Bcurcol,
                   Bcurrow, Bcurimb1, Bcurinb1, Bfr, Bii, Bimb, Bimb1, Binb,
@@ -334,7 +334,7 @@ void PB_Cpsyr2kAC( TYPE, DIRECAB, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 */
    char           * Aptr = NULL, * Aptr0 = NULL, * Bptr = NULL, * Bptr0 = NULL,
                   * WA = NULL, * WB = NULL, * WAC = NULL, *WBC = NULL;
-   int            Ad0[DLEN_], Bd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_],
+   Int            Ad0[DLEN_], Bd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_],
                   WAd[DLEN_], WBd[DLEN_], WACd [DLEN_], WBCd [DLEN_];
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_CpsyrkA.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpsyrkA.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CpsyrkA( PBTYP_T * TYPE, char * DIRECA, char * CONJUG,
-                 char * UPLO, char * TRANS, int N, int K, char * ALPHA,
-                 char * A, int IA, int JA, int * DESCA, char * BETA,
-                 char * C, int IC, int JC, int * DESCC )
+                 char * UPLO, char * TRANS, Int N, Int K, char * ALPHA,
+                 char * A, Int IA, Int JA, Int * DESCA, char * BETA,
+                 char * C, Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpsyrkA( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
                  JA, DESCA, BETA, C, IC, JC, DESCC )
@@ -28,13 +28,13 @@ void PB_CpsyrkA( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECA, * TRANS, * UPLO;
-   int            IA, IC, JA, JC, K, N;
+   Int            IA, IC, JA, JC, K, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    char           * A, * C;
 #endif
 {
@@ -272,7 +272,7 @@ void PB_CpsyrkA( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            AcurrocR, Afwd, AiD, AiR, AiiD, AiiR, AinbD, AinbR, Ainb1D,
+   Int            AcurrocR, Afwd, AiD, AiR, AiiD, AiiR, AinbD, AinbR, Ainb1D,
                   Ainb1R, AisR, Ald, AmyprocD, AmyprocR, AnbD, AnbR, AnpR,
                   AnprocsD, AnprocsR, ArocD, ArocR, Arocs, AsrcR, Ccol, Cii,
                   Cimb1, Cinb1, Cjj, Clcmb, Cld, Clp, Clq, Cnq0, Cmb, Cmp,
@@ -284,7 +284,7 @@ void PB_CpsyrkA( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 /*
 *  .. Local Arrays ..
 */
-   int            Cd0[DLEN_], DBUFA[DLEN_], WACd0[DLEN_], WARd0[DLEN_];
+   Int            Cd0[DLEN_], DBUFA[DLEN_], WACd0[DLEN_], WARd0[DLEN_];
    char           * Aptr = NULL, * Cptr = NULL, * WAC = NULL, * WAR  = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_CpsyrkAC.c
+++ b/PBLAS/SRC/PTOOLS/PB_CpsyrkAC.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CpsyrkAC( PBTYP_T * TYPE, char * DIRECA, char * CONJUG,
-                  char * UPLO, char * TRANS, int N, int K, char * ALPHA,
-                  char * A, int IA, int JA, int * DESCA, char * BETA,
-                  char * C, int IC, int JC, int * DESCC )
+                  char * UPLO, char * TRANS, Int N, Int K, char * ALPHA,
+                  char * A, Int IA, Int JA, Int * DESCA, char * BETA,
+                  char * C, Int IC, Int JC, Int * DESCC )
 #else
 void PB_CpsyrkAC( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
                  JA, DESCA, BETA, C, IC, JC, DESCC )
@@ -28,13 +28,13 @@ void PB_CpsyrkAC( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG, * DIRECA, * TRANS, * UPLO;
-   int            IA, IC, JA, JC, K, N;
+   Int            IA, IC, JA, JC, K, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    char           * A, * C;
 #endif
 {
@@ -272,7 +272,7 @@ void PB_CpsyrkAC( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 *  .. Local Scalars ..
 */
    char           GatherDir, ScatterDir, * one, top, tran, * zero;
-   int            Acol, Acurcol, Acurimb1, Acurinb1, Acurrow, Afr, Aii, Aimb,
+   Int            Acol, Acurcol, Acurimb1, Acurinb1, Acurrow, Afr, Aii, Aimb,
                   Aimb1, Ainb, Ainb1, Ajj, Ald, Am, Amb, Amp, Amp0, An, Anb,
                   Anq, Anq0, Arow, Ccsrc, Cimb, Cinb, Cmb, Cnb, Crsrc, WAfr,
                   WCfr, WCsum, conjg, ctxt, fwd, k, kb, kbb, kend, kstart,
@@ -282,7 +282,7 @@ void PB_CpsyrkAC( TYPE, DIRECA, CONJUG, UPLO, TRANS, N, K, ALPHA, A, IA,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_], DBUFA[DLEN_], WAd[DLEN_], WCd[DLEN_];
+   Int            Ad0[DLEN_], DBUFA[DLEN_], WAd[DLEN_], WCd[DLEN_];
    char           * Aptr = NULL, * Aptr0 = NULL, * WA = NULL, * WC = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cptradd.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cptradd.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_Cptradd( PBTYP_T * TYPE, char * DIRECAC, char * UPLO, char * TRANS,
-                 int M, int N, char * ALPHA, char * A, int IA, int JA,
-                 int * DESCA, char * BETA, char * C, int IC, int JC,
-                 int * DESCC )
+                 Int M, Int N, char * ALPHA, char * A, Int IA, Int JA,
+                 Int * DESCA, char * BETA, char * C, Int IC, Int JC,
+                 Int * DESCC )
 #else
 void PB_Cptradd( TYPE, DIRECAC, UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA,
                  BETA, C, IC, JC, DESCC )
@@ -28,13 +28,13 @@ void PB_Cptradd( TYPE, DIRECAC, UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    char           * DIRECAC, * TRANS, * UPLO;
-   int            IA, IC, JA, JC, M, N;
+   Int            IA, IC, JA, JC, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    char           * A, * C;
 #endif
 {
@@ -227,11 +227,11 @@ void PB_Cptradd( TYPE, DIRECAC, UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Local Scalars ..
 */
    char           Dir, * one, * zero;
-   int            Afr, conjg, k, kb, kbb, kend, kstart, kstep, ktmp;
+   Int            Afr, conjg, k, kb, kbb, kend, kstart, kstep, ktmp;
 /*
 *  .. Local Arrays ..
 */
-   int            DBUFA[DLEN_];
+   Int            DBUFA[DLEN_];
    char           * Aptr = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cptran.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cptran.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cptran( PBTYP_T * TYPE, char * CONJUG, int M, int N,
-                char * ALPHA, char * A, int IA, int JA, int * DESCA,
-                char * BETA,  char * C, int IC, int JC, int * DESCC )
+void PB_Cptran( PBTYP_T * TYPE, char * CONJUG, Int M, Int N,
+                char * ALPHA, char * A, Int IA, Int JA, Int * DESCA,
+                char * BETA,  char * C, Int IC, Int JC, Int * DESCC )
 #else
 void PB_Cptran( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, BETA,
                 C, IC, JC, DESCC )
@@ -27,13 +27,13 @@ void PB_Cptran( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    char           * CONJUG;
-   int            IA, IC, JA, JC, M, N;
+   Int            IA, IC, JA, JC, M, N;
    char           * ALPHA, * BETA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    char           * A, * C;
 #endif
 {
@@ -202,7 +202,7 @@ void PB_Cptran( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Local Scalars ..
 */
    char           Aroc, Croc, * one, * talpha, * tbeta, * zero;
-   int            ACnD, ACnR, Abufld, AcurrocR, Afr, AiD, AiR, AiiD, AiiR,
+   Int            ACnD, ACnR, Abufld, AcurrocR, Afr, AiD, AiR, AiiD, AiiR,
                   AinbD, AinbR, Ainb1D, Ainb1R, AisR, Akk, Ald, AmyprocD,
                   AmyprocR, AnbD, AnbR, AnpD, AnpR, AnprocsD, AnprocsR, Aoff,
                   ArocD, ArocR, AsrcR, Cbufld, CcurrocR, Cfr, CiD, CiR, CiiD,
@@ -215,7 +215,7 @@ void PB_Cptran( TYPE, CONJUG, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 /*
 *  .. Local Arrays ..
 */
-   int            DBUFA[DLEN_], DBUFC[DLEN_];
+   Int            DBUFA[DLEN_], DBUFC[DLEN_];
    char           * Abuf = NULL, * Cbuf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cptrm.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cptrm.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_Cptrm( PBTYP_T * TYPE, PBTYP_T * UTYP, char * SIDE, char * UPLO,
-               char * TRANS, char * DIAG, int N, int K, char * ALPHA,
-               char * A, int IA, int JA, int * DESCA,
-               char * X, int LDX, char * Y, int LDY,
+               char * TRANS, char * DIAG, Int N, Int K, char * ALPHA,
+               char * A, Int IA, Int JA, Int * DESCA,
+               char * X, Int LDX, char * Y, Int LDY,
                TZTRM_T TRM )
 #else
 void PB_Cptrm( TYPE, UTYP, SIDE, UPLO, TRANS, DIAG, N, K, ALPHA, A,
@@ -29,14 +29,14 @@ void PB_Cptrm( TYPE, UTYP, SIDE, UPLO, TRANS, DIAG, N, K, ALPHA, A,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * SIDE, * TRANS, * UPLO;
-   int            IA, JA, K, LDX, LDY, N;
+   Int            IA, JA, K, LDX, LDY, N;
    char           * ALPHA;
    PBTYP_T        * TYPE, * UTYP;
    TZTRM_T        TRM;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * X, * Y;
 #endif
 {
@@ -246,7 +246,7 @@ void PB_Cptrm( TYPE, UTYP, SIDE, UPLO, TRANS, DIAG, N, K, ALPHA, A,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
+   Int            Acol, Arow, Aii, Aimb1, Ainb1, Ajj, Ald, Amp, Amb, Anb, Anq,
                   Aoffi, Aoffj, Arcol, Arrow, GoEast, GoSouth, IsColRepl,
                   IsRowRepl, Xinc, Yinc, XYii=0, XYjj=0, XYoffi=-1, XYoffj=-1,
                   XisRow, iimax, ilow, imbloc, inbloc, ioffd, ioffxy, iupp,

--- a/PBLAS/SRC/PTOOLS/PB_CptrmmAB.c
+++ b/PBLAS/SRC/PTOOLS/PB_CptrmmAB.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CptrmmAB( PBTYP_T * TYPE, char * VARIANT, char * SIDE, char * UPLO,
-                  char * TRANSA, char * DIAG, int M, int N, char * ALPHA,
-                  char * A, int IA, int JA, int * DESCA, char * B, int IB,
-                  int JB, int * DESCB )
+                  char * TRANSA, char * DIAG, Int M, Int N, char * ALPHA,
+                  char * A, Int IA, Int JA, Int * DESCA, char * B, Int IB,
+                  Int JB, Int * DESCB )
 #else
 void PB_CptrmmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, IA,
                   JA, DESCA, B, IB, JB, DESCB )
@@ -28,13 +28,13 @@ void PB_CptrmmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, IA,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * SIDE, * TRANSA, * UPLO, * VARIANT;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -255,14 +255,14 @@ void PB_CptrmmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, IA,
 *  .. Local Scalars ..
 */
    char           conjg, * one, top, * zero;
-   int            Afr, Bcol, Bcurcol, Bcurimb1, Bcurinb1, Bcurrow, Bfr, Bii,
+   Int            Afr, Bcol, Bcurcol, Bcurimb1, Bcurinb1, Bcurrow, Bfr, Bii,
                   Bimb, Bimb1, Binb, Binb1, Bjj, Bld, Bmb, Bmp, Bmp0, Bnb, Bnq,
                   Bnq0, Brow, WAfr, WBfr, WBsum, ctxt, k, kb, kbb, ktmp, lside,
                   mycol, myrow, notran, npcol, nprow, size, unit, upper;
 /*
 *  .. Local Arrays ..
 */
-   int            Bd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WAd[DLEN_],
+   Int            Bd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WAd[DLEN_],
                   WBd[DLEN_];
    char           * Aptr = NULL, * Bptr = NULL, * Bptr0 = NULL, * WA = NULL,
                   * WB   = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_CptrmmB.c
+++ b/PBLAS/SRC/PTOOLS/PB_CptrmmB.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CptrmmB( PBTYP_T * TYPE, char * DIRECB, char * SIDE,
-                 char * UPLO, char * TRANSA, char * DIAG, int M, int N,
-                 char * ALPHA, char * A, int IA, int JA, int * DESCA,
-                 char * B, int IB, int JB, int * DESCB )
+                 char * UPLO, char * TRANSA, char * DIAG, Int M, Int N,
+                 char * ALPHA, char * A, Int IA, Int JA, Int * DESCA,
+                 char * B, Int IB, Int JB, Int * DESCB )
 #else
 void PB_CptrmmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
                  IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,13 +28,13 @@ void PB_CptrmmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * DIRECB, * SIDE, * TRANSA, * UPLO;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -256,7 +256,7 @@ void PB_CptrmmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 */
    char           Broc, GemmTa, GemmTb, TranOp, WBroc, WCroc, conjg, * one,
                   * talpha, * tbeta, top, * zero;
-   int            Acol, Aii, Aimb1, Ainb1, Ajj, Alcmb, Ald, Alp, Alp0, Alq,
+   Int            Acol, Aii, Aimb1, Ainb1, Ajj, Alcmb, Ald, Alp, Alp0, Alq,
                   Alq0, Amb, Amp, An, Anb, Anq, Arow, BcurrocR, Bfwd, BiiD,
                   BiiR, Binb1D, Binb1R, BisR, Bld, BmyprocD, BmyprocR, BnD,
                   BnR, BnbD, BnbR, BnpR, BnprocsD, BnprocsR, BrocD, BrocR,
@@ -268,7 +268,7 @@ void PB_CptrmmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_], DBUFB[DLEN_], WCd[DLEN_], WBd[DLEN_];
+   Int            Ad0[DLEN_], DBUFB[DLEN_], WCd[DLEN_], WBd[DLEN_];
    char           * Aptr = NULL, * Bptr = NULL, * WB = NULL, * WC = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cptrsm.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cptrsm.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cptrsm( PBTYP_T * TYPE, int FBCAST, char * SIDE, char * UPLO,
-                char * TRANS, char * DIAG, int M, int N, char * ALPHA,
-                char * A, int IA, int JA, int * DESCA, char * BC,
-                int LDBC, char * BR, int LDBR )
+void PB_Cptrsm( PBTYP_T * TYPE, Int FBCAST, char * SIDE, char * UPLO,
+                char * TRANS, char * DIAG, Int M, Int N, char * ALPHA,
+                char * A, Int IA, Int JA, Int * DESCA, char * BC,
+                Int LDBC, char * BR, Int LDBR )
 #else
 void PB_Cptrsm( TYPE, FBCAST, SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
                 A, IA, JA, DESCA, BC, LDBC, BR, LDBR )
@@ -28,12 +28,12 @@ void PB_Cptrsm( TYPE, FBCAST, SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    char           * ALPHA, * DIAG, * SIDE, * TRANS, * UPLO;
-   int            FBCAST, IA, JA, LDBC, LDBR, M, N;
+   Int            FBCAST, IA, JA, LDBC, LDBR, M, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * BC, * BR;
 #endif
 {
@@ -252,7 +252,7 @@ void PB_Cptrsm( TYPE, FBCAST, SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Local Scalars ..
 */
    char           btop, * negone, * one, * talpha1, * talpha2, * zero;
-   int            Acol, Aii, Aimb1, Ainb1, Ais1Col, Ais1Row, AisColRep,
+   Int            Acol, Aii, Aimb1, Ainb1, Ais1Col, Ais1Row, AisColRep,
                   AisRowRep, Ajj, Alcol, Ald, Alrow, Amb, Anpprev, Anb, Anp,
                   Anq, Arow, Asrc, ChangeRoc=0, LNorRT, Na, Nb, bcst, ctxt,
                   izero=0, k=0, kb, kbprev=0, kbsize, lside, mb1, mycol, myrow,

--- a/PBLAS/SRC/PTOOLS/PB_CptrsmAB.c
+++ b/PBLAS/SRC/PTOOLS/PB_CptrsmAB.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CptrsmAB( PBTYP_T * TYPE, char * VARIANT, char * SIDE, char * UPLO,
-                  char * TRANSA, char * DIAG, int M, int N, char * ALPHA,
-                  char * A, int IA, int JA, int * DESCA, char * B, int IB,
-                  int JB, int * DESCB )
+                  char * TRANSA, char * DIAG, Int M, Int N, char * ALPHA,
+                  char * A, Int IA, Int JA, Int * DESCA, char * B, Int IB,
+                  Int JB, Int * DESCB )
 #else
 void PB_CptrsmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
                   IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,13 +28,13 @@ void PB_CptrsmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * SIDE, * TRANSA, * UPLO, * VARIANT;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -255,7 +255,7 @@ void PB_CptrsmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 *  .. Local Scalars ..
 */
    char           conjg, * negone, * one, * talph, top, * zero;
-   int            Afr, Bcol, Bcurcol, Bcurimb1, Bcurinb1, Bcurrow, Bfr, Bii,
+   Int            Afr, Bcol, Bcurcol, Bcurimb1, Bcurinb1, Bcurrow, Bfr, Bii,
                   Bimb, Bimb1, Binb, Binb1, Bjj, Bld, Bmb, Bmp, Bmp0, Bnb, Bnq,
                   Bnq0, Brow, WAfr, WAoff, WBfr, WBsum, ctxt, k, kb, kbb, kmax,
                   ktmp, lside, mn, mycol, myrow, notran, npcol, nprow, size,
@@ -265,7 +265,7 @@ void PB_CptrsmAB( TYPE, VARIANT, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 /*
 *  .. Local Arrays ..
 */
-   int            Bd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WAd[DLEN_],
+   Int            Bd0[DLEN_], DBUFA[DLEN_], DBUFB[DLEN_], WAd[DLEN_],
                   WBd[DLEN_];
    char           * Aptr = NULL, * Bptr = NULL, * Bptr0 = NULL, * WA = NULL,
                   * WB   = NULL;

--- a/PBLAS/SRC/PTOOLS/PB_CptrsmAB0.c
+++ b/PBLAS/SRC/PTOOLS/PB_CptrsmAB0.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CptrsmAB0( PBTYP_T * TYPE, char * SIDE, char * UPLO, char * DIAG,
-                   int M, int N, char * ALPHA, char * A, int IA, int JA,
-                   int * DESCA, char * B, int IB, int JB, int * DESCB,
-                   char * * C, int * DESCC, int * CFREE )
+                   Int M, Int N, char * ALPHA, char * A, Int IA, Int JA,
+                   Int * DESCA, char * B, Int IB, Int JB, Int * DESCB,
+                   char * * C, Int * DESCC, Int * CFREE )
 #else
 void PB_CptrsmAB0( TYPE, SIDE, UPLO, DIAG, M, N, ALPHA, A, IA, JA, DESCA,
                    B, IB, JB, DESCB, C, DESCC, CFREE )
@@ -28,13 +28,13 @@ void PB_CptrsmAB0( TYPE, SIDE, UPLO, DIAG, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * SIDE, * UPLO;
-   int            * CFREE, IA, IB, JA, JB, M, N;
+   Int            * CFREE, IA, IB, JA, JB, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * * C;
 #endif
 {
@@ -42,7 +42,7 @@ void PB_CptrsmAB0( TYPE, SIDE, UPLO, DIAG, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Local Scalars ..
 */
    char           btop, * negone, * one, * talpha, * zero;
-   int            Acol, Acurcol, Acurrow, Aii, Aimb, Aimb1, Ainb, Ainb1, Ajj,
+   Int            Acol, Acurcol, Acurrow, Aii, Aimb, Aimb1, Ainb, Ainb1, Ajj,
                   Ald, Almb1, Alnb1, Amb, Amp0, Anq0, An, Anb, Arow, Bcol, Bii,
                   Bimb, Bimb1, Binb, Binb1, Bjj, Bld, Bmb, Bmp0, Bnb, Bnq0,
                   Brow, Cld, ctxt, k=1, kb, kblks, kbprev, ktmp, lside, mycol,

--- a/PBLAS/SRC/PTOOLS/PB_CptrsmAB1.c
+++ b/PBLAS/SRC/PTOOLS/PB_CptrsmAB1.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CptrsmAB1( PBTYP_T * TYPE, char * SIDE, char * UPLO, char * TRANSA,
-                   char * DIAG, int M, int N, char * ALPHA, char * A, int IA,
-                   int JA, int * DESCA,  char * B, int IB, int JB, int * DESCB,
-                   char * C, int * DESCC )
+                   char * DIAG, Int M, Int N, char * ALPHA, char * A, Int IA,
+                   Int JA, Int * DESCA,  char * B, Int IB, Int JB, Int * DESCB,
+                   char * C, Int * DESCC )
 #else
 void PB_CptrsmAB1( TYPE, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, IA, JA,
                    DESCA, B, IB, JB, DESCB, C, DESCC )
@@ -28,13 +28,13 @@ void PB_CptrsmAB1( TYPE, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, IA, JA,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * SIDE, * TRANSA, * UPLO;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    char           * A, * B, * C;
 #endif
 {
@@ -42,7 +42,7 @@ void PB_CptrsmAB1( TYPE, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A, IA, JA,
 *  .. Local Scalars ..
 */
    char           * negone, * one;
-   int            Acol, Acurcol, Acurrow, Aii, Aimb, Aimb1, Ainb, Ainb1, Ajj,
+   Int            Acol, Acurcol, Acurrow, Aii, Aimb, Aimb1, Ainb, Ainb1, Ajj,
                   Ald, Almb1, Alnb1, Amb, Amp0, An, Anb, Anq0, Anxtrow, Anxtcol,
                   Arow, Bcol, Bii, Bimb, Binb, Bjj, Bld, Bmb, Bmp0, Bnb, Bnq0,
                   Brow, Cld, ctxt, k=1, kb, kblks, lside, mycol, myrow, npcol,

--- a/PBLAS/SRC/PTOOLS/PB_CptrsmB.c
+++ b/PBLAS/SRC/PTOOLS/PB_CptrsmB.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_CptrsmB( PBTYP_T * TYPE, char * DIRECB, char * SIDE,
-                 char * UPLO, char * TRANSA, char * DIAG, int M, int N,
-                 char * ALPHA, char * A, int IA, int JA, int * DESCA,
-                 char * B, int IB, int JB, int * DESCB )
+                 char * UPLO, char * TRANSA, char * DIAG, Int M, Int N,
+                 char * ALPHA, char * A, Int IA, Int JA, Int * DESCA,
+                 char * B, Int IB, Int JB, Int * DESCB )
 #else
 void PB_CptrsmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
                  IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,13 +28,13 @@ void PB_CptrsmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * DIRECB, * SIDE, * TRANSA, * UPLO;
-   int            IA, IB, JA, JB, M, N;
+   Int            IA, IB, JA, JB, M, N;
    char           * ALPHA;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    char           * A, * B;
 #endif
 {
@@ -256,7 +256,7 @@ void PB_CptrsmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 */
    char           Broc, TranOp, conjg, * negone, * one, * talpha, * talph0, top,
                   * zero;
-   int            Acol, Aii, Aimb1, Ainb1, Ajj, Akp, Akq, Alcmb, Ald, Amb, An,
+   Int            Acol, Aii, Aimb1, Ainb1, Ajj, Akp, Akq, Alcmb, Ald, Amb, An,
                   Anb, Anp, Anp0, Anq, Anq0, Arow, Asrc, Astart, BcurrocR, Bfwd,
                   BiiD, BiiR, Binb1D, Binb1R, BisR, Bld, BmyprocD, BmyprocR,
                   BnD, BnR, BnbD, BnbR, BnpR, BnprocsD, BnprocsR, BrocD, BrocR,
@@ -270,7 +270,7 @@ void PB_CptrsmB( TYPE, DIRECB, SIDE, UPLO, TRANSA, DIAG, M, N, ALPHA, A,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad0[DLEN_], DBUFB[DLEN_], WBCd[DLEN_], WBRd[DLEN_];
+   Int            Ad0[DLEN_], DBUFB[DLEN_], WBCd[DLEN_], WBRd[DLEN_];
    char           * Aptr = NULL, * Bptr = NULL, * WBC = NULL, * WBR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cptrsv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cptrsv.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Cptrsv( PBTYP_T * TYPE, int FBCAST, char * UPLO, char * TRANS,
-                char * DIAG, int N, char * A, int IA, int JA,
-                int * DESCA, char * XC, int INCXC, char * XR,
-                int INCXR )
+void PB_Cptrsv( PBTYP_T * TYPE, Int FBCAST, char * UPLO, char * TRANS,
+                char * DIAG, Int N, char * A, Int IA, Int JA,
+                Int * DESCA, char * XC, Int INCXC, char * XR,
+                Int INCXR )
 #else
 void PB_Cptrsv( TYPE, FBCAST, UPLO, TRANS, DIAG, N, A, IA, JA, DESCA,
                 XC, INCXC, XR, INCXR )
@@ -28,12 +28,12 @@ void PB_Cptrsv( TYPE, FBCAST, UPLO, TRANS, DIAG, N, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    char           * DIAG, * TRANS, * UPLO;
-   int            FBCAST, IA, INCXC, INCXR, JA, N;
+   Int            FBCAST, IA, INCXC, INCXR, JA, N;
    PBTYP_T        * TYPE;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA;
+   Int            * DESCA;
    char           * A, * XC, * XR;
 #endif
 {
@@ -227,7 +227,7 @@ void PB_Cptrsv( TYPE, FBCAST, UPLO, TRANS, DIAG, N, A, IA, JA, DESCA,
 *  .. Local Scalars ..
 */
    char           btop, * negone, * one, * zero;
-   int            Acol, Aii, Aimb1, Ainb1, Ais1Col, Ais1Row, AisColRep,
+   Int            Acol, Aii, Aimb1, Ainb1, Ais1Col, Ais1Row, AisColRep,
                   AisRowRep, Ajj, Alcol, Ald, Alrow, Amb, Anpprev, Anb, Anp,
                   Anq, Arow, Asrc, ChangeRoc=0, bcst, ctxt, ione=1, k=0, kb,
                   kbprev=0, kbsize, mb1, mycol, myrow, n1, n1last, n1p,

--- a/PBLAS/SRC/PTOOLS/PB_Cspan.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cspan.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-int PB_Cspan( int N, int I, int INB, int NB, int SRCPROC, int NPROCS )
+Int PB_Cspan( Int N, Int I, Int INB, Int NB, Int SRCPROC, Int NPROCS )
 #else
-int PB_Cspan( N, I, INB, NB, SRCPROC, NPROCS )
+Int PB_Cspan( N, I, INB, NB, SRCPROC, NPROCS )
 /*
 *  .. Scalar Arguments ..
 */
-   int            I, INB, N, NB, NPROCS, SRCPROC;
+   Int            I, INB, N, NB, NPROCS, SRCPROC;
 #endif
 {
 /*

--- a/PBLAS/SRC/PTOOLS/PB_Cstypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cstypeset.c
@@ -34,7 +34,7 @@ PBTYP_T * PB_Cstypeset()
 /*
 *  .. Local Scalars ..
 */
-   static int     setup=0;
+   static Int     setup=0;
    static PBTYP_T TypeStruct;
    static float   zero, one, negone;
 /* ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctop.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctop.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-char * PB_Ctop( int * ICTXT, char * OP, char * SCOPE, char * TOP )
+char * PB_Ctop( Int * ICTXT, char * OP, char * SCOPE, char * TOP )
 #else
 char * PB_Ctop( ICTXT, OP, SCOPE, TOP )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * ICTXT;
+   Int            * ICTXT;
 /*
 *  .. Array Arguments ..
 */

--- a/PBLAS/SRC/PTOOLS/PB_Ctzahemv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzahemv.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzahemv( PBTYP_T * TYPE, char * SIDE, char * UPLO, int M, int N,
-                  int K, int IOFFD, char * ALPHA, char * A, int LDA,
-                  char * XC, int LDXC, char * XR, int LDXR, char * YC,
-                  int LDYC, char * YR, int LDYR )
+void PB_Ctzahemv( PBTYP_T * TYPE, char * SIDE, char * UPLO, Int M, Int N,
+                  Int K, Int IOFFD, char * ALPHA, char * A, Int LDA,
+                  char * XC, Int LDXC, char * XR, Int LDXR, char * YC,
+                  Int LDYC, char * YR, Int LDYR )
 #else
 void PB_Ctzahemv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
                   LDXC, XR, LDXR, YC, LDYC, YR, LDYR )
@@ -28,7 +28,7 @@ void PB_Ctzahemv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -172,7 +172,7 @@ void PB_Ctzahemv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, ione=1, j1, m1, mn, n1, size, usiz;
+   Int            i1, ione=1, j1, m1, mn, n1, size, usiz;
    AGEMV_T        agemv;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzasymv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzasymv.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzasymv( PBTYP_T * TYPE, char * SIDE, char * UPLO, int M, int N,
-                  int K, int IOFFD, char * ALPHA, char * A, int LDA,
-                  char * XC, int LDXC, char * XR, int LDXR, char * YC,
-                  int LDYC, char * YR, int LDYR )
+void PB_Ctzasymv( PBTYP_T * TYPE, char * SIDE, char * UPLO, Int M, Int N,
+                  Int K, Int IOFFD, char * ALPHA, char * A, Int LDA,
+                  char * XC, Int LDXC, char * XR, Int LDXR, char * YC,
+                  Int LDYC, char * YR, Int LDYR )
 #else
 void PB_Ctzasymv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
                   LDXC, XR, LDXR, YC, LDYC, YR, LDYR )
@@ -28,7 +28,7 @@ void PB_Ctzasymv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -172,7 +172,7 @@ void PB_Ctzasymv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, ione=1, j1, m1, mn, n1, size, usiz;
+   Int            i1, ione=1, j1, m1, mn, n1, size, usiz;
    AGEMV_T        agemv;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzatrmv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzatrmv.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_Ctzatrmv( PBTYP_T * TYPE, char * SIDE, char * UPLO,
-                  char * TRANS, char * DIAG, int M, int N, int K,
-                  int IOFFD, char * ALPHA, char * A, int LDA, char * X,
-                  int LDX, char * Y, int LDY )
+                  char * TRANS, char * DIAG, Int M, Int N, Int K,
+                  Int IOFFD, char * ALPHA, char * A, Int LDA, char * X,
+                  Int LDX, char * Y, Int LDY )
 #else
 void PB_Ctzatrmv( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
                   A, LDA, X, LDX, Y, LDY )
@@ -28,7 +28,7 @@ void PB_Ctzatrmv( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
 *  .. Scalar Arguments ..
 */
    char               * SIDE, * UPLO, * TRANS, * DIAG;
-   int                IOFFD, K, LDA, LDX, LDY, M, N;
+   Int                IOFFD, K, LDA, LDX, LDY, M, N;
    char               * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -198,7 +198,7 @@ void PB_Ctzatrmv( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
 /*
 *  .. Local Scalars ..
 */
-   int                ione = 1;
+   Int                ione = 1;
    char               * Aptr = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzhemm.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzhemm.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzhemm( PBTYP_T * TYPE, char * SIDE, char * UPLO, int M, int N,
-                 int K, int IOFFD, char * ALPHA, char * A, int LDA,
-                 char * BC, int LDBC, char * BR, int LDBR, char * CC,
-                 int LDCC, char * CR, int LDCR )
+void PB_Ctzhemm( PBTYP_T * TYPE, char * SIDE, char * UPLO, Int M, Int N,
+                 Int K, Int IOFFD, char * ALPHA, char * A, Int LDA,
+                 char * BC, Int LDBC, char * BR, Int LDBR, char * CC,
+                 Int LDCC, char * CR, Int LDCR )
 #else
 void PB_Ctzhemm( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, BC,
                  LDBC, BR, LDBR, CC, LDCC, CR, LDCR )
@@ -28,7 +28,7 @@ void PB_Ctzhemm( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, BC,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IOFFD, K, LDA, LDBC, LDBR, LDCC, LDCR, M, N;
+   Int            IOFFD, K, LDA, LDBC, LDBR, LDCC, LDCR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -183,7 +183,7 @@ void PB_Ctzhemm( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, BC,
 *  .. Local Scalars ..
 */
    char           * Calph, * one, type;
-   int            i1, j1, m1, mn, n1, size;
+   Int            i1, j1, m1, mn, n1, size;
    cmplx          Calph8;
    cmplx16        Calph16;
    GEMM_T         gemm;

--- a/PBLAS/SRC/PTOOLS/PB_Ctzhemv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzhemv.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzhemv( PBTYP_T * TYPE, char * SIDE, char * UPLO, int M, int N,
-                 int K, int IOFFD, char * ALPHA, char * A, int LDA,
-                 char * XC, int LDXC, char * XR, int LDXR, char * YC,
-                 int LDYC, char * YR, int LDYR )
+void PB_Ctzhemv( PBTYP_T * TYPE, char * SIDE, char * UPLO, Int M, Int N,
+                 Int K, Int IOFFD, char * ALPHA, char * A, Int LDA,
+                 char * XC, Int LDXC, char * XR, Int LDXR, char * YC,
+                 Int LDYC, char * YR, Int LDYR )
 #else
 void PB_Ctzhemv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
                  LDXC, XR, LDXR, YC, LDYC, YR, LDYR )
@@ -28,7 +28,7 @@ void PB_Ctzhemv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -172,7 +172,7 @@ void PB_Ctzhemv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, ione=1, j1, m1, mn, n1, size;
+   Int            i1, ione=1, j1, m1, mn, n1, size;
    GEMV_T         gemv;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzher.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzher.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzher( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                int IOFFD, char * ALPHA, char * XC, int LDXC, char * XR,
-                int LDXR, char * A, int LDA )
+void PB_Ctzher( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                Int IOFFD, char * ALPHA, char * XC, Int LDXC, char * XR,
+                Int LDXR, char * A, Int LDA )
 #else
 void PB_Ctzher( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, XR, LDXR,
                A, LDA )
@@ -27,7 +27,7 @@ void PB_Ctzher( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, XR, LDXR,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -151,7 +151,7 @@ void PB_Ctzher( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, XR, LDXR,
 /*
 *  .. Local Scalars ..
 */
-   int            i1, ione=1, j1, m1, mn, n1, size;
+   Int            i1, ione=1, j1, m1, mn, n1, size;
    GERC_T         gerc;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzher2.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzher2.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzher2( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                 int IOFFD, char * ALPHA, char * XC, int LDXC,
-                 char * YC, int LDYC, char * XR, int LDXR, char * YR,
-                 int LDYR, char * A, int LDA )
+void PB_Ctzher2( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                 Int IOFFD, char * ALPHA, char * XC, Int LDXC,
+                 char * YC, Int LDYC, char * XR, Int LDXR, char * YR,
+                 Int LDYR, char * A, Int LDA )
 #else
 void PB_Ctzher2( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, YC, LDYC,
                  XR, LDXR, YR, LDYR, A, LDA )
@@ -28,7 +28,7 @@ void PB_Ctzher2( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, YC, LDYC,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -170,7 +170,7 @@ void PB_Ctzher2( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, YC, LDYC,
 /*
 *  .. Local Scalars ..
 */
-   int            i1, ione=1, j1, m1, mn, n1, size;
+   Int            i1, ione=1, j1, m1, mn, n1, size;
    char           * Calph, type;
    cmplx          Calph8;
    cmplx16        Calph16;

--- a/PBLAS/SRC/PTOOLS/PB_Ctzher2k.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzher2k.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzher2k( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                 int IOFFD, char * ALPHA, char * AC, int LDAC,
-                 char * BC, int LDBC, char * AR, int LDAR, char * BR,
-                 int LDBR, char * C, int LDC )
+void PB_Ctzher2k( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                 Int IOFFD, char * ALPHA, char * AC, Int LDAC,
+                 char * BC, Int LDBC, char * AR, Int LDAR, char * BR,
+                 Int LDBR, char * C, Int LDC )
 #else
 void PB_Ctzher2k( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, BC, LDBC,
                 AR, LDAR, BR, LDBR, C, LDC )
@@ -28,7 +28,7 @@ void PB_Ctzher2k( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, BC, LDBC,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDAC, LDAR, LDBC, LDBR, LDC, M, N;
+   Int            IOFFD, K, LDAC, LDAR, LDBC, LDBR, LDC, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -154,7 +154,7 @@ void PB_Ctzher2k( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, BC, LDBC,
 *  .. Local Scalars ..
 */
    char           * Calph, * one, type;
-   int            i1, j1, m1, mn, n1, size;
+   Int            i1, j1, m1, mn, n1, size;
    cmplx          Calph8;
    cmplx16        Calph16;
    GEMM_T         gemm;

--- a/PBLAS/SRC/PTOOLS/PB_Ctzherk.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzherk.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzherk( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                 int IOFFD, char * ALPHA, char * AC, int LDAC,
-                 char * AR, int LDAR, char * C, int LDC )
+void PB_Ctzherk( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                 Int IOFFD, char * ALPHA, char * AC, Int LDAC,
+                 char * AR, Int LDAR, char * C, Int LDC )
 #else
 void PB_Ctzherk( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, AR, LDAR,
                  C, LDC )
@@ -27,7 +27,7 @@ void PB_Ctzherk( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, AR, LDAR,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDAC, LDAR, LDC, M, N;
+   Int            IOFFD, K, LDAC, LDAR, LDC, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -153,7 +153,7 @@ void PB_Ctzherk( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, AR, LDAR,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, j1, m1, mn, n1, size;
+   Int            i1, j1, m1, mn, n1, size;
    GEMM_T         gemm;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzsymm.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzsymm.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzsymm( PBTYP_T * TYPE, char * SIDE, char * UPLO, int M, int N,
-                 int K, int IOFFD, char * ALPHA, char * A, int LDA,
-                 char * BC, int LDBC, char * BR, int LDBR, char * CC,
-                 int LDCC, char * CR, int LDCR )
+void PB_Ctzsymm( PBTYP_T * TYPE, char * SIDE, char * UPLO, Int M, Int N,
+                 Int K, Int IOFFD, char * ALPHA, char * A, Int LDA,
+                 char * BC, Int LDBC, char * BR, Int LDBR, char * CC,
+                 Int LDCC, char * CR, Int LDCR )
 #else
 void PB_Ctzsymm( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, BC,
                  LDBC, BR, LDBR, CC, LDCC, CR, LDCR )
@@ -28,7 +28,7 @@ void PB_Ctzsymm( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, BC,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IOFFD, K, LDA, LDBC, LDBR, LDCC, LDCR, M, N;
+   Int            IOFFD, K, LDA, LDBC, LDBR, LDCC, LDCR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -183,7 +183,7 @@ void PB_Ctzsymm( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, BC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, j1, m1, mn, n1, size;
+   Int            i1, j1, m1, mn, n1, size;
    GEMM_T         gemm;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzsymv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzsymv.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzsymv( PBTYP_T * TYPE, char * SIDE, char * UPLO, int M, int N,
-                 int K, int IOFFD, char * ALPHA, char * A, int LDA,
-                 char * XC, int LDXC, char * XR, int LDXR, char * YC,
-                 int LDYC, char * YR, int LDYR )
+void PB_Ctzsymv( PBTYP_T * TYPE, char * SIDE, char * UPLO, Int M, Int N,
+                 Int K, Int IOFFD, char * ALPHA, char * A, Int LDA,
+                 char * XC, Int LDXC, char * XR, Int LDXR, char * YC,
+                 Int LDYC, char * YR, Int LDYR )
 #else
 void PB_Ctzsymv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
                  LDXC, XR, LDXR, YC, LDYC, YR, LDYR )
@@ -28,7 +28,7 @@ void PB_Ctzsymv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Scalar Arguments ..
 */
    char           * SIDE, * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -172,7 +172,7 @@ void PB_Ctzsymv( TYPE, SIDE, UPLO, M, N, K, IOFFD, ALPHA, A, LDA, XC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, ione=1, j1, m1, mn, n1, size;
+   Int            i1, ione=1, j1, m1, mn, n1, size;
    GEMV_T         gemv;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzsyr.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzsyr.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzsyr( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                int IOFFD, char * ALPHA, char * XC, int LDXC, char * XR,
-                int LDXR, char * A, int LDA )
+void PB_Ctzsyr( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                Int IOFFD, char * ALPHA, char * XC, Int LDXC, char * XR,
+                Int LDXR, char * A, Int LDA )
 #else
 void PB_Ctzsyr( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, XR, LDXR,
                 A, LDA )
@@ -27,7 +27,7 @@ void PB_Ctzsyr( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, XR, LDXR,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -151,7 +151,7 @@ void PB_Ctzsyr( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, XR, LDXR,
 /*
 *  .. Local Scalars ..
 */
-   int            i1, ione=1, j1, m1, mn, n1, size;
+   Int            i1, ione=1, j1, m1, mn, n1, size;
    GERU_T         geru;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzsyr2.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzsyr2.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzsyr2( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                 int IOFFD, char * ALPHA, char * XC, int LDXC,
-                 char * YC, int LDYC, char * XR, int LDXR, char * YR,
-                 int LDYR, char * A, int LDA )
+void PB_Ctzsyr2( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                 Int IOFFD, char * ALPHA, char * XC, Int LDXC,
+                 char * YC, Int LDYC, char * XR, Int LDXR, char * YR,
+                 Int LDYR, char * A, Int LDA )
 #else
 void PB_Ctzsyr2( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, YC, LDYC,
                  XR, LDXR, YR, LDYR, A, LDA )
@@ -28,7 +28,7 @@ void PB_Ctzsyr2( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, YC, LDYC,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
+   Int            IOFFD, K, LDA, LDXC, LDXR, LDYC, LDYR, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -170,7 +170,7 @@ void PB_Ctzsyr2( TYPE, UPLO, M, N, K, IOFFD, ALPHA, XC, LDXC, YC, LDYC,
 /*
 *  .. Local Scalars ..
 */
-   int            i1, ione=1, j1, m1, mn, n1, size;
+   Int            i1, ione=1, j1, m1, mn, n1, size;
    GERU_T         geru;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzsyr2k.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzsyr2k.c
@@ -17,10 +17,10 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzsyr2k( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                 int IOFFD, char * ALPHA, char * AC, int LDAC,
-                 char * BC, int LDBC, char * AR, int LDAR, char * BR,
-                 int LDBR, char * C, int LDC )
+void PB_Ctzsyr2k( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                 Int IOFFD, char * ALPHA, char * AC, Int LDAC,
+                 char * BC, Int LDBC, char * AR, Int LDAR, char * BR,
+                 Int LDBR, char * C, Int LDC )
 #else
 void PB_Ctzsyr2k( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, BC, LDBC,
                 AR, LDAR, BR, LDBR, C, LDC )
@@ -28,7 +28,7 @@ void PB_Ctzsyr2k( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, BC, LDBC,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDAC, LDAR, LDBC, LDBR, LDC, M, N;
+   Int            IOFFD, K, LDAC, LDAR, LDBC, LDBR, LDC, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -171,7 +171,7 @@ void PB_Ctzsyr2k( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, BC, LDBC,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, j1, m1, mn, n1, size;
+   Int            i1, j1, m1, mn, n1, size;
    GEMM_T         gemm;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctzsyrk.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctzsyrk.c
@@ -17,9 +17,9 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_Ctzsyrk( PBTYP_T * TYPE, char * UPLO, int M, int N, int K,
-                 int IOFFD, char * ALPHA, char * AC, int LDAC,
-                 char * AR, int LDAR, char * C, int LDC )
+void PB_Ctzsyrk( PBTYP_T * TYPE, char * UPLO, Int M, Int N, Int K,
+                 Int IOFFD, char * ALPHA, char * AC, Int LDAC,
+                 char * AR, Int LDAR, char * C, Int LDC )
 #else
 void PB_Ctzsyrk( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, AR, LDAR,
                  C, LDC )
@@ -27,7 +27,7 @@ void PB_Ctzsyrk( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, AR, LDAR,
 *  .. Scalar Arguments ..
 */
    char           * UPLO;
-   int            IOFFD, K, LDAC, LDAR, LDC, M, N;
+   Int            IOFFD, K, LDAC, LDAR, LDC, M, N;
    char           * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -153,7 +153,7 @@ void PB_Ctzsyrk( TYPE, UPLO, M, N, K, IOFFD, ALPHA, AC, LDAC, AR, LDAR,
 *  .. Local Scalars ..
 */
    char           * one;
-   int            i1, j1, m1, mn, n1, size;
+   Int            i1, j1, m1, mn, n1, size;
    GEMM_T         gemm;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctztrmm.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctztrmm.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_Ctztrmm( PBTYP_T * TYPE, char * SIDE, char * UPLO, char * TRANS,
-                 char * DIAG, int M, int N, int K, int IOFFD,
-                 char * ALPHA, char * A, int LDA, char * B, int LDB,
-                 char * C, int LDC )
+                 char * DIAG, Int M, Int N, Int K, Int IOFFD,
+                 char * ALPHA, char * A, Int LDA, char * B, Int LDB,
+                 char * C, Int LDC )
 #else
 void PB_Ctztrmm( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
                  A, LDA, B, LDB, C, LDC )
@@ -28,7 +28,7 @@ void PB_Ctztrmm( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
 *  .. Scalar Arguments ..
 */
    char               * SIDE, * UPLO, * TRANS, * DIAG;
-   int                IOFFD, K, LDA, LDB, LDC, M, N;
+   Int                IOFFD, K, LDA, LDB, LDC, M, N;
    char               * ALPHA;
 /*
 *  .. Array Arguments ..

--- a/PBLAS/SRC/PTOOLS/PB_Ctztrmv.c
+++ b/PBLAS/SRC/PTOOLS/PB_Ctztrmv.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void PB_Ctztrmv( PBTYP_T * TYPE, char * SIDE, char * UPLO, char * TRANS,
-                 char * DIAG, int M, int N, int K, int IOFFD,
-                 char * ALPHA, char * A, int LDA, char * X, int LDX,
-                 char * Y, int LDY )
+                 char * DIAG, Int M, Int N, Int K, Int IOFFD,
+                 char * ALPHA, char * A, Int LDA, char * X, Int LDX,
+                 char * Y, Int LDY )
 #else
 void PB_Ctztrmv( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
                  A, LDA, X, LDX, Y, LDY )
@@ -28,7 +28,7 @@ void PB_Ctztrmv( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
 *  .. Scalar Arguments ..
 */
    char               * SIDE, * UPLO, * TRANS, * DIAG;
-   int                IOFFD, K, LDA, LDX, LDY, M, N;
+   Int                IOFFD, K, LDA, LDX, LDY, M, N;
    char               * ALPHA;
 /*
 *  .. Array Arguments ..
@@ -186,7 +186,7 @@ void PB_Ctztrmv( TYPE, SIDE, UPLO, TRANS, DIAG, M, N, K, IOFFD, ALPHA,
 /*
 *  .. Local Scalars ..
 */
-   int                ione = 1;
+   Int                ione = 1;
    char               * Aptr = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/PTOOLS/PB_Cwarn.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cwarn.c
@@ -58,7 +58,7 @@
 #endif
 
 #ifdef __STDC__
-void PB_Cwarn( int ICTXT, int LINE, char * ROUT, char * FORM, ... )
+void PB_Cwarn( Int ICTXT, Int LINE, char * ROUT, char * FORM, ... )
 #else
 void PB_Cwarn( va_alist )
 va_dcl
@@ -103,16 +103,16 @@ va_dcl
 *  ---------------------------------------------------------------------
 */
    va_list        argptr;
-   int            iam, mycol, myrow, npcol, nprow;
+   Int            iam, mycol, myrow, npcol, nprow;
    char           cline[100];
 /* ..
 *  .. External Functions ..
 */
 #ifdef TestingPblas
 #ifdef __STDC__
-   int            PB_NoAbort( int * );
+   Int            PB_NoAbort( Int * );
 #else
-   int            PB_NoAbort();
+   Int            PB_NoAbort();
 #endif
 #endif
 
@@ -120,14 +120,14 @@ va_dcl
    va_start( argptr, FORM );
 #else
    char           * ROUT, * FORM;
-   int            ICTXT, LINE;
+   Int            ICTXT, LINE;
 /* ..
 *  .. Executable Statements ..
 *
 */
    va_start( argptr );
-   ICTXT = va_arg( argptr, int );
-   LINE  = va_arg( argptr, int );
+   ICTXT = va_arg( argptr, Int );
+   LINE  = va_arg( argptr, Int );
    ROUT  = va_arg( argptr, char * );
    FORM  = va_arg( argptr, char * );
 #endif

--- a/PBLAS/SRC/PTOOLS/PB_Cztypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cztypeset.c
@@ -34,7 +34,7 @@ PBTYP_T * PB_Cztypeset()
 /*
 *  .. Local Scalars ..
 */
-   static int     setup=0;
+   static Int     setup=0;
    static PBTYP_T TypeStruct;
    static cmplx16 zero, one, negone;
 /* ..

--- a/PBLAS/SRC/PTOOLS/PB_topget_.c
+++ b/PBLAS/SRC/PTOOLS/PB_topget_.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_topget_( int * ICTXT, F_CHAR_T OP, F_CHAR_T SCOPE, F_CHAR_T TOP )
+void PB_topget_( Int * ICTXT, F_CHAR_T OP, F_CHAR_T SCOPE, F_CHAR_T TOP )
 #else
 void PB_topget_( ICTXT, OP, SCOPE, TOP )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * ICTXT;
+   Int            * ICTXT;
 /*
 *  .. Array Arguments ..
 */

--- a/PBLAS/SRC/PTOOLS/PB_topset_.c
+++ b/PBLAS/SRC/PTOOLS/PB_topset_.c
@@ -17,13 +17,13 @@
 #include "../PBblas.h"
 
 #ifdef __STDC__
-void PB_topset_( int * ICTXT, F_CHAR_T OP, F_CHAR_T SCOPE, F_CHAR_T TOP )
+void PB_topset_( Int * ICTXT, F_CHAR_T OP, F_CHAR_T SCOPE, F_CHAR_T TOP )
 #else
 void PB_topset_( ICTXT, OP, SCOPE, TOP )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * ICTXT;
+   Int            * ICTXT;
 /*
 *  .. Array Arguments ..
 */

--- a/PBLAS/SRC/pblas.h
+++ b/PBLAS/SRC/pblas.h
@@ -101,6 +101,10 @@
 *  TYPE DEFINITIONS AND CONVERSION UTILITIES
 *  ---------------------------------------------------------------------
 */
+#ifndef Int
+#define Int int
+#endif
+
 #if( ( _MACH_ == _T3D_ ) || ( _MACH_ == _T3E_ ) )
 
 #define    float               double
@@ -111,7 +115,7 @@
 #define    C2F_CHAR(a)         ( _cptofcd( (a), 1 ) )
                                          /* Type of FORTRAN functions */
 #define    F_VOID_FCT          void   fortran           /* Subroutine */
-#define    F_INTG_FCT          int    fortran     /* INTEGER function */
+#define    F_INTG_FCT          Int    fortran     /* INTEGER function */
 
 #else                 /* Type of character argument in a FORTRAN call */
 
@@ -121,7 +125,7 @@ typedef    char *              F_CHAR_T;
 #define    C2F_CHAR(a)            (a)
                                          /* Type of FORTRAN functions */
 #define    F_VOID_FCT             void                  /* Subroutine */
-#define    F_INTG_FCT             int             /* INTEGER function */
+#define    F_INTG_FCT             Int             /* INTEGER function */
 
 #endif
 /*
@@ -137,141 +141,141 @@ typedef    double              cmplx16[2];
 
 #ifdef __STDC__
 
-typedef void           (*GESD2D_T)   ( int,       int,       int,
-                                       char *,    int,       int,
-                                       int );
-typedef void           (*GERV2D_T)   ( int,       int,       int,
-                                       char *,    int,       int,
-                                       int );
-typedef void           (*GEBS2D_T)   ( int,       char *,    char *,
-                                       int,       int,       char *,
-                                       int );
-typedef void           (*GEBR2D_T)   ( int,       char *,    char *,
-                                       int,       int,       char *,
-                                       int,       int,       int );
-typedef void           (*GSUM2D_T)   ( int,       char *,    char *,
-                                       int,       int,       char *,
-                                       int,       int,       int );
+typedef void           (*GESD2D_T)   ( Int,       Int,       Int,
+                                       char *,    Int,       Int,
+                                       Int );
+typedef void           (*GERV2D_T)   ( Int,       Int,       Int,
+                                       char *,    Int,       Int,
+                                       Int );
+typedef void           (*GEBS2D_T)   ( Int,       char *,    char *,
+                                       Int,       Int,       char *,
+                                       Int );
+typedef void           (*GEBR2D_T)   ( Int,       char *,    char *,
+                                       Int,       Int,       char *,
+                                       Int,       Int,       Int );
+typedef void           (*GSUM2D_T)   ( Int,       char *,    char *,
+                                       Int,       Int,       char *,
+                                       Int,       Int,       Int );
 
-typedef F_VOID_FCT     (*MMADD_T)    ( int  *,    int  *,    char *,
-                                       char *,    int  *,    char *,
-                                       char *,    int  * );
-typedef F_VOID_FCT     (*MMSHFT_T)   ( int  *,    int  *,    int *,
-                                       char *,    int  * );
-typedef F_VOID_FCT     (*VVDOT_T)    ( int  *,    char *,    char *,
-                                       int  *,    char *,    int  * );
-typedef F_VOID_FCT     (*VVSET_T)    ( int  *,    char *,    char *,
-                                       int  * );
-typedef F_VOID_FCT     (*TZPAD_T)    ( F_CHAR_T,  F_CHAR_T,  int  *,
-                                       int  *,    int  *,    char *,
-                                       char *,    char *,    int  * );
-typedef F_VOID_FCT     (*TZPADCPY_T) ( F_CHAR_T,  F_CHAR_T,  int  *,
-                                       int  *,    int  *,    char *,
-                                       int *,     char *,    int  * );
-typedef F_VOID_FCT     (*TZSET_T)    ( F_CHAR_T,  int  *,    int  *,
-                                       int  *,    char *,    char *,
-                                       char *,    int  * );
-typedef F_VOID_FCT     (*TZSCAL_T)   ( F_CHAR_T,  int *,     int  *,
-                                       int  *,    char *,    char *,
-                                       int  * );
+typedef F_VOID_FCT     (*MMADD_T)    ( Int  *,    Int  *,    char *,
+                                       char *,    Int  *,    char *,
+                                       char *,    Int  * );
+typedef F_VOID_FCT     (*MMSHFT_T)   ( Int  *,    Int  *,    Int *,
+                                       char *,    Int  * );
+typedef F_VOID_FCT     (*VVDOT_T)    ( Int  *,    char *,    char *,
+                                       Int  *,    char *,    Int  * );
+typedef F_VOID_FCT     (*VVSET_T)    ( Int  *,    char *,    char *,
+                                       Int  * );
+typedef F_VOID_FCT     (*TZPAD_T)    ( F_CHAR_T,  F_CHAR_T,  Int  *,
+                                       Int  *,    Int  *,    char *,
+                                       char *,    char *,    Int  * );
+typedef F_VOID_FCT     (*TZPADCPY_T) ( F_CHAR_T,  F_CHAR_T,  Int  *,
+                                       Int  *,    Int  *,    char *,
+                                       Int *,     char *,    Int  * );
+typedef F_VOID_FCT     (*TZSET_T)    ( F_CHAR_T,  Int  *,    Int  *,
+                                       Int  *,    char *,    char *,
+                                       char *,    Int  * );
+typedef F_VOID_FCT     (*TZSCAL_T)   ( F_CHAR_T,  Int *,     Int  *,
+                                       Int  *,    char *,    char *,
+                                       Int  * );
 
-typedef F_VOID_FCT     (*AXPY_T)     ( int *,     char *,    char *,
-                                       int *,     char *,    int * );
-typedef F_VOID_FCT     (*COPY_T)     ( int *,     char *,    int *,
-                                       char *,    int * );
-typedef F_VOID_FCT     (*SWAP_T)     ( int *,     char *,    int *,
-                                       char *,    int * );
+typedef F_VOID_FCT     (*AXPY_T)     ( Int *,     char *,    char *,
+                                       Int *,     char *,    Int * );
+typedef F_VOID_FCT     (*COPY_T)     ( Int *,     char *,    Int *,
+                                       char *,    Int * );
+typedef F_VOID_FCT     (*SWAP_T)     ( Int *,     char *,    Int *,
+                                       char *,    Int * );
 
-typedef F_VOID_FCT     (*GEMV_T)     ( F_CHAR_T,  int *,     int *,
-                                       char *,    char *,    int *,
-                                       char *,    int *,     char *,
-                                       char *,    int * );
-typedef F_VOID_FCT     (*AGEMV_T)    ( F_CHAR_T,  int *,     int *,
-                                       char *,    char *,    int *,
-                                       char *,    int *,     char *,
-                                       char *,    int * );
-typedef F_VOID_FCT     (*SYMV_T)     ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    char *,
-                                       int * );
-typedef F_VOID_FCT     (*ASYMV_T)    ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    char *,
-                                       int * );
-typedef F_VOID_FCT     (*HEMV_T)     ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    char *,
-                                       int * );
-typedef F_VOID_FCT     (*AHEMV_T)    ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    char *,
-                                       int * );
+typedef F_VOID_FCT     (*GEMV_T)     ( F_CHAR_T,  Int *,     Int *,
+                                       char *,    char *,    Int *,
+                                       char *,    Int *,     char *,
+                                       char *,    Int * );
+typedef F_VOID_FCT     (*AGEMV_T)    ( F_CHAR_T,  Int *,     Int *,
+                                       char *,    char *,    Int *,
+                                       char *,    Int *,     char *,
+                                       char *,    Int * );
+typedef F_VOID_FCT     (*SYMV_T)     ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
+typedef F_VOID_FCT     (*ASYMV_T)    ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
+typedef F_VOID_FCT     (*HEMV_T)     ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
+typedef F_VOID_FCT     (*AHEMV_T)    ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
 typedef F_VOID_FCT     (*TRMV_T)     ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                       int *,     char *,    int *,
-                                       char *,    int * );
+                                       Int *,     char *,    Int *,
+                                       char *,    Int * );
 typedef F_VOID_FCT     (*ATRMV_T)    ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    int *,
-                                       char *,    char *,    int * );
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    Int *,
+                                       char *,    char *,    Int * );
 typedef F_VOID_FCT     (*TRSV_T)     ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                       int *,     char *,    int *,
-                                       char *,    int * );
-typedef F_VOID_FCT     (*GERC_T)     ( int *,     int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    int * );
-typedef F_VOID_FCT     (*GERU_T)     ( int *,     int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    int * );
-typedef F_VOID_FCT     (*SYR_T)      ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int * );
-typedef F_VOID_FCT     (*HER_T)      ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int * );
-typedef F_VOID_FCT     (*SYR2_T)     ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    int * );
-typedef F_VOID_FCT     (*HER2_T)     ( F_CHAR_T,  int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    int * );
+                                       Int *,     char *,    Int *,
+                                       char *,    Int * );
+typedef F_VOID_FCT     (*GERC_T)     ( Int *,     Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    Int * );
+typedef F_VOID_FCT     (*GERU_T)     ( Int *,     Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    Int * );
+typedef F_VOID_FCT     (*SYR_T)      ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int * );
+typedef F_VOID_FCT     (*HER_T)      ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int * );
+typedef F_VOID_FCT     (*SYR2_T)     ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    Int * );
+typedef F_VOID_FCT     (*HER2_T)     ( F_CHAR_T,  Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    Int * );
 
-typedef F_VOID_FCT     (*GEMM_T)     ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     int *,     char *,
-                                       char *,    int *,     char *,
-                                       int *,     char *,    char *,
-                                       int * );
-typedef F_VOID_FCT     (*SYMM_T)     ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    int *,
-                                       char *,    char *,    int * );
-typedef F_VOID_FCT     (*HEMM_T)     ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    int *,
-                                       char *,    char *,    int * );
-typedef F_VOID_FCT     (*SYRK_T)     ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    char *,
-                                       int * );
-typedef F_VOID_FCT     (*HERK_T)     ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    char *,
-                                       int * );
-typedef F_VOID_FCT     (*SYR2K_T)    ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    int *,
-                                       char *,    char *,    int * );
-typedef F_VOID_FCT     (*HER2K_T)    ( F_CHAR_T,  F_CHAR_T,  int *,
-                                       int *,     char *,    char *,
-                                       int *,     char *,    int *,
-                                       char *,    char *,    int * );
+typedef F_VOID_FCT     (*GEMM_T)     ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     Int *,     char *,
+                                       char *,    Int *,     char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
+typedef F_VOID_FCT     (*SYMM_T)     ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    Int *,
+                                       char *,    char *,    Int * );
+typedef F_VOID_FCT     (*HEMM_T)     ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    Int *,
+                                       char *,    char *,    Int * );
+typedef F_VOID_FCT     (*SYRK_T)     ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
+typedef F_VOID_FCT     (*HERK_T)     ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    char *,
+                                       Int * );
+typedef F_VOID_FCT     (*SYR2K_T)    ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    Int *,
+                                       char *,    char *,    Int * );
+typedef F_VOID_FCT     (*HER2K_T)    ( F_CHAR_T,  F_CHAR_T,  Int *,
+                                       Int *,     char *,    char *,
+                                       Int *,     char *,    Int *,
+                                       char *,    char *,    Int * );
 typedef F_VOID_FCT     (*TRMM_T)     ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                       F_CHAR_T,  int *,     int *,
-                                       char *,    char *,    int *,
-                                       char *,    int * );
+                                       F_CHAR_T,  Int *,     Int *,
+                                       char *,    char *,    Int *,
+                                       char *,    Int * );
 typedef F_VOID_FCT     (*TRSM_T)     ( F_CHAR_T,  F_CHAR_T,  F_CHAR_T,
-                                       F_CHAR_T,  int *,     int *,
-                                       char *,    char *,    int *,
-                                       char *,    int * );
+                                       F_CHAR_T,  Int *,     Int *,
+                                       char *,    char *,    Int *,
+                                       char *,    Int * );
 
 #else
 
@@ -325,8 +329,8 @@ typedef F_VOID_FCT     (*TRSM_T)     ();
 typedef struct
 {
    char           type;                  /* Encoding of the data type */
-   int            usiz;    /* length in bytes of elementary data type */
-   int            size;               /* length in bytes of data type */
+   Int            usiz;    /* length in bytes of elementary data type */
+   Int            size;               /* length in bytes of data type */
 
    char           * zero,
                   * one,
@@ -397,29 +401,29 @@ typedef struct
 
 #ifdef __STDC__
 
-typedef void           (*TZSYR_T)    ( PBTYP_T *, char *,    int,
-                                       int,       int,       int,
-                                       char *,    char *,    int,
-                                       char *,    int,       char *,
-                                       int );
-typedef void           (*TZSYR2_T)   ( PBTYP_T *, char *,    int,
-                                       int,       int,       int,
-                                       char *,    char *,    int,
-                                       char *,    int,       char *,
-                                       int,       char *,    int,
-                                       char *,    int );
+typedef void           (*TZSYR_T)    ( PBTYP_T *, char *,    Int,
+                                       Int,       Int,       Int,
+                                       char *,    char *,    Int,
+                                       char *,    Int,       char *,
+                                       Int );
+typedef void           (*TZSYR2_T)   ( PBTYP_T *, char *,    Int,
+                                       Int,       Int,       Int,
+                                       char *,    char *,    Int,
+                                       char *,    Int,       char *,
+                                       Int,       char *,    Int,
+                                       char *,    Int );
 typedef void           (*TZTRM_T)    ( PBTYP_T *, char *,    char *,
-                                       char *,    char *,    int,
-                                       int,       int,       int,
-                                       char *,    char *,    int,
-                                       char *,    int,       char *,
-                                       int );
+                                       char *,    char *,    Int,
+                                       Int,       Int,       Int,
+                                       char *,    char *,    Int,
+                                       char *,    Int,       char *,
+                                       Int );
 typedef void           (*TZSYM_T)    ( PBTYP_T *, char *,    char *,
-                                       int,       int,       int,
-                                       int,       char *,    char *,
-                                       int,       char *,    int,
-                                       char *,    int,       char *,
-                                       int,       char *,    int );
+                                       Int,       Int,       Int,
+                                       Int,       char *,    char *,
+                                       Int,       char *,    Int,
+                                       char *,    Int,       char *,
+                                       Int,       char *,    Int );
 #else
 
 typedef void           (*TZSYR_T)    ();
@@ -431,32 +435,32 @@ typedef void           (*TZSYM_T)    ();
 
 typedef struct
 {
-   int offd;                                /* Global diagonal offset */
-   int lcmt00;                            /* LCM value of first block */
+   Int offd;                                /* Global diagonal offset */
+   Int lcmt00;                            /* LCM value of first block */
 
-   int mp;                                    /* Local number of rows */
-   int imb1;                      /* Size of first row block (global) */
-   int imbloc;                       /* Size of first local row block */
-   int mb;                                          /* Row block size */
-   int lmbloc;                        /* Size of last local row block */
-   int mblks;                           /* Number of local row blocks */
-   int iupp;                /* LCM row bound for first diagonal block */
-   int upp;                       /* LCM row bound for diagonal block */
-   int prow;                       /* Relative row process coordinate */
-   int nprow;                               /* Number of process rows */
+   Int mp;                                    /* Local number of rows */
+   Int imb1;                      /* Size of first row block (global) */
+   Int imbloc;                       /* Size of first local row block */
+   Int mb;                                          /* Row block size */
+   Int lmbloc;                        /* Size of last local row block */
+   Int mblks;                           /* Number of local row blocks */
+   Int iupp;                /* LCM row bound for first diagonal block */
+   Int upp;                       /* LCM row bound for diagonal block */
+   Int prow;                       /* Relative row process coordinate */
+   Int nprow;                               /* Number of process rows */
 
-   int nq;                                 /* Local number of columns */
-   int inb1;                   /* Size of first column block (global) */
-   int inbloc;                    /* Size of first local column block */
-   int nb;                                       /* Column block size */
-   int lnbloc;                     /* Size of last local column block */
-   int nblks;                        /* Number of local column blocks */
-   int ilow;             /* LCM column bound for first diagonal block */
-   int low;                    /* LCM column bound for diagonal block */
-   int pcol;                    /* Relative column process coordinate */
-   int npcol;                            /* Number of process columns */
+   Int nq;                                 /* Local number of columns */
+   Int inb1;                   /* Size of first column block (global) */
+   Int inbloc;                    /* Size of first local column block */
+   Int nb;                                       /* Column block size */
+   Int lnbloc;                     /* Size of last local column block */
+   Int nblks;                        /* Number of local column blocks */
+   Int ilow;             /* LCM column bound for first diagonal block */
+   Int low;                    /* LCM column bound for diagonal block */
+   Int pcol;                    /* Relative column process coordinate */
+   Int npcol;                            /* Number of process columns */
 
-   int lcmb;    /* Least common multiple of nprow * mb and npcol * nb */
+   Int lcmb;    /* Least common multiple of nprow * mb and npcol * nb */
 
 } PB_VM_T;
 

--- a/PBLAS/SRC/pcagemv_.c
+++ b/PBLAS/SRC/pcagemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcagemv_( F_CHAR_T TRANS, int * M, int * N, float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pcagemv_( F_CHAR_T TRANS, Int * M, Int * N, float * ALPHA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                float * BETA,
-               float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pcagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -259,7 +259,7 @@ void pcagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * one, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -267,7 +267,7 @@ void pcagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pcahemv_.c
+++ b/PBLAS/SRC/pcahemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcahemv_( F_CHAR_T UPLO, int * N, float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pcahemv_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                float * BETA,
-               float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pcahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -248,7 +248,7 @@ void pcahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
                   Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld, Xi, Xj,
                   YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum, YRld, Ycol, Yi,
                   Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1,
@@ -259,7 +259,7 @@ void pcahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr  = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR    = NULL;

--- a/PBLAS/SRC/pcamax_.c
+++ b/PBLAS/SRC/pcamax_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcamax_( int * N, float * AMAX, int * INDX,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pcamax_( Int * N, float * AMAX, Int * INDX,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pcamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INDX, * IX, * JX, * N;
+   Int            * INCX, * INDX, * IX, * JX, * N;
    float          * AMAX;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -181,7 +181,7 @@ void pcamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           cbtop, cctop, rbtop, rctop;
-   int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
+   Int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
                   Xnb, Xnp, Xnq, Xrow, Xsrc, ctxt, dist, dst, idumm, info, k,
                   maxpos, mycol, mydist, myrow, npcol, nprow, src, size;
    PBTYP_T        * type;
@@ -189,7 +189,7 @@ void pcamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 *  .. Local Arrays ..
 */
    char           * Xptr;
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    cmplx          work[4];
 /* ..
 *  .. Executable Statements ..
@@ -347,7 +347,7 @@ l_20:
             AMAX[IMAG_PART] = work[0][IMAG_PART];
             *INDX = ( ( ( AMAX[REAL_PART] == ZERO ) &&
                         ( AMAX[IMAG_PART] == ZERO ) ) ?
-                    ( *JX ) : ( (int)(work[1][REAL_PART]) ) );
+                    ( *JX ) : ( (Int)(work[1][REAL_PART]) ) );
          }
          else
          {
@@ -530,7 +530,7 @@ l_40:
             AMAX[IMAG_PART] = work[0][IMAG_PART];
             *INDX = ( ( ( AMAX[REAL_PART] == ZERO ) &&
                         ( AMAX[IMAG_PART] == ZERO ) ) ?
-                    ( *IX ) : ( (int)(work[1][REAL_PART]) ) );
+                    ( *IX ) : ( (Int)(work[1][REAL_PART]) ) );
          }
          else
          {

--- a/PBLAS/SRC/pcatrmv_.c
+++ b/PBLAS/SRC/pcatrmv_.c
@@ -17,13 +17,13 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
+void pcatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
-               float * X, int * IX, int * JX, int * DESCX,
-               int * INCX, float * BETA,
-               float * Y, int * IY, int * JY, int * DESCY,
-               int * INCY )
+               float * A, Int * IA, Int * JA, Int * DESCA,
+               float * X, Int * IX, Int * JX, Int * DESCX,
+               Int * INCX, float * BETA,
+               float * Y, Int * IY, Int * JY, Int * DESCY,
+               Int * INCY )
 #else
 void pcatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
                JX, DESCX, INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -31,13 +31,13 @@ void pcatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -281,7 +281,7 @@ void pcatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Yroc, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xi, Xj, YAfr,
                   YAld, YApbY, YAsum, Ycol, Yi, Yii, Yj, Yjj, Yld, Ynp, Ynq,
                   Yrow, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
@@ -291,7 +291,7 @@ void pcatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pcaxpy_.c
+++ b/PBLAS/SRC/pcaxpy_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcaxpy_( int * N,
+void pcaxpy_( Int * N,
               float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -186,12 +186,12 @@ void pcaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pccopy_.c
+++ b/PBLAS/SRC/pccopy_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pccopy_( int * N,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pccopy_( Int * N,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pccopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -177,12 +177,12 @@ void pccopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcdotc_.c
+++ b/PBLAS/SRC/pcdotc_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcdotc_( int * N,
+void pcdotc_( Int * N,
               float * DOT,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcdotc_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    float          * DOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -206,7 +206,7 @@ void pcdotc_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
                   Xinb1D, XisD, XisR, XisRow, Xj, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xrow, Ycol, Yi, Yii, YinbD, Yinb1D, YisD, YisR, YisRow, Yj,
@@ -219,7 +219,7 @@ void pcdotc_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Arrays ..
 */
    char           * buf = NULL;
-   int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
+   Int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcdotu_.c
+++ b/PBLAS/SRC/pcdotu_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcdotu_( int * N,
+void pcdotu_( Int * N,
               float * DOT,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcdotu_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    float          * DOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -206,7 +206,7 @@ void pcdotu_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
                   Xinb1D, XisD, XisR, XisRow, Xj, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xrow, Ycol, Yi, Yii, YinbD, Yinb1D, YisD, YisR, YisRow, Yj,
@@ -219,7 +219,7 @@ void pcdotu_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Arrays ..
 */
    char           * buf = NULL;
-   int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
+   Int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcgeadd_.c
+++ b/PBLAS/SRC/pcgeadd_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcgeadd_( F_CHAR_T TRANS, int * M, int * N,
+void pcgeadd_( F_CHAR_T TRANS, Int * M, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
                float * BETA,
-               float * C, int * IC, int * JC, int * DESCC )
+               float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -202,12 +202,12 @@ void pcgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 *  .. Local Scalars ..
 */
    char           DirA, DirC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
+   Int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
                   notran;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcgemm_.c
+++ b/PBLAS/SRC/pcgemm_.c
@@ -18,12 +18,12 @@
 
 #ifdef __STDC__
 void pcgemm_( F_CHAR_T TRANSA, F_CHAR_T TRANSB,
-              int * M, int * N, int * K,
+              Int * M, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -31,12 +31,12 @@ void pcgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANSA, TRANSB;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -244,14 +244,14 @@ void pcgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, DirBC, OpC, OpR, TrA, TrB, ctop, ctopsave, rtop,
                   rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
                   info, mycol, myrow, nb, nota, notb, npcol, nprow;
    double         ABest, ACest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcgemv_.c
+++ b/PBLAS/SRC/pcgemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcgemv_( F_CHAR_T TRANS, int * M, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pcgemv_( F_CHAR_T TRANS, Int * M, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               float * BETA,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pcgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -250,7 +250,7 @@ void pcgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -258,7 +258,7 @@ void pcgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pcgerc_.c
+++ b/PBLAS/SRC/pcgerc_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcgerc_( int * M, int * N, float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              float * A, int * IA, int * JA, int * DESCA )
+void pcgerc_( Int * M, Int * N, float * ALPHA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pcgerc_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
               INCY, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -216,14 +216,14 @@ void pcgerc_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, Yi, Yj, ctxt, info, ione=1,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd[DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pcgeru_.c
+++ b/PBLAS/SRC/pcgeru_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcgeru_( int * M, int * N, float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              float * A, int * IA, int * JA, int * DESCA )
+void pcgeru_( Int * M, Int * N, float * ALPHA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pcgeru_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
               INCY, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -216,14 +216,14 @@ void pcgeru_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, Yi, Yj, ctxt, info, ione=1,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd[DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pchemm_.c
+++ b/PBLAS/SRC/pchemm_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pchemm_( F_CHAR_T SIDE, F_CHAR_T UPLO, int * M, int * N,
+void pchemm_( F_CHAR_T SIDE, F_CHAR_T UPLO, Int * M, Int * N,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pchemm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pchemm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       SIDE, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -264,14 +264,14 @@ void pchemm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, SideOp, UploA, cbtop, cbtopsave, cctop, cctopsave,
                   rbtop, rbtopsave, rctop, rctopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   lside, mycol, myrow, nb, npcol, nprow, upper;
    double         ABCest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pchemv_.c
+++ b/PBLAS/SRC/pchemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pchemv_( F_CHAR_T UPLO, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pchemv_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               float * BETA,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pchemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pchemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -246,7 +246,7 @@ void pchemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum,
                   YRld, Ycol, Yi, Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow,
@@ -257,7 +257,7 @@ void pchemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pcher2_.c
+++ b/PBLAS/SRC/pcher2_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcher2_( F_CHAR_T UPLO, int * N, float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              float * A, int * IA, int * JA, int * DESCA )
+void pcher2_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pcher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
               DESCY, INCY, A, IA, JA, DESCA )
@@ -28,13 +28,13 @@ void pcher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -246,7 +246,7 @@ void pcher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCld, YRfr, YRld, Yi, Yj, ctxt, info, ione=1,
                   k, kb, ktmp, mycol, myrow, nb, npcol, nprow, size, upper;
@@ -255,7 +255,7 @@ void pcher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
+   Int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
                   YCd0[DLEN_], YRd0[DLEN_], Yd  [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pcher2k_.c
+++ b/PBLAS/SRC/pcher2k_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcher2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pcher2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcher2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pcher2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -277,14 +277,14 @@ void pcher2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   mycol, myrow, nb, notran, npcol, nprow, upper;
    double         ABCest, ABest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcher_.c
+++ b/PBLAS/SRC/pcher_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcher_( F_CHAR_T UPLO, int * N, float * ALPHA,
-             float * X, int * IX, int * JX, int * DESCX, int * INCX,
-             float * A, int * IA, int * JA, int * DESCA )
+void pcher_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+             float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pcher_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    float          * A, * X;
 #endif
 {
@@ -214,7 +214,7 @@ void pcher_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
                   npcol, nprow, size, upper;
@@ -223,7 +223,7 @@ void pcher_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pcherk_.c
+++ b/PBLAS/SRC/pcherk_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcherk_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pcherk_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
               C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pcherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * K, * N;
+   Int            * IA, * IC, * JA, * JC, * K, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -244,7 +244,7 @@ void pcherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
+   Int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
                   myrow, nb, notran, npcol, nprow, upper;
    double         Aest, ACest, tmp1, tmp2, tmp3, tmp4;
    cmplx          Calph;
@@ -252,7 +252,7 @@ void pcherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcscal_.c
+++ b/PBLAS/SRC/pcscal_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcscal_( int * N, float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pcscal_( Int * N, float * ALPHA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pcscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -155,13 +155,13 @@ void pcscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Local Scalars ..
 */
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcsscal_.c
+++ b/PBLAS/SRC/pcsscal_.c
@@ -17,20 +17,20 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcsscal_( int * N,
+void pcsscal_( Int * N,
                float * ALPHA,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX )
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pcsscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -156,13 +156,13 @@ void pcsscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Local Scalars ..
 */
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcswap_.c
+++ b/PBLAS/SRC/pcswap_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcswap_( int * N,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pcswap_( Int * N,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pcswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -176,7 +176,7 @@ void pcswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * one, * top, tran, * zero;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
                   Xinb1D, XinbD, XisRow, Xii, Xj, Xjj, Xld, Xlinc, Xm, XmyprocD,
                   XmyprocR, Xn, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xroc, Xrow, Ycol, Yi, Yii, Yinb1D, YinbD, YisD, YisR, YisRow,
@@ -189,7 +189,7 @@ void pcswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
    char           * buf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pcsymm_.c
+++ b/PBLAS/SRC/pcsymm_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcsymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, int * M, int * N,
+void pcsymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, Int * M, Int * N,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pcsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       SIDE, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -261,14 +261,14 @@ void pcsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, SideOp, UploA, cbtop, cbtopsave, cctop, cctopsave,
                   rbtop, rbtopsave, rctop, rctopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   lside, mycol, myrow, nb, npcol, nprow, upper;
    double         ABCest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcsyr2k_.c
+++ b/PBLAS/SRC/pcsyr2k_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcsyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pcsyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pcsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -271,14 +271,14 @@ void pcsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   mycol, myrow, nb, notran, npcol, nprow, upper;
    double         ABCest, ABest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pcsyrk_.c
+++ b/PBLAS/SRC/pcsyrk_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pcsyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pcsyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pcsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
               C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pcsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * K, * N;
+   Int            * IA, * IC, * JA, * JC, * K, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -238,14 +238,14 @@ void pcsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
+   Int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
                   myrow, nb, notran, npcol, nprow, upper;
    double         Aest, ACest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pctradd_.c
+++ b/PBLAS/SRC/pctradd_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pctradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * M, int * N,
+void pctradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * M, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
                float * BETA,
-               float * C, int * IC, int * JC, int * DESCC )
+               float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pctradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
                C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pctradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -242,12 +242,12 @@ void pctradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Local Scalars ..
 */
    char           DirAC, TranOp, UploC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
                   nprow, upper;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pctranc_.c
+++ b/PBLAS/SRC/pctranc_.c
@@ -17,22 +17,22 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pctranc_( int * M, int * N,
+void pctranc_( Int * M, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
                float * BETA,
-               float * C, int * IC, int * JC, int * DESCC )
+               float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pctranc_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -190,11 +190,11 @@ void pctranc_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Local Scalars ..
 */
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pctranu_.c
+++ b/PBLAS/SRC/pctranu_.c
@@ -17,22 +17,22 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pctranu_( int * M, int * N,
+void pctranu_( Int * M, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
                float * BETA,
-               float * C, int * IC, int * JC, int * DESCC )
+               float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pctranu_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -188,11 +188,11 @@ void pctranu_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Local Scalars ..
 */
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pctrmm_.c
+++ b/PBLAS/SRC/pctrmm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pctrmm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pctrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pctrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    float          * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pctrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
                   myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pctrmv_.c
+++ b/PBLAS/SRC/pctrmv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pctrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pctrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pctrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pctrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    float          * A, * X;
 #endif
 {
@@ -224,7 +224,7 @@ void pctrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Xroc, * one, * tbeta, top, *zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xcol, Xi, Xii,
                   Xj, Xjj, Xld, Xnp, Xnq, Xrow, YAfr, YAld, YApbY, YAsum,
                   ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb, notran,
@@ -233,7 +233,7 @@ void pctrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pctrsm_.c
+++ b/PBLAS/SRC/pctrsm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pctrsm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pctrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pctrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    float          * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pctrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
                   mycol, myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pctrsv_.c
+++ b/PBLAS/SRC/pctrsv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pctrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pctrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pctrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pctrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    float          * A, * X;
 #endif
 {
@@ -226,7 +226,7 @@ void pctrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 */
    char           DiagA, TranOp, UploA, Xroc, btop, ctop, * negone, * one,
                   * zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
                   Anp, Anp0, Anq, Anq0, Arow, Asrc, XACapbX, XACfr, XACld,
                   XACsum, XARapbX, XARfr, XARld, XARsum, Xi, Xj, ctxt, info,
                   ione=1, k, kb, kbnext, kbprev, ktmp, mycol, myrow, nb, notran,
@@ -235,7 +235,7 @@ void pctrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XAC = NULL, * XAR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pdagemv_.c
+++ b/PBLAS/SRC/pdagemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdagemv_( F_CHAR_T TRANS, int * M, int * N, double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pdagemv_( F_CHAR_T TRANS, Int * M, Int * N, double * ALPHA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                double * BETA,
-               double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pdagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -255,7 +255,7 @@ void pdagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * one, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -263,7 +263,7 @@ void pdagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pdamax_.c
+++ b/PBLAS/SRC/pdamax_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdamax_( int * N, double * AMAX, int * INDX,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pdamax_( Int * N, double * AMAX, Int * INDX,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pdamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INDX, * IX, * JX, * N;
+   Int            * INCX, * INDX, * IX, * JX, * N;
    double         * AMAX;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -181,13 +181,13 @@ void pdamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           cbtop, cctop, rbtop, rctop;
-   int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
+   Int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
                   Xnb, Xnp, Xnq, Xrow, Xsrc, ctxt, dist, dst, idumm, info, k,
                   maxpos, mycol, mydist, myrow, npcol, nprow, src;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    double         work[4];
 /* ..
 *  .. Executable Statements ..
@@ -324,7 +324,7 @@ l_20:
 *  zero, then select a coherent INDX.
 */
             *AMAX = work[0];
-            *INDX = ( ( *AMAX == ZERO ) ? ( *JX ) : ( (int)(work[1]) ) );
+            *INDX = ( ( *AMAX == ZERO ) ? ( *JX ) : ( (Int)(work[1]) ) );
          }
          else
          {
@@ -483,7 +483,7 @@ l_40:
 *  zero, then select a coherent INDX.
 */
             *AMAX = work[0];
-            *INDX = ( ( *AMAX == ZERO ) ? ( *IX ) : ( (int)(work[1]) ) );
+            *INDX = ( ( *AMAX == ZERO ) ? ( *IX ) : ( (Int)(work[1]) ) );
          }
          else
          {

--- a/PBLAS/SRC/pdasum_.c
+++ b/PBLAS/SRC/pdasum_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdasum_( int * N, double * ASUM,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pdasum_( Int * N, double * ASUM,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pdasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * ASUM;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -175,12 +175,12 @@ void pdasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdasymv_.c
+++ b/PBLAS/SRC/pdasymv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdasymv_( F_CHAR_T UPLO, int * N, double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pdasymv_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                double * BETA,
-               double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pdasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -245,7 +245,7 @@ void pdasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
                   Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld, Xi, Xj,
                   YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum, YRld, Ycol, Yi,
                   Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1,
@@ -256,7 +256,7 @@ void pdasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr  = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR    = NULL;

--- a/PBLAS/SRC/pdatrmv_.c
+++ b/PBLAS/SRC/pdatrmv_.c
@@ -17,13 +17,13 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
+void pdatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
-               double * X, int * IX, int * JX, int * DESCX,
-               int * INCX, double * BETA,
-               double * Y, int * IY, int * JY, int * DESCY,
-               int * INCY )
+               double * A, Int * IA, Int * JA, Int * DESCA,
+               double * X, Int * IX, Int * JX, Int * DESCX,
+               Int * INCX, double * BETA,
+               double * Y, Int * IY, Int * JY, Int * DESCY,
+               Int * INCY )
 #else
 void pdatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
                JX, DESCX, INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -31,13 +31,13 @@ void pdatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -277,7 +277,7 @@ void pdatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Yroc, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xi, Xj, YAfr,
                   YAld, YApbY, YAsum, Ycol, Yi, Yii, Yj, Yjj, Yld, Ynp, Ynq,
                   Yrow, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
@@ -287,7 +287,7 @@ void pdatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pdaxpy_.c
+++ b/PBLAS/SRC/pdaxpy_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdaxpy_( int * N,
+void pdaxpy_( Int * N,
               double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -186,12 +186,12 @@ void pdaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdcopy_.c
+++ b/PBLAS/SRC/pdcopy_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdcopy_( int * N,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pdcopy_( Int * N,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdcopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -177,12 +177,12 @@ void pdcopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pddot_.c
+++ b/PBLAS/SRC/pddot_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pddot_( int * N,
+void pddot_( Int * N,
              double * DOT,
-             double * X, int * IX, int * JX, int * DESCX, int * INCX,
-             double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+             double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pddot_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    double         * DOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -206,7 +206,7 @@ void pddot_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
                   Xinb1D, XisD, XisR, XisRow, Xj, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xrow, Ycol, Yi, Yii, YinbD, Yinb1D, YisD, YisR, YisRow, Yj,
@@ -219,7 +219,7 @@ void pddot_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Arrays ..
 */
    char           * buf = NULL;
-   int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
+   Int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdgeadd_.c
+++ b/PBLAS/SRC/pdgeadd_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdgeadd_( F_CHAR_T TRANS, int * M, int * N,
+void pdgeadd_( F_CHAR_T TRANS, Int * M, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
                double * BETA,
-               double * C, int * IC, int * JC, int * DESCC )
+               double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -202,12 +202,12 @@ void pdgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 *  .. Local Scalars ..
 */
    char           DirA, DirC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
+   Int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
                   notran;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdgemm_.c
+++ b/PBLAS/SRC/pdgemm_.c
@@ -18,12 +18,12 @@
 
 #ifdef __STDC__
 void pdgemm_( F_CHAR_T TRANSA, F_CHAR_T TRANSB,
-              int * M, int * N, int * K,
+              Int * M, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -31,12 +31,12 @@ void pdgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANSA, TRANSB;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -244,14 +244,14 @@ void pdgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, DirBC, OpC, OpR, TrA, TrB, ctop, ctopsave, rtop,
                   rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
                   info, mycol, myrow, nb, nota, notb, npcol, nprow;
    double         ABest, ACest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdgemv_.c
+++ b/PBLAS/SRC/pdgemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdgemv_( F_CHAR_T TRANS, int * M, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pdgemv_( F_CHAR_T TRANS, Int * M, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               double * BETA,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pdgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -248,7 +248,7 @@ void pdgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -256,7 +256,7 @@ void pdgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pdger_.c
+++ b/PBLAS/SRC/pdger_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdger_( int * M, int * N, double * ALPHA,
-             double * X, int * IX, int * JX, int * DESCX, int * INCX,
-             double * Y, int * IY, int * JY, int * DESCY, int * INCY,
-             double * A, int * IA, int * JA, int * DESCA )
+void pdger_( Int * M, Int * N, double * ALPHA,
+             double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+             double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pdger_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
              INCY, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -216,14 +216,14 @@ void pdger_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, Yi, Yj, ctxt, info, ione=1,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd[DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pdnrm2_.c
+++ b/PBLAS/SRC/pdnrm2_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdnrm2_( int * N, double * NORM2,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pdnrm2_( Int * N, double * NORM2,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pdnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * NORM2;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -173,13 +173,13 @@ void pdnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
                   info, k, mycol, mydist, myrow, npcol, nprow, src;
    double         scale, ssq, temp1, temp2;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    double         * Xptr = NULL, work[4];
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pdscal_.c
+++ b/PBLAS/SRC/pdscal_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdscal_( int * N, double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pdscal_( Int * N, double * ALPHA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pdscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -155,12 +155,12 @@ void pdscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Local Scalars ..
 */
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdswap_.c
+++ b/PBLAS/SRC/pdswap_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdswap_( int * N,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pdswap_( Int * N,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -176,7 +176,7 @@ void pdswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * one, * top, tran, * zero;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
                   Xinb1D, XinbD, XisRow, Xii, Xj, Xjj, Xld, Xlinc, Xm, XmyprocD,
                   XmyprocR, Xn, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xroc, Xrow, Ycol, Yi, Yii, Yinb1D, YinbD, YisD, YisR, YisRow,
@@ -189,7 +189,7 @@ void pdswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
    char           * buf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pdsymm_.c
+++ b/PBLAS/SRC/pdsymm_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdsymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, int * M, int * N,
+void pdsymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, Int * M, Int * N,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pdsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       SIDE, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -261,14 +261,14 @@ void pdsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, SideOp, UploA, cbtop, cbtopsave, cctop, cctopsave,
                   rbtop, rbtopsave, rctop, rctopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   lside, mycol, myrow, nb, npcol, nprow, upper;
    double         ABCest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdsymv_.c
+++ b/PBLAS/SRC/pdsymv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdsymv_( F_CHAR_T UPLO, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pdsymv_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               double * BETA,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pdsymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pdsymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -243,7 +243,7 @@ void pdsymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum,
                   YRld, Ycol, Yi, Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow,
@@ -254,7 +254,7 @@ void pdsymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pdsyr2_.c
+++ b/PBLAS/SRC/pdsyr2_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdsyr2_( F_CHAR_T UPLO, int * N, double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              double * A, int * IA, int * JA, int * DESCA )
+void pdsyr2_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pdsyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
               DESCY, INCY, A, IA, JA, DESCA )
@@ -28,13 +28,13 @@ void pdsyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -242,7 +242,7 @@ void pdsyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCld, YRfr, YRld, Yi, Yj, ctxt, info, ione=1,
                   k, kb, ktmp, mycol, myrow, nb, npcol, nprow, size, upper;
@@ -250,7 +250,7 @@ void pdsyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
+   Int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
                   YCd0[DLEN_], YRd0[DLEN_], Yd  [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pdsyr2k_.c
+++ b/PBLAS/SRC/pdsyr2k_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdsyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pdsyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pdsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -276,14 +276,14 @@ void pdsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   mycol, myrow, nb, notran, npcol, nprow, upper;
    double         ABCest, ABest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdsyr_.c
+++ b/PBLAS/SRC/pdsyr_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdsyr_( F_CHAR_T UPLO, int * N, double * ALPHA,
-             double * X, int * IX, int * JX, int * DESCX, int * INCX,
-             double * A, int * IA, int * JA, int * DESCA )
+void pdsyr_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+             double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pdsyr_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    double         * A, * X;
 #endif
 {
@@ -210,7 +210,7 @@ void pdsyr_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
                   npcol, nprow, size, upper;
@@ -218,7 +218,7 @@ void pdsyr_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pdsyrk_.c
+++ b/PBLAS/SRC/pdsyrk_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdsyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pdsyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
               C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pdsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * K, * N;
+   Int            * IA, * IC, * JA, * JC, * K, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -241,14 +241,14 @@ void pdsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
+   Int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
                   myrow, nb, notran, npcol, nprow, upper;
    double         Aest, ACest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdtradd_.c
+++ b/PBLAS/SRC/pdtradd_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdtradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * M, int * N,
+void pdtradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * M, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
                double * BETA,
-               double * C, int * IC, int * JC, int * DESCC )
+               double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdtradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
                C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pdtradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -242,12 +242,12 @@ void pdtradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Local Scalars ..
 */
    char           DirAC, TranOp, UploC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
                   nprow, upper;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdtran_.c
+++ b/PBLAS/SRC/pdtran_.c
@@ -17,22 +17,22 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdtran_( int * M, int * N,
+void pdtran_( Int * M, Int * N,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pdtran_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -188,11 +188,11 @@ void pdtran_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Local Scalars ..
 */
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdtrmm_.c
+++ b/PBLAS/SRC/pdtrmm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pdtrmm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pdtrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pdtrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    double         * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pdtrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
                   myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdtrmv_.c
+++ b/PBLAS/SRC/pdtrmv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdtrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pdtrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pdtrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pdtrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    double         * A, * X;
 #endif
 {
@@ -219,7 +219,7 @@ void pdtrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Xroc, * one, * tbeta, top, *zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xcol, Xi, Xii,
                   Xj, Xjj, Xld, Xnp, Xnq, Xrow, YAfr, YAld, YApbY, YAsum,
                   ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb, notran,
@@ -228,7 +228,7 @@ void pdtrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pdtrsm_.c
+++ b/PBLAS/SRC/pdtrsm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pdtrsm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pdtrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pdtrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    double         * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pdtrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
                   mycol, myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdtrsv_.c
+++ b/PBLAS/SRC/pdtrsv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdtrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pdtrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pdtrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pdtrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    double         * A, * X;
 #endif
 {
@@ -224,7 +224,7 @@ void pdtrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 */
    char           DiagA, TranOp, UploA, Xroc, btop, ctop, * negone, * one,
                   * zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
                   Anp, Anp0, Anq, Anq0, Arow, Asrc, XACapbX, XACfr, XACld,
                   XACsum, XARapbX, XARfr, XARld, XARsum, Xi, Xj, ctxt, info,
                   ione=1, k, kb, kbnext, kbprev, ktmp, mycol, myrow, nb, notran,
@@ -233,7 +233,7 @@ void pdtrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XAC = NULL, * XAR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pdzasum_.c
+++ b/PBLAS/SRC/pdzasum_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdzasum_( int * N, double * ASUM,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pdzasum_( Int * N, double * ASUM,
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pdzasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * ASUM;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -175,13 +175,13 @@ void pdzasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           * Xptr = NULL, top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pdznrm2_.c
+++ b/PBLAS/SRC/pdznrm2_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pdznrm2_( int * N, double * NORM2,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pdznrm2_( Int * N, double * NORM2,
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pdznrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * NORM2;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -173,14 +173,14 @@ void pdznrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           * Xptr = NULL, top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
                   info, k, mycol, mydist, myrow, npcol, nprow, src, size;
    double         Xtmp, scale, ssq, temp1, temp2;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    double         work[4];
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/picopy_.c
+++ b/PBLAS/SRC/picopy_.c
@@ -17,20 +17,20 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void picopy_( int * N,
-              int * X, int * IX, int * JX, int * DESCX, int * INCX,
-              int * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void picopy_( Int * N,
+              Int * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              Int * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void picopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
-   int            * X, * Y;
+   Int            * DESCX, * DESCY;
+   Int            * X, * Y;
 #endif
 {
 /*
@@ -177,12 +177,12 @@ void picopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psagemv_.c
+++ b/PBLAS/SRC/psagemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psagemv_( F_CHAR_T TRANS, int * M, int * N, float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void psagemv_( F_CHAR_T TRANS, Int * M, Int * N, float * ALPHA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                float * BETA,
-               float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void psagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void psagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -255,7 +255,7 @@ void psagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * one, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -263,7 +263,7 @@ void psagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/psamax_.c
+++ b/PBLAS/SRC/psamax_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psamax_( int * N, float * AMAX, int * INDX,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void psamax_( Int * N, float * AMAX, Int * INDX,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void psamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INDX, * IX, * JX, * N;
+   Int            * INCX, * INDX, * IX, * JX, * N;
    float          * AMAX;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -181,13 +181,13 @@ void psamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           cbtop, cctop, rbtop, rctop;
-   int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
+   Int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
                   Xnb, Xnp, Xnq, Xrow, Xsrc, ctxt, dist, dst, idumm, info, k,
                   maxpos, mycol, mydist, myrow, npcol, nprow, src;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    float          work[4];
 /* ..
 *  .. Executable Statements ..
@@ -324,7 +324,7 @@ l_20:
 *  zero, then select a coherent INDX.
 */
             *AMAX = work[0];
-            *INDX = ( ( *AMAX == ZERO ) ? ( *JX ) : ( (int)(work[1]) ) );
+            *INDX = ( ( *AMAX == ZERO ) ? ( *JX ) : ( (Int)(work[1]) ) );
          }
          else
          {
@@ -483,7 +483,7 @@ l_40:
 *  zero, then select a coherent INDX.
 */
             *AMAX = work[0];
-            *INDX = ( ( *AMAX == ZERO ) ? ( *IX ) : ( (int)(work[1]) ) );
+            *INDX = ( ( *AMAX == ZERO ) ? ( *IX ) : ( (Int)(work[1]) ) );
          }
          else
          {

--- a/PBLAS/SRC/psasum_.c
+++ b/PBLAS/SRC/psasum_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psasum_( int * N, float * ASUM,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void psasum_( Int * N, float * ASUM,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void psasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * ASUM;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -175,12 +175,12 @@ void psasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psasymv_.c
+++ b/PBLAS/SRC/psasymv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psasymv_( F_CHAR_T UPLO, int * N, float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void psasymv_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                float * BETA,
-               float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void psasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void psasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -245,7 +245,7 @@ void psasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
                   Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld, Xi, Xj,
                   YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum, YRld, Ycol, Yi,
                   Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1,
@@ -256,7 +256,7 @@ void psasymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr  = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR    = NULL;

--- a/PBLAS/SRC/psatrmv_.c
+++ b/PBLAS/SRC/psatrmv_.c
@@ -17,13 +17,13 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
+void psatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
-               float * X, int * IX, int * JX, int * DESCX,
-               int * INCX, float * BETA,
-               float * Y, int * IY, int * JY, int * DESCY,
-               int * INCY )
+               float * A, Int * IA, Int * JA, Int * DESCA,
+               float * X, Int * IX, Int * JX, Int * DESCX,
+               Int * INCX, float * BETA,
+               float * Y, Int * IY, Int * JY, Int * DESCY,
+               Int * INCY )
 #else
 void psatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
                JX, DESCX, INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -31,13 +31,13 @@ void psatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -277,7 +277,7 @@ void psatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Yroc, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xi, Xj, YAfr,
                   YAld, YApbY, YAsum, Ycol, Yi, Yii, Yj, Yjj, Yld, Ynp, Ynq,
                   Yrow, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
@@ -287,7 +287,7 @@ void psatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/psaxpy_.c
+++ b/PBLAS/SRC/psaxpy_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psaxpy_( int * N,
+void psaxpy_( Int * N,
               float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void psaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -186,12 +186,12 @@ void psaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pscasum_.c
+++ b/PBLAS/SRC/pscasum_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pscasum_( int * N, float * ASUM,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pscasum_( Int * N, float * ASUM,
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pscasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * ASUM;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -175,13 +175,13 @@ void pscasum_( N, ASUM, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           * Xptr = NULL, top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pscnrm2_.c
+++ b/PBLAS/SRC/pscnrm2_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pscnrm2_( int * N, float * NORM2,
-               float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pscnrm2_( Int * N, float * NORM2,
+               float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pscnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * NORM2;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -173,14 +173,14 @@ void pscnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           * Xptr = NULL, top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
                   info, k, mycol, mydist, myrow, npcol, nprow, src, size;
    float          Xtmp, scale, ssq, temp1, temp2;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    float          work[4];
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pscopy_.c
+++ b/PBLAS/SRC/pscopy_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pscopy_( int * N,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pscopy_( Int * N,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pscopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -177,12 +177,12 @@ void pscopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psdot_.c
+++ b/PBLAS/SRC/psdot_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psdot_( int * N,
+void psdot_( Int * N,
              float * DOT,
-             float * X, int * IX, int * JX, int * DESCX, int * INCX,
-             float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+             float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void psdot_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    float          * DOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -206,7 +206,7 @@ void psdot_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
                   Xinb1D, XisD, XisR, XisRow, Xj, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xrow, Ycol, Yi, Yii, YinbD, Yinb1D, YisD, YisR, YisRow, Yj,
@@ -219,7 +219,7 @@ void psdot_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Arrays ..
 */
    char           * buf = NULL;
-   int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
+   Int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psgeadd_.c
+++ b/PBLAS/SRC/psgeadd_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psgeadd_( F_CHAR_T TRANS, int * M, int * N,
+void psgeadd_( F_CHAR_T TRANS, Int * M, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
                float * BETA,
-               float * C, int * IC, int * JC, int * DESCC )
+               float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void psgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -202,12 +202,12 @@ void psgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 *  .. Local Scalars ..
 */
    char           DirA, DirC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
+   Int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
                   notran;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psgemm_.c
+++ b/PBLAS/SRC/psgemm_.c
@@ -18,12 +18,12 @@
 
 #ifdef __STDC__
 void psgemm_( F_CHAR_T TRANSA, F_CHAR_T TRANSB,
-              int * M, int * N, int * K,
+              Int * M, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void psgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -31,12 +31,12 @@ void psgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANSA, TRANSB;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -244,14 +244,14 @@ void psgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, DirBC, OpC, OpR, TrA, TrB, ctop, ctopsave, rtop,
                   rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
                   info, mycol, myrow, nb, nota, notb, npcol, nprow;
    double         ABest, ACest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psgemv_.c
+++ b/PBLAS/SRC/psgemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psgemv_( F_CHAR_T TRANS, int * M, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void psgemv_( F_CHAR_T TRANS, Int * M, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               float * BETA,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void psgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void psgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -248,7 +248,7 @@ void psgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -256,7 +256,7 @@ void psgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/psger_.c
+++ b/PBLAS/SRC/psger_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psger_( int * M, int * N, float * ALPHA,
-             float * X, int * IX, int * JX, int * DESCX, int * INCX,
-             float * Y, int * IY, int * JY, int * DESCY, int * INCY,
-             float * A, int * IA, int * JA, int * DESCA )
+void psger_( Int * M, Int * N, float * ALPHA,
+             float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+             float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void psger_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
              INCY, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -216,14 +216,14 @@ void psger_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, Yi, Yj, ctxt, info, ione=1,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd[DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/psnrm2_.c
+++ b/PBLAS/SRC/psnrm2_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psnrm2_( int * N, float * NORM2,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void psnrm2_( Int * N, float * NORM2,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void psnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * NORM2;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -173,13 +173,13 @@ void psnrm2_( N, NORM2, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           top;
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, dst, dist,
                   info, k, mycol, mydist, myrow, npcol, nprow, src;
    float          scale, ssq, temp1, temp2;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    float          * Xptr = NULL, work[4];
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/psscal_.c
+++ b/PBLAS/SRC/psscal_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psscal_( int * N, float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX )
+void psscal_( Int * N, float * ALPHA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void psscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    float          * X;
 #endif
 {
@@ -155,12 +155,12 @@ void psscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Local Scalars ..
 */
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/psswap_.c
+++ b/PBLAS/SRC/psswap_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void psswap_( int * N,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void psswap_( Int * N,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void psswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    float          * X, * Y;
 #endif
 {
@@ -176,7 +176,7 @@ void psswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * one, * top, tran, * zero;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
                   Xinb1D, XinbD, XisRow, Xii, Xj, Xjj, Xld, Xlinc, Xm, XmyprocD,
                   XmyprocR, Xn, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xroc, Xrow, Ycol, Yi, Yii, Yinb1D, YinbD, YisD, YisR, YisRow,
@@ -189,7 +189,7 @@ void psswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
    char           * buf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pssymm_.c
+++ b/PBLAS/SRC/pssymm_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pssymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, int * M, int * N,
+void pssymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, Int * M, Int * N,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pssymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pssymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       SIDE, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -261,14 +261,14 @@ void pssymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, SideOp, UploA, cbtop, cbtopsave, cctop, cctopsave,
                   rbtop, rbtopsave, rctop, rctopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   lside, mycol, myrow, nb, npcol, nprow, upper;
    double         ABCest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pssymv_.c
+++ b/PBLAS/SRC/pssymv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pssymv_( F_CHAR_T UPLO, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pssymv_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               float * BETA,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pssymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pssymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -243,7 +243,7 @@ void pssymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum,
                   YRld, Ycol, Yi, Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow,
@@ -254,7 +254,7 @@ void pssymv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pssyr2_.c
+++ b/PBLAS/SRC/pssyr2_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pssyr2_( F_CHAR_T UPLO, int * N, float * ALPHA,
-              float * X, int * IX, int * JX, int * DESCX, int * INCX,
-              float * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              float * A, int * IA, int * JA, int * DESCA )
+void pssyr2_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+              float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              float * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pssyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
               DESCY, INCY, A, IA, JA, DESCA )
@@ -28,13 +28,13 @@ void pssyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    float          * A, * X, * Y;
 #endif
 {
@@ -242,7 +242,7 @@ void pssyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCld, YRfr, YRld, Yi, Yj, ctxt, info, ione=1,
                   k, kb, ktmp, mycol, myrow, nb, npcol, nprow, size, upper;
@@ -250,7 +250,7 @@ void pssyr2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
+   Int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
                   YCd0[DLEN_], YRd0[DLEN_], Yd  [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pssyr2k_.c
+++ b/PBLAS/SRC/pssyr2k_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pssyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pssyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pssyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pssyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    float          * A, * B, * C;
 #endif
 {
@@ -276,14 +276,14 @@ void pssyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   mycol, myrow, nb, notran, npcol, nprow, upper;
    double         ABCest, ABest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pssyr_.c
+++ b/PBLAS/SRC/pssyr_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pssyr_( F_CHAR_T UPLO, int * N, float * ALPHA,
-             float * X, int * IX, int * JX, int * DESCX, int * INCX,
-             float * A, int * IA, int * JA, int * DESCA )
+void pssyr_( F_CHAR_T UPLO, Int * N, float * ALPHA,
+             float * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             float * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pssyr_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    float          * A, * X;
 #endif
 {
@@ -210,7 +210,7 @@ void pssyr_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
                   npcol, nprow, size, upper;
@@ -218,7 +218,7 @@ void pssyr_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pssyrk_.c
+++ b/PBLAS/SRC/pssyrk_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pssyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pssyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pssyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
               C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pssyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * K, * N;
+   Int            * IA, * IC, * JA, * JC, * K, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -241,14 +241,14 @@ void pssyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
+   Int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
                   myrow, nb, notran, npcol, nprow, upper;
    double         Aest, ACest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pstradd_.c
+++ b/PBLAS/SRC/pstradd_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pstradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * M, int * N,
+void pstradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * M, Int * N,
                float * ALPHA,
-               float * A, int * IA, int * JA, int * DESCA,
+               float * A, Int * IA, Int * JA, Int * DESCA,
                float * BETA,
-               float * C, int * IC, int * JC, int * DESCC )
+               float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pstradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
                C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pstradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -242,12 +242,12 @@ void pstradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Local Scalars ..
 */
    char           DirAC, TranOp, UploC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
                   nprow, upper;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pstran_.c
+++ b/PBLAS/SRC/pstran_.c
@@ -17,22 +17,22 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pstran_( int * M, int * N,
+void pstran_( Int * M, Int * N,
               float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
               float * BETA,
-              float * C, int * IC, int * JC, int * DESCC )
+              float * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pstran_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    float          * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    float          * A, * C;
 #endif
 {
@@ -188,11 +188,11 @@ void pstran_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Local Scalars ..
 */
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pstrmm_.c
+++ b/PBLAS/SRC/pstrmm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pstrmm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pstrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pstrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    float          * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pstrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
                   myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pstrmv_.c
+++ b/PBLAS/SRC/pstrmv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pstrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pstrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pstrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pstrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    float          * A, * X;
 #endif
 {
@@ -219,7 +219,7 @@ void pstrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Xroc, * one, * tbeta, top, *zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xcol, Xi, Xii,
                   Xj, Xjj, Xld, Xnp, Xnq, Xrow, YAfr, YAld, YApbY, YAsum,
                   ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb, notran,
@@ -228,7 +228,7 @@ void pstrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pstrsm_.c
+++ b/PBLAS/SRC/pstrsm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pstrsm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, float * ALPHA,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, float * ALPHA,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pstrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pstrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    float          * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    float          * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pstrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
                   mycol, myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pstrsv_.c
+++ b/PBLAS/SRC/pstrsv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pstrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              float * A, int * IA, int * JA, int * DESCA,
-              float * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pstrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              float * A, Int * IA, Int * JA, Int * DESCA,
+              float * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pstrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pstrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    float          * A, * X;
 #endif
 {
@@ -224,7 +224,7 @@ void pstrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 */
    char           DiagA, TranOp, UploA, Xroc, btop, ctop, * negone, * one,
                   * zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
                   Anp, Anp0, Anq, Anq0, Arow, Asrc, XACapbX, XACfr, XACld,
                   XACsum, XARapbX, XARfr, XARld, XARsum, Xi, Xj, ctxt, info,
                   ione=1, k, kb, kbnext, kbprev, ktmp, mycol, myrow, nb, notran,
@@ -233,7 +233,7 @@ void pstrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XAC = NULL, * XAR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pzagemv_.c
+++ b/PBLAS/SRC/pzagemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzagemv_( F_CHAR_T TRANS, int * M, int * N, double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pzagemv_( F_CHAR_T TRANS, Int * M, Int * N, double * ALPHA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                double * BETA,
-               double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pzagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -259,7 +259,7 @@ void pzagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * one, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -267,7 +267,7 @@ void pzagemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pzahemv_.c
+++ b/PBLAS/SRC/pzahemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzahemv_( F_CHAR_T UPLO, int * N, double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pzahemv_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
                double * BETA,
-               double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+               double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
                INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pzahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -248,7 +248,7 @@ void pzahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Amp,
                   Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld, Xi, Xj,
                   YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum, YRld, Ycol, Yi,
                   Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1,
@@ -259,7 +259,7 @@ void pzahemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr  = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR    = NULL;

--- a/PBLAS/SRC/pzamax_.c
+++ b/PBLAS/SRC/pzamax_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzamax_( int * N, double * AMAX, int * INDX,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pzamax_( Int * N, double * AMAX, Int * INDX,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pzamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INDX, * IX, * JX, * N;
+   Int            * INCX, * INDX, * IX, * JX, * N;
    double         * AMAX;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -181,7 +181,7 @@ void pzamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 *  .. Local Scalars ..
 */
    char           cbtop, cctop, rbtop, rctop;
-   int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
+   Int            Xcol, Xgindx, Xi, Xii, Ximb, Xinb, Xj, Xjj, Xlindx, Xld, Xmb,
                   Xnb, Xnp, Xnq, Xrow, Xsrc, ctxt, dist, dst, idumm, info, k,
                   maxpos, mycol, mydist, myrow, npcol, nprow, src, size;
    PBTYP_T        * type;
@@ -189,7 +189,7 @@ void pzamax_( N, AMAX, INDX, X, IX, JX, DESCX, INCX )
 *  .. Local Arrays ..
 */
    char           * Xptr;
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
    cmplx16        work[4];
 /* ..
 *  .. Executable Statements ..
@@ -347,7 +347,7 @@ l_20:
             AMAX[IMAG_PART] = work[0][IMAG_PART];
             *INDX = ( ( ( AMAX[REAL_PART] == ZERO ) &&
                         ( AMAX[IMAG_PART] == ZERO ) ) ?
-                    ( *JX ) : ( (int)(work[1][REAL_PART]) ) );
+                    ( *JX ) : ( (Int)(work[1][REAL_PART]) ) );
          }
          else
          {
@@ -530,7 +530,7 @@ l_40:
             AMAX[IMAG_PART] = work[0][IMAG_PART];
             *INDX = ( ( ( AMAX[REAL_PART] == ZERO ) &&
                         ( AMAX[IMAG_PART] == ZERO ) ) ?
-                    ( *IX ) : ( (int)(work[1][REAL_PART]) ) );
+                    ( *IX ) : ( (Int)(work[1][REAL_PART]) ) );
          }
          else
          {

--- a/PBLAS/SRC/pzatrmv_.c
+++ b/PBLAS/SRC/pzatrmv_.c
@@ -17,13 +17,13 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
+void pzatrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
-               double * X, int * IX, int * JX, int * DESCX,
-               int * INCX, double * BETA,
-               double * Y, int * IY, int * JY, int * DESCY,
-               int * INCY )
+               double * A, Int * IA, Int * JA, Int * DESCA,
+               double * X, Int * IX, Int * JX, Int * DESCX,
+               Int * INCX, double * BETA,
+               double * Y, Int * IY, Int * JY, Int * DESCY,
+               Int * INCY )
 #else
 void pzatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
                JX, DESCX, INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -31,13 +31,13 @@ void pzatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -281,7 +281,7 @@ void pzatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Yroc, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xi, Xj, YAfr,
                   YAld, YApbY, YAsum, Ycol, Yi, Yii, Yj, Yjj, Yld, Ynp, Ynq,
                   Yrow, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
@@ -291,7 +291,7 @@ void pzatrmv_( UPLO, TRANS, DIAG, N, ALPHA, A, IA, JA, DESCA, X, IX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pzaxpy_.c
+++ b/PBLAS/SRC/pzaxpy_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzaxpy_( int * N,
+void pzaxpy_( Int * N,
               double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -186,12 +186,12 @@ void pzaxpy_( N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzcopy_.c
+++ b/PBLAS/SRC/pzcopy_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzcopy_( int * N,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pzcopy_( Int * N,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzcopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -177,12 +177,12 @@ void pzcopy_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Scalars ..
 */
-   int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Xi, Xj, Yi, Yj, ctxt, info, mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzdotc_.c
+++ b/PBLAS/SRC/pzdotc_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzdotc_( int * N,
+void pzdotc_( Int * N,
               double * DOT,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzdotc_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    double         * DOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -206,7 +206,7 @@ void pzdotc_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
                   Xinb1D, XisD, XisR, XisRow, Xj, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xrow, Ycol, Yi, Yii, YinbD, Yinb1D, YisD, YisR, YisRow, Yj,
@@ -219,7 +219,7 @@ void pzdotc_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Arrays ..
 */
    char           * buf = NULL;
-   int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
+   Int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzdotu_.c
+++ b/PBLAS/SRC/pzdotu_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzdotu_( int * N,
+void pzdotu_( Int * N,
               double * DOT,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzdotu_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
    double         * DOT;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -206,7 +206,7 @@ void pzdotu_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           scope, * top;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, Xii, XinbD,
                   Xinb1D, XisD, XisR, XisRow, Xj, Xjj, Xld, Xlinc, XmyprocD,
                   XmyprocR, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xrow, Ycol, Yi, Yii, YinbD, Yinb1D, YisD, YisR, YisRow, Yj,
@@ -219,7 +219,7 @@ void pzdotu_( N, DOT, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Arrays ..
 */
    char           * buf = NULL;
-   int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
+   Int            Xd[DLEN_], Yd[DLEN_], dbuf[ DLEN_ ];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzdscal_.c
+++ b/PBLAS/SRC/pzdscal_.c
@@ -17,20 +17,20 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzdscal_( int * N,
+void pzdscal_( Int * N,
                double * ALPHA,
-               double * X, int * IX, int * JX, int * DESCX, int * INCX )
+               double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pzdscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -156,13 +156,13 @@ void pzdscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Local Scalars ..
 */
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzgeadd_.c
+++ b/PBLAS/SRC/pzgeadd_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzgeadd_( F_CHAR_T TRANS, int * M, int * N,
+void pzgeadd_( F_CHAR_T TRANS, Int * M, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
                double * BETA,
-               double * C, int * IC, int * JC, int * DESCC )
+               double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -202,12 +202,12 @@ void pzgeadd_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 *  .. Local Scalars ..
 */
    char           DirA, DirC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
+   Int            Ai, Aj, Ci, Cj, TrA, ctxt, info, mycol, myrow, npcol, nprow,
                   notran;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzgemm_.c
+++ b/PBLAS/SRC/pzgemm_.c
@@ -18,12 +18,12 @@
 
 #ifdef __STDC__
 void pzgemm_( F_CHAR_T TRANSA, F_CHAR_T TRANSB,
-              int * M, int * N, int * K,
+              Int * M, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -31,12 +31,12 @@ void pzgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANSA, TRANSB;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -244,14 +244,14 @@ void pzgemm_( TRANSA, TRANSB, M, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, DirBC, OpC, OpR, TrA, TrB, ctop, ctopsave, rtop,
                   rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ChooseBC, Ci, Cj, ForceTop, ctxt,
                   info, mycol, myrow, nb, nota, notb, npcol, nprow;
    double         ABest, ACest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzgemv_.c
+++ b/PBLAS/SRC/pzgemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzgemv_( F_CHAR_T TRANS, int * M, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pzgemv_( F_CHAR_T TRANS, Int * M, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               double * BETA,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pzgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -250,7 +250,7 @@ void pzgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           TrA, Yroc, * tbeta, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, YApbY, YAsum, Ycol, Yi, Yii,
                   Yj, Yjj, Yld, Ynp, Ynq, Yrow, ctxt, info, ione=1, mycol,
                   myrow, nota, npcol, nprow;
@@ -258,7 +258,7 @@ void pzgemv_( TRANS, M, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd [DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pzgerc_.c
+++ b/PBLAS/SRC/pzgerc_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzgerc_( int * M, int * N, double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              double * A, int * IA, int * JA, int * DESCA )
+void pzgerc_( Int * M, Int * N, double * ALPHA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pzgerc_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
               INCY, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -216,14 +216,14 @@ void pzgerc_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, Yi, Yj, ctxt, info, ione=1,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd[DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pzgeru_.c
+++ b/PBLAS/SRC/pzgeru_.c
@@ -17,23 +17,23 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzgeru_( int * M, int * N, double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              double * A, int * IA, int * JA, int * DESCA )
+void pzgeru_( Int * M, Int * N, double * ALPHA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pzgeru_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
               INCY, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -216,14 +216,14 @@ void pzgeru_( M, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY,
 /*
 *  .. Local Scalars ..
 */
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Ald, Amb, Amp, Anb,
                   Anq, Arow, XAfr, Xi, Xj, YAfr, Yi, Yj, ctxt, info, ione=1,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
+   Int            Ad[DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_],
                   Yd[DLEN_];
    char           * XA = NULL, * YA = NULL;
 /* ..

--- a/PBLAS/SRC/pzhemm_.c
+++ b/PBLAS/SRC/pzhemm_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzhemm_( F_CHAR_T SIDE, F_CHAR_T UPLO, int * M, int * N,
+void pzhemm_( F_CHAR_T SIDE, F_CHAR_T UPLO, Int * M, Int * N,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzhemm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pzhemm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       SIDE, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -264,14 +264,14 @@ void pzhemm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, SideOp, UploA, cbtop, cbtopsave, cctop, cctopsave,
                   rbtop, rbtopsave, rctop, rctopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   lside, mycol, myrow, nb, npcol, nprow, upper;
    double         ABCest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzhemv_.c
+++ b/PBLAS/SRC/pzhemv_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzhemv_( F_CHAR_T UPLO, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
+void pzhemv_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
               double * BETA,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzhemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
               INCX, BETA, Y, IY, JY, DESCY, INCY )
@@ -29,13 +29,13 @@ void pzhemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -246,7 +246,7 @@ void pzhemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 *  .. Local Scalars ..
 */
    char           UploA, * one, top;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCpbY, YCsum, YCld, YRfr, YRpbY, YRsum,
                   YRld, Ycol, Yi, Yii, YisRow, Yj, Yjj, Yld, Ynp, Ynq, Yrow,
@@ -257,7 +257,7 @@ void pzhemv_( UPLO, N, ALPHA, A, IA, JA, DESCA, X, IX, JX, DESCX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
+   Int            Ad [DLEN_], Ad0[DLEN_], XCd[DLEN_], XRd[DLEN_], Xd[DLEN_],
                   YCd[DLEN_], YRd[DLEN_], Yd [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pzher2_.c
+++ b/PBLAS/SRC/pzher2_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzher2_( F_CHAR_T UPLO, int * N, double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY,
-              double * A, int * IA, int * JA, int * DESCA )
+void pzher2_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY,
+              double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pzher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
               DESCY, INCY, A, IA, JA, DESCA )
@@ -28,13 +28,13 @@ void pzher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
+   Int            * IA, * INCX, * INCY, * IX, * IY, * JA, * JX, * JY,
                   * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX, * DESCY;
+   Int            * DESCA, * DESCX, * DESCY;
    double         * A, * X, * Y;
 #endif
 {
@@ -246,7 +246,7 @@ void pzher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, YCfr, YCld, YRfr, YRld, Yi, Yj, ctxt, info, ione=1,
                   k, kb, ktmp, mycol, myrow, nb, npcol, nprow, size, upper;
@@ -255,7 +255,7 @@ void pzher2_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, Y, IY, JY,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
+   Int            Ad  [DLEN_], Ad0 [DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_],
                   YCd0[DLEN_], YRd0[DLEN_], Yd  [DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL, * YC = NULL,
                   * YR   = NULL;

--- a/PBLAS/SRC/pzher2k_.c
+++ b/PBLAS/SRC/pzher2k_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzher2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pzher2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzher2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pzher2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -277,14 +277,14 @@ void pzher2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   mycol, myrow, nb, notran, npcol, nprow, upper;
    double         ABCest, ABest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzher_.c
+++ b/PBLAS/SRC/pzher_.c
@@ -17,21 +17,21 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzher_( F_CHAR_T UPLO, int * N, double * ALPHA,
-             double * X, int * IX, int * JX, int * DESCX, int * INCX,
-             double * A, int * IA, int * JA, int * DESCA )
+void pzher_( F_CHAR_T UPLO, Int * N, double * ALPHA,
+             double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+             double * A, Int * IA, Int * JA, Int * DESCA )
 #else
 void pzher_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    double         * A, * X;
 #endif
 {
@@ -214,7 +214,7 @@ void pzher_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 *  .. Local Scalars ..
 */
    char           UploA;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XCfr, XCld, XRfr, XRld,
                   Xi, Xj, ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb,
                   npcol, nprow, size, upper;
@@ -223,7 +223,7 @@ void pzher_( UPLO, N, ALPHA, X, IX, JX, DESCX, INCX, A, IA, JA, DESCA )
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XCd0[DLEN_], XRd0[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XC = NULL, * XR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pzherk_.c
+++ b/PBLAS/SRC/pzherk_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzherk_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pzherk_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
               C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pzherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * K, * N;
+   Int            * IA, * IC, * JA, * JC, * K, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -244,7 +244,7 @@ void pzherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
+   Int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
                   myrow, nb, notran, npcol, nprow, upper;
    double         Aest, ACest, tmp1, tmp2, tmp3, tmp4;
    cmplx16        Calph;
@@ -252,7 +252,7 @@ void pzherk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzscal_.c
+++ b/PBLAS/SRC/pzscal_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzscal_( int * N, double * ALPHA,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX )
+void pzscal_( Int * N, double * ALPHA,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX )
 #else
 void pzscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * IX, * JX, * N;
+   Int            * INCX, * IX, * JX, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX;
+   Int            * DESCX;
    double         * X;
 #endif
 {
@@ -64,7 +64,7 @@ void pzscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 *                                   the NPROW x NPCOL BLACS process grid
 *                                   A  is  distributed over. The context
 *                                   itself  is  global,  but  the handle
-*                                   (the integer value) may vary.
+*                                   (the Integer value) may vary.
 *  M_A     (global) DESCA[ M_     ] The  number of rows in the distribu-
 *                                   ted matrix A, M_A >= 0.
 *  N_A     (global) DESCA[ N_     ] The number of columns in the distri-
@@ -131,11 +131,11 @@ void pzscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 *          subvector.
 *
 *  IX      (global input) INTEGER
-*          On entry, IX  specifies X's global row index, which points to
+*          On entry, IX  specifies X's global row index, which poInts to
 *          the beginning of the submatrix sub( X ).
 *
 *  JX      (global input) INTEGER
-*          On entry, JX  specifies X's global column index, which points
+*          On entry, JX  specifies X's global column index, which poInts
 *          to the beginning of the submatrix sub( X ).
 *
 *  DESCX   (global and local input) INTEGER array
@@ -155,13 +155,13 @@ void pzscal_( N, ALPHA, X, IX, JX, DESCX, INCX )
 /*
 *  .. Local Scalars ..
 */
-   int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
+   Int            Xcol, Xi, Xii, Xj, Xjj, Xld, Xnp, Xnq, Xrow, ctxt, info,
                   mycol, myrow, npcol, nprow;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_];
+   Int            Xd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzswap_.c
+++ b/PBLAS/SRC/pzswap_.c
@@ -17,19 +17,19 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzswap_( int * N,
-              double * X, int * IX, int * JX, int * DESCX, int * INCX,
-              double * Y, int * IY, int * JY, int * DESCY, int * INCY )
+void pzswap_( Int * N,
+              double * X, Int * IX, Int * JX, Int * DESCX, Int * INCX,
+              double * Y, Int * IY, Int * JY, Int * DESCY, Int * INCY )
 #else
 void pzswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
+   Int            * INCX, * INCY, * IX, * IY, * JX, * JY, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCX, * DESCY;
+   Int            * DESCX, * DESCY;
    double         * X, * Y;
 #endif
 {
@@ -176,7 +176,7 @@ void pzswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 *  .. Local Scalars ..
 */
    char           Xscope, Yscope, * one, * top, tran, * zero;
-   int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
+   Int            OneBlock, OneDgrid, RRorCC, Square, Xcol, Xi, XisD, XisR,
                   Xinb1D, XinbD, XisRow, Xii, Xj, Xjj, Xld, Xlinc, Xm, XmyprocD,
                   XmyprocR, Xn, XnbD, XnpD, XnprocsD, XnprocsR, XprocD, XprocR,
                   Xroc, Xrow, Ycol, Yi, Yii, Yinb1D, YinbD, YisD, YisR, YisRow,
@@ -189,7 +189,7 @@ void pzswap_( N, X, IX, JX, DESCX, INCX, Y, IY, JY, DESCY, INCY )
 /*
 *  .. Local Arrays ..
 */
-   int            Xd[DLEN_], Yd[DLEN_];
+   Int            Xd[DLEN_], Yd[DLEN_];
    char           * buf = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pzsymm_.c
+++ b/PBLAS/SRC/pzsymm_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzsymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, int * M, int * N,
+void pzsymm_( F_CHAR_T SIDE, F_CHAR_T UPLO, Int * M, Int * N,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pzsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       SIDE, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -261,14 +261,14 @@ void pzsymm_( SIDE, UPLO, M, N, ALPHA, A, IA, JA, DESCA,
 */
    char           DirAB, SideOp, UploA, cbtop, cbtopsave, cctop, cctopsave,
                   rbtop, rbtopsave, rctop, rctopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   lside, mycol, myrow, nb, npcol, nprow, upper;
    double         ABCest, BCest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzsyr2k_.c
+++ b/PBLAS/SRC/pzsyr2k_.c
@@ -17,12 +17,12 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzsyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pzsyr2k_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
               B, IB, JB, DESCB, BETA, C, IC, JC, DESCC )
@@ -30,12 +30,12 @@ void pzsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
+   Int            * IA, * IB, * IC, * JA, * JB, * JC, * K, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB, * DESCC;
+   Int            * DESCA, * DESCB, * DESCC;
    double         * A, * B, * C;
 #endif
 {
@@ -271,14 +271,14 @@ void pzsyr2k_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
+   Int            Ai, Aj, Bi, Bj, ChooseABC, Ci, Cj, ForceTop, ctxt, info,
                   mycol, myrow, nb, notran, npcol, nprow, upper;
    double         ABCest, ABest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pzsyrk_.c
+++ b/PBLAS/SRC/pzsyrk_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pzsyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * N, int * K,
+void pzsyrk_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * N, Int * K,
               double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
               double * BETA,
-              double * C, int * IC, int * JC, int * DESCC )
+              double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pzsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
               C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pzsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * K, * N;
+   Int            * IA, * IC, * JA, * JC, * K, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -238,14 +238,14 @@ void pzsyrk_( UPLO, TRANS, N, K, ALPHA, A, IA, JA, DESCA, BETA,
 */
    char           DirA, OpC, OpR, TopC, TopR, TranOp, UploC, ctop, ctopsave,
                   rtop, rtopsave;
-   int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
+   Int            Ai, Aj, ChooseAC, Ci, Cj, ForceTop, ctxt, info, mycol,
                   myrow, nb, notran, npcol, nprow, upper;
    double         Aest, ACest, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pztradd_.c
+++ b/PBLAS/SRC/pztradd_.c
@@ -17,11 +17,11 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pztradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, int * M, int * N,
+void pztradd_( F_CHAR_T UPLO, F_CHAR_T TRANS, Int * M, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
                double * BETA,
-               double * C, int * IC, int * JC, int * DESCC )
+               double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pztradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
                C, IC, JC, DESCC )
@@ -29,12 +29,12 @@ void pztradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       TRANS, UPLO;
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -242,12 +242,12 @@ void pztradd_( UPLO, TRANS, M, N, ALPHA, A, IA, JA, DESCA, BETA,
 *  .. Local Scalars ..
 */
    char           DirAC, TranOp, UploC, ctop, rtop;
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, notran, npcol,
                   nprow, upper;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pztranc_.c
+++ b/PBLAS/SRC/pztranc_.c
@@ -17,22 +17,22 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pztranc_( int * M, int * N,
+void pztranc_( Int * M, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
                double * BETA,
-               double * C, int * IC, int * JC, int * DESCC )
+               double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pztranc_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -190,11 +190,11 @@ void pztranc_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Local Scalars ..
 */
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pztranu_.c
+++ b/PBLAS/SRC/pztranu_.c
@@ -17,22 +17,22 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pztranu_( int * M, int * N,
+void pztranu_( Int * M, Int * N,
                double * ALPHA,
-               double * A, int * IA, int * JA, int * DESCA,
+               double * A, Int * IA, Int * JA, Int * DESCA,
                double * BETA,
-               double * C, int * IC, int * JC, int * DESCC )
+               double * C, Int * IC, Int * JC, Int * DESCC )
 #else
 void pztranu_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Scalar Arguments ..
 */
-   int            * IA, * IC, * JA, * JC, * M, * N;
+   Int            * IA, * IC, * JA, * JC, * M, * N;
    double         * ALPHA, * BETA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCC;
+   Int            * DESCA, * DESCC;
    double         * A, * C;
 #endif
 {
@@ -188,11 +188,11 @@ void pztranu_( M, N, ALPHA, A, IA, JA, DESCA, BETA, C, IC, JC, DESCC )
 /*
 *  .. Local Scalars ..
 */
-   int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
+   Int            Ai, Aj, Ci, Cj, ctxt, info, mycol, myrow, npcol, nprow;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Cd[DLEN_];
+   Int            Ad[DLEN_], Cd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pztrmm_.c
+++ b/PBLAS/SRC/pztrmm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pztrmm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pztrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pztrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    double         * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pztrmm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, lside, mycol,
                   myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pztrmv_.c
+++ b/PBLAS/SRC/pztrmv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pztrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pztrmv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pztrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pztrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    double         * A, * X;
 #endif
 {
@@ -224,7 +224,7 @@ void pztrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Local Scalars ..
 */
    char           DiagA, TranOp, UploA, Xroc, * one, * tbeta, top, *zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb,
                   Amp, Amp0, Anb, Anq, Anq0, Arow, XAfr, XAld, Xcol, Xi, Xii,
                   Xj, Xjj, Xld, Xnp, Xnq, Xrow, YAfr, YAld, YApbY, YAsum,
                   ctxt, info, ione=1, k, kb, ktmp, mycol, myrow, nb, notran,
@@ -233,7 +233,7 @@ void pztrmv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
+   Int            Ad [DLEN_], Ad0[DLEN_], XAd[DLEN_], Xd[DLEN_], YAd[DLEN_];
    char           * Aptr = NULL, * XA = NULL, * YA = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/PBLAS/SRC/pztrsm_.c
+++ b/PBLAS/SRC/pztrsm_.c
@@ -18,9 +18,9 @@
 
 #ifdef __STDC__
 void pztrsm_( F_CHAR_T SIDE, F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG,
-              int * M, int * N, double * ALPHA,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * B, int * IB, int * JB, int * DESCB )
+              Int * M, Int * N, double * ALPHA,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * B, Int * IB, Int * JB, Int * DESCB )
 #else
 void pztrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
               A, IA, JA, DESCA, B, IB, JB, DESCB )
@@ -28,12 +28,12 @@ void pztrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, SIDE, TRANS, UPLO;
-   int            * IA, * IB, * JA, * JB, * M, * N;
+   Int            * IA, * IB, * JA, * JB, * M, * N;
    double         * ALPHA;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCB;
+   Int            * DESCA, * DESCB;
    double         * A, * B;
 #endif
 {
@@ -241,14 +241,14 @@ void pztrsm_( SIDE, UPLO, TRANS, DIAG, M, N, ALPHA,
 */
    char           DiagA, DirB, OpC, OpR, SideOp, TopC, TopR, TranOp, UploA,
                   Var, ctop, ctopsave, rtop, rtopsave;
-   int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
+   Int            Ai, Aj, Bi, Bj, ChooseAB, ForceTop, ctxt, info, itmp, lside,
                   mycol, myrow, nb, notran, nounit, npcol, nprow, upper;
    double         ABestL, ABestR, Best, tmp1, tmp2, tmp3, tmp4;
    PBTYP_T        * type;
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Bd[DLEN_];
+   Int            Ad[DLEN_], Bd[DLEN_];
 /* ..
 *  .. Executable Statements ..
 *

--- a/PBLAS/SRC/pztrsv_.c
+++ b/PBLAS/SRC/pztrsv_.c
@@ -17,10 +17,10 @@
 #include "PBblas.h"
 
 #ifdef __STDC__
-void pztrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, int * N,
-              double * A, int * IA, int * JA, int * DESCA,
-              double * X, int * IX, int * JX, int * DESCX,
-              int * INCX )
+void pztrsv_( F_CHAR_T UPLO, F_CHAR_T TRANS, F_CHAR_T DIAG, Int * N,
+              double * A, Int * IA, Int * JA, Int * DESCA,
+              double * X, Int * IX, Int * JX, Int * DESCX,
+              Int * INCX )
 #else
 void pztrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
               DESCX, INCX )
@@ -28,11 +28,11 @@ void pztrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 *  .. Scalar Arguments ..
 */
    F_CHAR_T       DIAG, TRANS, UPLO;
-   int            * IA, * INCX, * IX, * JA, * JX, * N;
+   Int            * IA, * INCX, * IX, * JA, * JX, * N;
 /*
 *  .. Array Arguments ..
 */
-   int            * DESCA, * DESCX;
+   Int            * DESCA, * DESCX;
    double         * A, * X;
 #endif
 {
@@ -226,7 +226,7 @@ void pztrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 */
    char           DiagA, TranOp, UploA, Xroc, btop, ctop, * negone, * one,
                   * zero;
-   int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
+   Int            Acol, Ai, Aii, Aimb1, Ainb1, Aj, Ajj, Akp, Akq, Ald, Amb, Anb,
                   Anp, Anp0, Anq, Anq0, Arow, Asrc, XACapbX, XACfr, XACld,
                   XACsum, XARapbX, XARfr, XARld, XARsum, Xi, Xj, ctxt, info,
                   ione=1, k, kb, kbnext, kbprev, ktmp, mycol, myrow, nb, notran,
@@ -235,7 +235,7 @@ void pztrsv_( UPLO, TRANS, DIAG, N, A, IA, JA, DESCA, X, IX, JX,
 /*
 *  .. Local Arrays ..
 */
-   int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
+   Int            Ad[DLEN_], Ad0[DLEN_], XACd[DLEN_], XARd[DLEN_], Xd[DLEN_];
    char           * Aptr = NULL, * XAC = NULL, * XAR = NULL;
 /* ..
 *  .. Executable Statements ..

--- a/README
+++ b/README
@@ -134,3 +134,21 @@ This include file is then referenced in all subdirectory Makefiles.  Once
 the include file has been modified, the entire installation process (including
 the building of testing executables) can be performed by typing ``make''
 in the top-level ScaLAPACK directory.
+
+ScaLAPACK uses the default (typically 4-byte) integers. With compilers that
+support it, the library can be compiled with long (8-byte) integers instead.
+This can be achived by providing the flag "-DInt=long" to the C compiler
+(or with another corresponding C type) and, simultaneously, the appropriate
+integer promotion flag (e.g. "-fdefault-integer-8" or "-i8") to the Fortran
+compiler. It is expected that the BLAS/LAPACK library linked to ScaLAPACK uses
+the 8-byte integers as well. Note that in order to run the test suite with long
+integers, it is necessary to replace the hardcoded byte sizes in the tests
+before the compilation using
+
+    sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/EIG/* TESTING/LIN/*
+    sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/EIG/* TESTING/LIN/*
+
+Even then, the tests "xssep", "xsgsep" and "xssyevr" will fail, because they
+are already written with the assumption that an integer fits into memory
+occupied by a real number, which is mostly not true for combination of default
+Fortran real numbers and long integers.

--- a/REDIST/SRC/pcgemr.c
+++ b/REDIST/SRC/pcgemr.c
@@ -161,20 +161,20 @@ typedef struct {
   float r, i;
 }     complex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -188,7 +188,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -209,12 +209,12 @@ extern void Ccgerv2d();
 /* lapack */
 void  clacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 cgescanD0
@@ -226,7 +226,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpcgemr2do();
 extern void Cpcgemr2d();
 /* some defines for Cpcgemr2do */
@@ -246,8 +246,8 @@ extern void Cpcgemr2d();
 void 
 fortran_mr2d(m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   complex *A, *B;
 {
   Cpcgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -257,18 +257,18 @@ fortran_mr2d(m, n, A, ia, ja, desc_A,
 void 
 fortran_mr2dnew(m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   complex *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpcgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -279,15 +279,15 @@ Cpcgemr2do(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
   Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpcgemr2d(m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -303,22 +303,22 @@ Cpcgemr2d(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   complex *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   complex *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -349,7 +349,7 @@ Cpcgemr2d(m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -384,8 +384,8 @@ Cpcgemr2d(m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -431,7 +431,7 @@ Cpcgemr2d(m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -485,9 +485,9 @@ Cpcgemr2d(m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -541,7 +541,7 @@ Cpcgemr2d(m, n,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Ccgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
+	      Ccgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
 		       0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
@@ -573,13 +573,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -630,8 +630,8 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 #define Mlacpy(mo,no,ao,ldao,bo,ldbo) \
 { \
 complex *_a,*_b; \
-int _m,_n,_lda,_ldb; \
-    int _i,_j; \
+Int _m,_n,_lda,_ldb; \
+    Int _i,_j; \
     _m = (mo);_n = (no); \
     _a = (ao);_b = (bo); \
     _lda = (ldao) - _m; \
@@ -644,14 +644,14 @@ int _m,_n,_lda,_ldb; \
       _a += _lda; \
     } \
 }
-static2 int 
+static2 Int 
 block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *ma;
   complex *buff, *ptra;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   complex *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -668,12 +668,12 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
 }
 static2 void 
 buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *mb;
   complex *buff, *ptrb;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   complex *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -687,12 +687,12 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
     }
   }
 }
-static2 int 
+static2 Int 
 inter_len(hinb, hi, vinb, vi)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
 {
-  int   hlen, vlen, h, v;
+  Int   hlen, vlen, h, v;
   hlen = 0;
   for (h = 0; h < hinb; h++)
     hlen += hi[h].len;
@@ -704,9 +704,9 @@ inter_len(hinb, hi, vinb, vi)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   complex *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -719,23 +719,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
   Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pcgemr2.c
+++ b/REDIST/SRC/pcgemr2.c
@@ -26,20 +26,20 @@ typedef struct {
   float r, i;
 }     complex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -53,7 +53,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -74,12 +74,12 @@ extern void Ccgerv2d();
 /* lapack */
 void  clacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 cgescanD0
@@ -91,7 +91,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpcgemr2do();
 extern void Cpcgemr2d();
 /* some defines for Cpcgemr2do */
@@ -115,7 +115,7 @@ extern void Cpcgemr2d();
 void
 setmemory(adpointer, blocksize)
   complex **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -140,24 +140,24 @@ freememory(ptrtobefreed)
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -169,8 +169,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {

--- a/REDIST/SRC/pctrmr.c
+++ b/REDIST/SRC/pctrmr.c
@@ -176,20 +176,20 @@ typedef struct {
   float r, i;
 }     complex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -203,7 +203,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -224,12 +224,12 @@ extern void Ccgerv2d();
 /* lapack */
 void  clacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 ctrscanD0
@@ -241,7 +241,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpctrmr2do();
 extern void Cpctrmr2d();
 /* some defines for Cpctrmr2do */
@@ -262,8 +262,8 @@ void
 fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   complex *A, *B;
 {
   Cpctrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -274,18 +274,18 @@ void
 fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   complex *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpctrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -297,15 +297,15 @@ Cpctrmr2do(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
   Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpctrmr2d(uplo, diag, m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -322,22 +322,22 @@ Cpctrmr2d(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   complex *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   complex *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -368,7 +368,7 @@ Cpctrmr2d(uplo, diag, m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -403,8 +403,8 @@ Cpctrmr2d(uplo, diag, m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -450,7 +450,7 @@ Cpctrmr2d(uplo, diag, m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -504,9 +504,9 @@ Cpctrmr2d(uplo, diag, m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -543,8 +543,8 @@ Cpctrmr2d(uplo, diag, m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Ccgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Ccgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -564,8 +564,8 @@ Cpctrmr2d(uplo, diag, m, n,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Ccgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Ccgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -597,13 +597,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -654,9 +654,9 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   complex *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -669,23 +669,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pctrmr2.c
+++ b/REDIST/SRC/pctrmr2.c
@@ -26,20 +26,20 @@ typedef struct {
   float r, i;
 }     complex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -53,7 +53,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -74,12 +74,12 @@ extern void Ccgerv2d();
 /* lapack */
 void  clacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 ctrscanD0
@@ -91,7 +91,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpctrmr2do();
 extern void Cpctrmr2d();
 /* some defines for Cpctrmr2do */
@@ -115,7 +115,7 @@ extern void Cpctrmr2d();
 void
 setmemory(adpointer, blocksize)
   complex **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -140,28 +140,28 @@ freememory(ptrtobefreed)
 /* return the number of elements int the column after i and the distance of
  * the first one from i, i,j can be negative out of borns, the number of
  * elements returned can be negative (means 0) */
-static2 int
+static2 Int
 insidemat(uplo, diag, i, j, m, n, offset)
-  int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
+  Int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
   char *uplo, *diag;
-  int  *offset;
+  Int  *offset;
 {
   /* tests outside mxn */
   assert(j >= 0 && j < n);
   assert(i >= 0);
   if (toupper(*uplo) == 'U') {
-    int   nbline;	/* number of lines in the j_th column */
-    int   virtualnbline;	/* number of line if we were not limited by m */
+    Int   nbline;	/* number of lines in the j_th column */
+    Int   virtualnbline;	/* number of line if we were not limited by m */
     *offset = 0;
     virtualnbline = max(m - n, 0) + j + (toupper(*diag) == 'N');
     nbline = min(virtualnbline, m);
     return nbline - i;
   } else {
-    int   firstline;	/* first line in the j_th column */
-    int   diagcol;	/* column where the diag begin */
-    int   virtualline;	/* virtual first line if the matrix was extended with
+    Int   firstline;	/* first line in the j_th column */
+    Int   diagcol;	/* column where the diag begin */
+    Int   virtualline;	/* virtual first line if the matrix was extended with
 			 * negative indices */
-    int   off;
+    Int   off;
     diagcol = max(n - m, 0);;
     virtualline = j - diagcol + (toupper(*diag) == 'U');
     firstline = max(0, virtualline);
@@ -183,23 +183,23 @@ intersect(uplo, diag,
 	  m, n,
 	  ma, ia, ja, templateheight0, templatewidth0,
 	  mb, ib, jb, templateheight1, templatewidth1)
-  int   action, *ptrsizebuff;
-  int   j, start, end;
+  Int   action, *ptrsizebuff;
+  Int   j, start, end;
   complex **pptrbuff, *ptrblock;
-  int   templateheight0, templatewidth0;
-  int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   templateheight1, templatewidth1;
   MDESC *ma, *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
   char *uplo, *diag;
 /* Execute the action on the local memory for the current interval and
  * increment pptrbuff and ptrsizebuff of the intervalsize */
 /* Notice that if the interval is contigous in the virtual matrice, it is
  * also contigous in the real one ! */
 {
-  /* int       un = 1; only when we use dcopy instead of memcpy */
+  /* Int       un = 1; only when we use dcopy instead of memcpy */
   complex *ptrstart;
-  int   offset, nbline;
-  int   intervalsize;
+  Int   offset, nbline;
+  Int   intervalsize;
   assert(start < end);
   assert(j >= 0 && j < n);
   nbline =
@@ -242,24 +242,24 @@ intersect(uplo, diag,
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -271,8 +271,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {
@@ -320,24 +320,24 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
        v_inter, vinter_nb,
        h_inter, hinter_nb,
        ptrblock)
-  int   action,	/* # of the action done on the intersected intervals  */
+  Int   action,	/* # of the action done on the intersected intervals  */
        *ptrsizebuff;	/* size of the communication ptrbuffer (chosen to be
 			 * an output parameter in every cases) */
   complex *ptrbuff	/* address of the communication ptrbuffer (a
 			 * suffisant memory space is supposed to be allocated
       before the call) */ , *ptrblock;
-  int   p0, q0, p1, q1;
+  Int   p0, q0, p1, q1;
   IDESC *v_inter, *h_inter;
-  int   vinter_nb, hinter_nb;
-  int   m, n;
-  int   ia, ja, ib, jb;
+  Int   vinter_nb, hinter_nb;
+  Int   m, n;
+  Int   ia, ja, ib, jb;
   MDESC *ma, *mb;
   char *uplo, *diag;
 {/* Rmk: the a+au type addresses are strict bounds as a+au does not belong to
   * the [a..a+au-1] interval of length au */
-  int   templateheight1, templatewidth1;
-  int   templateheight0, templatewidth0;
-  int   h, v;	/* for scanning the intervals */
+  Int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   h, v;	/* for scanning the intervals */
   /* initializations */
   templateheight1 = p1 * mb->nbrow;
   templateheight0 = p0 * ma->nbrow;
@@ -349,7 +349,7 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
   (*ptrsizebuff) = 0;
   for (h = 0; h < hinter_nb; h++)
     for (v = 0; v < vinter_nb; v++) {
-      int   j;
+      Int   j;
       for (j = 0; j < h_inter[h].len; j++)
 	intersect(uplo, diag, j + h_inter[h].gstart,
 		  v_inter[v].gstart, v_inter[v].gstart + v_inter[v].len,

--- a/REDIST/SRC/pdgemr.c
+++ b/REDIST/SRC/pdgemr.c
@@ -158,20 +158,20 @@
 #define Clacpy Cdgelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -185,7 +185,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -206,12 +206,12 @@ extern void Cdgerv2d();
 /* lapack */
 void  dlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 dgescanD0
@@ -223,7 +223,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpdgemr2do();
 extern void Cpdgemr2d();
 /* some defines for Cpdgemr2do */
@@ -243,8 +243,8 @@ extern void Cpdgemr2d();
 void 
 fortran_mr2d(m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   double *A, *B;
 {
   Cpdgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -254,18 +254,18 @@ fortran_mr2d(m, n, A, ia, ja, desc_A,
 void 
 fortran_mr2dnew(m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   double *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpdgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -276,15 +276,15 @@ Cpdgemr2do(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpdgemr2d(m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -300,22 +300,22 @@ Cpdgemr2d(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   double *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   double *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -346,7 +346,7 @@ Cpdgemr2d(m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -381,8 +381,8 @@ Cpdgemr2d(m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -428,7 +428,7 @@ Cpdgemr2d(m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -482,9 +482,9 @@ Cpdgemr2d(m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -519,8 +519,8 @@ Cpdgemr2d(m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Cdgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Cdgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -538,8 +538,8 @@ Cpdgemr2d(m, n,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Cdgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Cdgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -570,13 +570,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -627,8 +627,8 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 #define Mlacpy(mo,no,ao,ldao,bo,ldbo) \
 { \
 double *_a,*_b; \
-int _m,_n,_lda,_ldb; \
-    int _i,_j; \
+Int _m,_n,_lda,_ldb; \
+    Int _i,_j; \
     _m = (mo);_n = (no); \
     _a = (ao);_b = (bo); \
     _lda = (ldao) - _m; \
@@ -641,14 +641,14 @@ int _m,_n,_lda,_ldb; \
       _a += _lda; \
     } \
 }
-static2 int 
+static2 Int 
 block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *ma;
   double *buff, *ptra;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   double *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -665,12 +665,12 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
 }
 static2 void 
 buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *mb;
   double *buff, *ptrb;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   double *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -684,12 +684,12 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
     }
   }
 }
-static2 int 
+static2 Int 
 inter_len(hinb, hi, vinb, vi)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
 {
-  int   hlen, vlen, h, v;
+  Int   hlen, vlen, h, v;
   hlen = 0;
   for (h = 0; h < hinb; h++)
     hlen += hi[h].len;
@@ -701,9 +701,9 @@ inter_len(hinb, hi, vinb, vi)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   double *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -716,23 +716,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pdgemr2.c
+++ b/REDIST/SRC/pdgemr2.c
@@ -23,20 +23,20 @@
 #define Clacpy Cdgelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Cdgerv2d();
 /* lapack */
 void  dlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 dgescanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpdgemr2do();
 extern void Cpdgemr2d();
 /* some defines for Cpdgemr2do */
@@ -112,7 +112,7 @@ extern void Cpdgemr2d();
 void
 setmemory(adpointer, blocksize)
   double **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -137,24 +137,24 @@ freememory(ptrtobefreed)
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -166,8 +166,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {

--- a/REDIST/SRC/pdtrmr.c
+++ b/REDIST/SRC/pdtrmr.c
@@ -173,20 +173,20 @@
 #define Clacpy Cdtrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -200,7 +200,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -221,12 +221,12 @@ extern void Cdgerv2d();
 /* lapack */
 void  dlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 dtrscanD0
@@ -238,7 +238,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpdtrmr2do();
 extern void Cpdtrmr2d();
 /* some defines for Cpdtrmr2do */
@@ -259,8 +259,8 @@ void
 fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   double *A, *B;
 {
   Cpdtrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -271,18 +271,18 @@ void
 fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   double *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpdtrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -294,15 +294,15 @@ Cpdtrmr2do(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpdtrmr2d(uplo, diag, m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -319,22 +319,22 @@ Cpdtrmr2d(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   double *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   double *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -365,7 +365,7 @@ Cpdtrmr2d(uplo, diag, m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -400,8 +400,8 @@ Cpdtrmr2d(uplo, diag, m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -447,7 +447,7 @@ Cpdtrmr2d(uplo, diag, m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -501,9 +501,9 @@ Cpdtrmr2d(uplo, diag, m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -540,8 +540,8 @@ Cpdtrmr2d(uplo, diag, m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Cdgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Cdgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -557,12 +557,12 @@ Cpdtrmr2d(uplo, diag, m, n,
 		 v_inter, vinter_nb, h_inter, hinter_nb, ptrNULL);
 	  if (recvsize > 0) {
 	    if (step == myrang && mesending) {
-	      Clacpy(recvsize, 1,
+	      Clacpy(recvsize, (Int)1,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Cdgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Cdgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -594,13 +594,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -651,9 +651,9 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   double *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -666,23 +666,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pdtrmr2.c
+++ b/REDIST/SRC/pdtrmr2.c
@@ -23,20 +23,20 @@
 #define Clacpy Cdtrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Cdgerv2d();
 /* lapack */
 void  dlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 dtrscanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpdtrmr2do();
 extern void Cpdtrmr2d();
 /* some defines for Cpdtrmr2do */
@@ -112,7 +112,7 @@ extern void Cpdtrmr2d();
 void
 setmemory(adpointer, blocksize)
   double **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -137,28 +137,28 @@ freememory(ptrtobefreed)
 /* return the number of elements int the column after i and the distance of
  * the first one from i, i,j can be negative out of borns, the number of
  * elements returned can be negative (means 0) */
-static2 int
+static2 Int
 insidemat(uplo, diag, i, j, m, n, offset)
-  int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
+  Int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
   char *uplo, *diag;
-  int  *offset;
+  Int  *offset;
 {
   /* tests outside mxn */
   assert(j >= 0 && j < n);
   assert(i >= 0);
   if (toupper(*uplo) == 'U') {
-    int   nbline;	/* number of lines in the j_th column */
-    int   virtualnbline;	/* number of line if we were not limited by m */
+    Int   nbline;	/* number of lines in the j_th column */
+    Int   virtualnbline;	/* number of line if we were not limited by m */
     *offset = 0;
     virtualnbline = max(m - n, 0) + j + (toupper(*diag) == 'N');
     nbline = min(virtualnbline, m);
     return nbline - i;
   } else {
-    int   firstline;	/* first line in the j_th column */
-    int   diagcol;	/* column where the diag begin */
-    int   virtualline;	/* virtual first line if the matrix was extended with
+    Int   firstline;	/* first line in the j_th column */
+    Int   diagcol;	/* column where the diag begin */
+    Int   virtualline;	/* virtual first line if the matrix was extended with
 			 * negative indices */
-    int   off;
+    Int   off;
     diagcol = max(n - m, 0);;
     virtualline = j - diagcol + (toupper(*diag) == 'U');
     firstline = max(0, virtualline);
@@ -180,13 +180,13 @@ intersect(uplo, diag,
 	  m, n,
 	  ma, ia, ja, templateheight0, templatewidth0,
 	  mb, ib, jb, templateheight1, templatewidth1)
-  int   action, *ptrsizebuff;
-  int   j, start, end;
+  Int   action, *ptrsizebuff;
+  Int   j, start, end;
   double **pptrbuff, *ptrblock;
-  int   templateheight0, templatewidth0;
-  int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   templateheight1, templatewidth1;
   MDESC *ma, *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
   char *uplo, *diag;
 /* Execute the action on the local memory for the current interval and
  * increment pptrbuff and ptrsizebuff of the intervalsize */
@@ -195,8 +195,8 @@ intersect(uplo, diag,
 {
   /* int       un = 1; only when we use dcopy instead of memcpy */
   double *ptrstart;
-  int   offset, nbline;
-  int   intervalsize;
+  Int   offset, nbline;
+  Int   intervalsize;
   assert(start < end);
   assert(j >= 0 && j < n);
   nbline =
@@ -239,24 +239,24 @@ intersect(uplo, diag,
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -268,8 +268,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {
@@ -317,24 +317,24 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
        v_inter, vinter_nb,
        h_inter, hinter_nb,
        ptrblock)
-  int   action,	/* # of the action done on the intersected intervals  */
+  Int   action,	/* # of the action done on the intersected intervals  */
        *ptrsizebuff;	/* size of the communication ptrbuffer (chosen to be
 			 * an output parameter in every cases) */
   double *ptrbuff	/* address of the communication ptrbuffer (a
 			 * suffisant memory space is supposed to be allocated
       before the call) */ , *ptrblock;
-  int   p0, q0, p1, q1;
+  Int   p0, q0, p1, q1;
   IDESC *v_inter, *h_inter;
-  int   vinter_nb, hinter_nb;
-  int   m, n;
-  int   ia, ja, ib, jb;
+  Int   vinter_nb, hinter_nb;
+  Int   m, n;
+  Int   ia, ja, ib, jb;
   MDESC *ma, *mb;
   char *uplo, *diag;
 {/* Rmk: the a+au type addresses are strict bounds as a+au does not belong to
   * the [a..a+au-1] interval of length au */
-  int   templateheight1, templatewidth1;
-  int   templateheight0, templatewidth0;
-  int   h, v;	/* for scanning the intervals */
+  Int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   h, v;	/* for scanning the intervals */
   /* initializations */
   templateheight1 = p1 * mb->nbrow;
   templateheight0 = p0 * ma->nbrow;
@@ -346,7 +346,7 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
   (*ptrsizebuff) = 0;
   for (h = 0; h < hinter_nb; h++)
     for (v = 0; v < vinter_nb; v++) {
-      int   j;
+      Int   j;
       for (j = 0; j < h_inter[h].len; j++)
 	intersect(uplo, diag, j + h_inter[h].gstart,
 		  v_inter[v].gstart, v_inter[v].gstart + v_inter[v].len,

--- a/REDIST/SRC/pgemraux.c
+++ b/REDIST/SRC/pgemraux.c
@@ -23,20 +23,20 @@
 #define Clacpy Cigelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 igescanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpigemr2do();
 extern void Cpigemr2d();
 /* some defines for Cpigemr2do */
@@ -106,7 +106,7 @@ extern void Cpigemr2d();
 #include <assert.h>
 void *
 mr2d_malloc(n)
-  int   n;
+  Int   n;
 {
   void *ptr;
   assert(n > 0);
@@ -117,11 +117,11 @@ mr2d_malloc(n)
   }
   return ptr;
 }
-int 
+Int 
 pgcd(a, b)
-  int   a, b;
+  Int   a, b;
 {
-  int   aux;
+  Int   aux;
   if (a < b)
     return pgcd(b, a);
   else {
@@ -132,11 +132,11 @@ pgcd(a, b)
       return pgcd(b, aux);
   }
 }
-int 
+Int 
 ppcm(a, b)
-  int   a, b;
+  Int   a, b;
 {
-  int   pg;
+  Int   pg;
   pg = pgcd(a, b);
   return a * (b / pg);
 }
@@ -144,11 +144,11 @@ ppcm(a, b)
  * row number myprow, of a distributed matrix with m rows distributed of on a
  * grid of processors with p rows with blocksize nbrow : this procedure can
  * also be used to compute the number of cols by replacing rows by cols */
-int 
+Int 
 localsize(myprow, p, nbrow, m)
-  int   myprow, p, nbrow, m;
+  Int   myprow, p, nbrow, m;
 {
-  int   templateheight, blockheight;
+  Int   templateheight, blockheight;
   templateheight = p * nbrow;
   if (m % templateheight != 0) {	/* not an exact boundary */
     if ((m % templateheight) > (nbrow * myprow)) {	/* processor
@@ -173,11 +173,11 @@ localsize(myprow, p, nbrow, m)
 }
 /****************************************************************/
 /* Returns the exact memory block size corresponding to the parameters */
-int
+Int
 memoryblocksize(a)
   MDESC *a;
 {
-  int   myprow, mypcol, p, q;
+  Int   myprow, mypcol, p, q;
   /* Compute the (myprow,mypcol) indices of processor mypnum in P0xQ0 We
    * assume the row-major ordering of the BLACS */
   Cblacs_gridinfo(a->ctxt, &p, &q, &myprow, &mypcol);
@@ -189,29 +189,29 @@ memoryblocksize(a)
 }
 void 
 checkequal(ctxt, a)
-  int   a, ctxt;
+  Int   a, ctxt;
 {
-  int   np, dummy, nbrow, myp, b;
+  Int   np, dummy, nbrow, myp, b;
   Cblacs_gridinfo(ctxt, &nbrow, &np, &dummy, &myp);
   assert(nbrow == 1);
   if (np == 1)
     return;
   if (myp == 0) {
-    Cigesd2d(ctxt, 1, 1, &a, 1, 0, 1);
-    Cigerv2d(ctxt, 1, 1, &b, 1, 0, np - 1);
+    Cigesd2d(ctxt, (Int)1, (Int)1, &a, (Int)1, (Int)0, (Int)1);
+    Cigerv2d(ctxt, (Int)1, (Int)1, &b, (Int)1, (Int)0, np - 1);
     assert(a == b);
   } else {
-    Cigerv2d(ctxt, 1, 1, &b, 1, 0, myp - 1);
+    Cigerv2d(ctxt, (Int)1, (Int)1, &b, (Int)1, (Int)0, myp - 1);
     assert(a == b);
-    Cigesd2d(ctxt, 1, 1, &a, 1, 0, (myp + 1) % np);
+    Cigesd2d(ctxt, (Int)1, (Int)1, &a, (Int)1, (Int)0, (myp + 1) % np);
   }
 }
 void 
 paramcheck(a, i, j, m, n, p, q, gcontext)
   MDESC *a;
-  int   i, j, m, n, p, q;
+  Int   i, j, m, n, p, q;
 {
-  int   p2, q2, myprow, mypcol;
+  Int   p2, q2, myprow, mypcol;
 #ifndef NDEBUG
   checkequal(gcontext, p);
   checkequal(gcontext, q);
@@ -254,12 +254,12 @@ nbrow=%d,lda=%d,sprow=%d\n",
 /* to change from the submatrix beginning at line i to one beginning at line
  * i' with i'< blocksize return the line number on the local process where
  * the new matrix begin, the new process number, and i' */
-int 
+Int 
 changeorigin(myp, sp, p, bs, i, decal, newsp)
-  int   myp, sp, p, bs, i;
-  int  *decal, *newsp;
+  Int   myp, sp, p, bs, i;
+  Int  *decal, *newsp;
 {
-  int   tempheight, firstblock, firsttemp;
+  Int   tempheight, firstblock, firsttemp;
   /* we begin by changing the parameters so that ia < templatewidth,... */
   tempheight = bs * p;
   firsttemp = i / tempheight;
@@ -273,14 +273,14 @@ changeorigin(myp, sp, p, bs, i, decal, newsp)
 }
 /******************************************************************/
 /* Return the indice in local memory of element of indice a in the matrix */
-int
+Int
 localindice(ig, jg, templateheight, templatewidth, a)
-  int   templateheight, templatewidth, ig, jg;
+  Int   templateheight, templatewidth, ig, jg;
   MDESC *a;
 /* Return the indice in local memory (scattered distribution) of the element
  * of indice a in global matrix */
 {
-  int   vtemp, htemp, vsubtemp, hsubtemp, il, jl;
+  Int   vtemp, htemp, vsubtemp, hsubtemp, il, jl;
   assert(ig >= 0 && ig < a->m && jg >= 0 && jg < a->n);
   /* coordinates in global matrix with the tests in intersect, ig MUST BE in
    * [0..m] and jg in [0..n] */
@@ -297,7 +297,7 @@ localindice(ig, jg, templateheight, templatewidth, a)
   assert(il < a->lda);
 #ifndef NDEBUG
   {
-    int   pr, pc, p, q, lp, lq;
+    Int   pr, pc, p, q, lp, lq;
     Cblacs_gridinfo(a->ctxt, &p, &q, &pr, &pc);
     p = templateheight / a->nbrow;
     q = templatewidth / a->nbcol;

--- a/REDIST/SRC/pigemr.c
+++ b/REDIST/SRC/pigemr.c
@@ -158,20 +158,20 @@
 #define Clacpy Cigelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -185,7 +185,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -206,12 +206,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 igescanD0
@@ -223,7 +223,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpigemr2do();
 extern void Cpigemr2d();
 /* some defines for Cpigemr2do */
@@ -243,9 +243,9 @@ extern void Cpigemr2d();
 void 
 fortran_mr2d(m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
-  int  *A, *B;
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *A, *B;
 {
   Cpigemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
@@ -254,37 +254,37 @@ fortran_mr2d(m, n, A, ia, ja, desc_A,
 void 
 fortran_mr2dnew(m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
-  int  *A, *B;
-  int  *gcontext;
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *A, *B;
+  Int  *gcontext;
 {
   Cpigemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
 Cpigemr2do(m, n,
 	   ptrmyblock, ia, ja, ma,
 	   ptrmynewblock, ib, jb, mb)
-  int  *ptrmyblock, *ptrmynewblock;
+  Int  *ptrmyblock, *ptrmynewblock;
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpigemr2d(m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -296,26 +296,26 @@ void
 Cpigemr2d(m, n,
 	  ptrmyblock, ia, ja, ma,
 	  ptrmynewblock, ib, jb, mb, globcontext)
-  int  *ptrmyblock, *ptrmynewblock;
+  Int  *ptrmyblock, *ptrmynewblock;
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
-  int  *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
-  int  *recvptr;
+  Int  *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
+  Int  *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -346,7 +346,7 @@ Cpigemr2d(m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -381,8 +381,8 @@ Cpigemr2d(m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, (Int)2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -428,7 +428,7 @@ Cpigemr2d(m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -482,9 +482,9 @@ Cpigemr2d(m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -519,8 +519,8 @@ Cpigemr2d(m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Cigesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Cigesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -534,12 +534,12 @@ Cpigemr2d(m, n,
 	  recvsize = inter_len(hinter_nb, h_inter, vinter_nb, v_inter);
 	  if (recvsize > 0) {
 	    if (step == myrang && mesending) {
-	      Clacpy(recvsize, 1,
+	      Clacpy(recvsize, (Int)1,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Cigerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Cigerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -570,13 +570,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -626,9 +626,9 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 }
 #define Mlacpy(mo,no,ao,ldao,bo,ldbo) \
 { \
-int *_a,*_b; \
-int _m,_n,_lda,_ldb; \
-    int _i,_j; \
+Int *_a,*_b; \
+Int _m,_n,_lda,_ldb; \
+    Int _i,_j; \
     _m = (mo);_n = (no); \
     _a = (ao);_b = (bo); \
     _lda = (ldao) - _m; \
@@ -641,15 +641,15 @@ int _m,_n,_lda,_ldb; \
       _a += _lda; \
     } \
 }
-static2 int 
+static2 Int 
 block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *ma;
-  int  *buff, *ptra;
+  Int  *buff, *ptra;
 {
-  int   h, v, sizebuff;
-  int  *ptr2;
+  Int   h, v, sizebuff;
+  Int  *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
     ptr2 = ptra + hi[h].lstart * ma->lda;
@@ -665,13 +665,13 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
 }
 static2 void 
 buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *mb;
-  int  *buff, *ptrb;
+  Int  *buff, *ptrb;
 {
-  int   h, v, sizebuff;
-  int  *ptr2;
+  Int   h, v, sizebuff;
+  Int  *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
     ptr2 = ptrb + hi[h].lstart * mb->lda;
@@ -684,12 +684,12 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
     }
   }
 }
-static2 int 
+static2 Int 
 inter_len(hinb, hi, vinb, vi)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
 {
-  int   hlen, vlen, h, v;
+  Int   hlen, vlen, h, v;
   hlen = 0;
   for (h = 0; h < hinb; h++)
     hlen += hi[h].len;
@@ -700,10 +700,10 @@ inter_len(hinb, hi, vinb, vi)
 }
 void 
 Clacpy(m, n, a, lda, b, ldb)
-  int  *a, *b;
-  int   m, n, lda, ldb;
+  Int  *a, *b;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -716,23 +716,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pigemr2.c
+++ b/REDIST/SRC/pigemr2.c
@@ -23,20 +23,20 @@
 #define Clacpy Cigelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 igescanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpigemr2do();
 extern void Cpigemr2d();
 /* some defines for Cpigemr2do */
@@ -111,22 +111,22 @@ extern void Cpigemr2d();
 /* Set the memory space with the malloc function */
 void
 setmemory(adpointer, blocksize)
-  int **adpointer;
-  int   blocksize;
+  Int **adpointer;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
     *adpointer = NULL;
     return;
   }
-  *adpointer = (int *) mr2d_malloc(
-				   blocksize * sizeof(int));
+  *adpointer = (Int *) mr2d_malloc(
+				   blocksize * sizeof(Int));
 }
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
 freememory(ptrtobefreed)
-  int  *ptrtobefreed;
+  Int  *ptrtobefreed;
 {
   if (ptrtobefreed == NULL)
     return;
@@ -137,24 +137,24 @@ freememory(ptrtobefreed)
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -166,8 +166,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {

--- a/REDIST/SRC/pitrmr.c
+++ b/REDIST/SRC/pitrmr.c
@@ -173,20 +173,20 @@
 #define Clacpy Citrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -200,7 +200,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -221,12 +221,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 itrscanD0
@@ -238,7 +238,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpitrmr2do();
 extern void Cpitrmr2d();
 /* some defines for Cpitrmr2do */
@@ -259,9 +259,9 @@ void
 fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
-  int  *A, *B;
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *A, *B;
 {
   Cpitrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
@@ -271,18 +271,18 @@ void
 fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
-  int  *A, *B;
-  int  *gcontext;
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *A, *B;
+  Int  *gcontext;
 {
   Cpitrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -290,19 +290,19 @@ Cpitrmr2do(uplo, diag, m, n,
 	   ptrmyblock, ia, ja, ma,
 	   ptrmynewblock, ib, jb, mb)
   char *uplo, *diag;
-  int  *ptrmyblock, *ptrmynewblock;
+  Int  *ptrmyblock, *ptrmynewblock;
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpitrmr2d(uplo, diag, m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -315,26 +315,26 @@ Cpitrmr2d(uplo, diag, m, n,
 	  ptrmyblock, ia, ja, ma,
 	  ptrmynewblock, ib, jb, mb, globcontext)
   char *uplo, *diag;
-  int  *ptrmyblock, *ptrmynewblock;
+  Int  *ptrmyblock, *ptrmynewblock;
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
-  int  *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
-  int  *recvptr;
+  Int  *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
+  Int  *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -365,7 +365,7 @@ Cpitrmr2d(uplo, diag, m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -400,8 +400,8 @@ Cpitrmr2d(uplo, diag, m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -447,7 +447,7 @@ Cpitrmr2d(uplo, diag, m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -501,9 +501,9 @@ Cpitrmr2d(uplo, diag, m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -540,8 +540,8 @@ Cpitrmr2d(uplo, diag, m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Cigesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Cigesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -557,12 +557,12 @@ Cpitrmr2d(uplo, diag, m, n,
 		 v_inter, vinter_nb, h_inter, hinter_nb, ptrNULL);
 	  if (recvsize > 0) {
 	    if (step == myrang && mesending) {
-	      Clacpy(recvsize, 1,
+	      Clacpy(recvsize, (Int)1,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Cigerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Cigerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -594,13 +594,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -650,10 +650,10 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 }
 void 
 Clacpy(m, n, a, lda, b, ldb)
-  int  *a, *b;
-  int   m, n, lda, ldb;
+  Int  *a, *b;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -666,23 +666,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pitrmr2.c
+++ b/REDIST/SRC/pitrmr2.c
@@ -23,20 +23,20 @@
 #define Clacpy Citrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 itrscanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpitrmr2do();
 extern void Cpitrmr2d();
 /* some defines for Cpitrmr2do */
@@ -111,22 +111,22 @@ extern void Cpitrmr2d();
 /* Set the memory space with the malloc function */
 void
 setmemory(adpointer, blocksize)
-  int **adpointer;
-  int   blocksize;
+  Int **adpointer;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
     *adpointer = NULL;
     return;
   }
-  *adpointer = (int *) mr2d_malloc(
-				   blocksize * sizeof(int));
+  *adpointer = (Int *) mr2d_malloc(
+				   blocksize * sizeof(Int));
 }
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
 freememory(ptrtobefreed)
-  int  *ptrtobefreed;
+  Int  *ptrtobefreed;
 {
   if (ptrtobefreed == NULL)
     return;
@@ -137,28 +137,28 @@ freememory(ptrtobefreed)
 /* return the number of elements int the column after i and the distance of
  * the first one from i, i,j can be negative out of borns, the number of
  * elements returned can be negative (means 0) */
-static2 int
+static2 Int
 insidemat(uplo, diag, i, j, m, n, offset)
-  int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
+  Int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
   char *uplo, *diag;
-  int  *offset;
+  Int  *offset;
 {
   /* tests outside mxn */
   assert(j >= 0 && j < n);
   assert(i >= 0);
   if (toupper(*uplo) == 'U') {
-    int   nbline;	/* number of lines in the j_th column */
-    int   virtualnbline;	/* number of line if we were not limited by m */
+    Int   nbline;	/* number of lines in the j_th column */
+    Int   virtualnbline;	/* number of line if we were not limited by m */
     *offset = 0;
     virtualnbline = max(m - n, 0) + j + (toupper(*diag) == 'N');
     nbline = min(virtualnbline, m);
     return nbline - i;
   } else {
-    int   firstline;	/* first line in the j_th column */
-    int   diagcol;	/* column where the diag begin */
-    int   virtualline;	/* virtual first line if the matrix was extended with
+    Int   firstline;	/* first line in the j_th column */
+    Int   diagcol;	/* column where the diag begin */
+    Int   virtualline;	/* virtual first line if the matrix was extended with
 			 * negative indices */
-    int   off;
+    Int   off;
     diagcol = max(n - m, 0);;
     virtualline = j - diagcol + (toupper(*diag) == 'U');
     firstline = max(0, virtualline);
@@ -180,13 +180,13 @@ intersect(uplo, diag,
 	  m, n,
 	  ma, ia, ja, templateheight0, templatewidth0,
 	  mb, ib, jb, templateheight1, templatewidth1)
-  int   action, *ptrsizebuff;
-  int   j, start, end;
-  int **pptrbuff, *ptrblock;
-  int   templateheight0, templatewidth0;
-  int   templateheight1, templatewidth1;
+  Int   action, *ptrsizebuff;
+  Int   j, start, end;
+  Int **pptrbuff, *ptrblock;
+  Int   templateheight0, templatewidth0;
+  Int   templateheight1, templatewidth1;
   MDESC *ma, *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
   char *uplo, *diag;
 /* Execute the action on the local memory for the current interval and
  * increment pptrbuff and ptrsizebuff of the intervalsize */
@@ -194,9 +194,9 @@ intersect(uplo, diag,
  * also contigous in the real one ! */
 {
   /* int       un = 1; only when we use dcopy instead of memcpy */
-  int  *ptrstart;
-  int   offset, nbline;
-  int   intervalsize;
+  Int  *ptrstart;
+  Int   offset, nbline;
+  Int   intervalsize;
   assert(start < end);
   assert(j >= 0 && j < n);
   nbline =
@@ -213,7 +213,7 @@ intersect(uplo, diag,
     ptrstart = ptrblock + localindice(start + ia, j + ja,
 				      templateheight0, templatewidth0, ma);
     memcpy((char *) (*pptrbuff), (char *) ptrstart,
-	   intervalsize * sizeof(int));
+	   intervalsize * sizeof(Int));
     /* icopy_(&intervalsize, (char *) (ptrstart), &un, (char *) (*pptrbuff),
      * &un); */
     (*pptrbuff) += intervalsize;
@@ -222,7 +222,7 @@ intersect(uplo, diag,
     ptrstart = ptrblock + localindice(start + ib, j + jb,
 				      templateheight1, templatewidth1, mb);
     memcpy((char *) ptrstart, (char *) (*pptrbuff),
-	   intervalsize * sizeof(int));
+	   intervalsize * sizeof(Int));
     /* icopy_(&intervalsize, (char *) (*pptrbuff), &un, (char *) (ptrstart),
      * &un); */
     (*pptrbuff) += intervalsize;
@@ -239,24 +239,24 @@ intersect(uplo, diag,
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -268,8 +268,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {
@@ -317,23 +317,23 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
        v_inter, vinter_nb,
        h_inter, hinter_nb,
        ptrblock)
-  int   action,	/* # of the action done on the intersected intervals  */
+  Int   action,	/* # of the action done on the intersected intervals  */
        *ptrsizebuff;	/* size of the communication ptrbuffer (chosen to be
 			 * an output parameter in every cases) */
-  int  *ptrbuff	/* address of the communication ptrbuffer (a suffisant memory
+  Int  *ptrbuff	/* address of the communication ptrbuffer (a suffisant memory
       space is supposed to be allocated before the call) */ , *ptrblock;
-  int   p0, q0, p1, q1;
+  Int   p0, q0, p1, q1;
   IDESC *v_inter, *h_inter;
-  int   vinter_nb, hinter_nb;
-  int   m, n;
-  int   ia, ja, ib, jb;
+  Int   vinter_nb, hinter_nb;
+  Int   m, n;
+  Int   ia, ja, ib, jb;
   MDESC *ma, *mb;
   char *uplo, *diag;
 {/* Rmk: the a+au type addresses are strict bounds as a+au does not belong to
   * the [a..a+au-1] interval of length au */
-  int   templateheight1, templatewidth1;
-  int   templateheight0, templatewidth0;
-  int   h, v;	/* for scanning the intervals */
+  Int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   h, v;	/* for scanning the intervals */
   /* initializations */
   templateheight1 = p1 * mb->nbrow;
   templateheight0 = p0 * ma->nbrow;
@@ -345,7 +345,7 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
   (*ptrsizebuff) = 0;
   for (h = 0; h < hinter_nb; h++)
     for (v = 0; v < vinter_nb; v++) {
-      int   j;
+      Int   j;
       for (j = 0; j < h_inter[h].len; j++)
 	intersect(uplo, diag, j + h_inter[h].gstart,
 		  v_inter[v].gstart, v_inter[v].gstart + v_inter[v].len,

--- a/REDIST/SRC/psgemr.c
+++ b/REDIST/SRC/psgemr.c
@@ -158,20 +158,20 @@
 #define Clacpy Csgelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -185,7 +185,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -206,12 +206,12 @@ extern void Csgerv2d();
 /* lapack */
 void  slacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 sgescanD0
@@ -223,7 +223,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpsgemr2do();
 extern void Cpsgemr2d();
 /* some defines for Cpsgemr2do */
@@ -243,8 +243,8 @@ extern void Cpsgemr2d();
 void 
 fortran_mr2d(m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   float *A, *B;
 {
   Cpsgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -254,18 +254,18 @@ fortran_mr2d(m, n, A, ia, ja, desc_A,
 void 
 fortran_mr2dnew(m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   float *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpsgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -276,15 +276,15 @@ Cpsgemr2do(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpsgemr2d(m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -300,22 +300,22 @@ Cpsgemr2d(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   float *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   float *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -346,7 +346,7 @@ Cpsgemr2d(m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -381,8 +381,12 @@ Cpsgemr2d(m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  printf("Aproc0 = {%d,%d}\n", proc0[0], proc0[1]);
+  printf("Aproc1 = {%d,%d}\n", proc1[0], proc1[1]);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
+  printf("Bproc0 = {%d,%d}\n", proc0[0], proc0[1]);
+  printf("Bproc1 = {%d,%d}\n", proc1[0], proc1[1]);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -428,7 +432,7 @@ Cpsgemr2d(m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -482,9 +486,9 @@ Cpsgemr2d(m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -519,8 +523,8 @@ Cpsgemr2d(m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Csgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Csgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -538,7 +542,7 @@ Cpsgemr2d(m, n,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Csgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
+	      Csgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
 		       0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
@@ -570,13 +574,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -627,8 +631,8 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 #define Mlacpy(mo,no,ao,ldao,bo,ldbo) \
 { \
 float *_a,*_b; \
-int _m,_n,_lda,_ldb; \
-    int _i,_j; \
+Int _m,_n,_lda,_ldb; \
+    Int _i,_j; \
     _m = (mo);_n = (no); \
     _a = (ao);_b = (bo); \
     _lda = (ldao) - _m; \
@@ -641,14 +645,14 @@ int _m,_n,_lda,_ldb; \
       _a += _lda; \
     } \
 }
-static2 int 
+static2 Int 
 block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *ma;
   float *buff, *ptra;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   float *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -665,12 +669,12 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
 }
 static2 void 
 buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *mb;
   float *buff, *ptrb;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   float *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -684,12 +688,12 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
     }
   }
 }
-static2 int 
+static2 Int 
 inter_len(hinb, hi, vinb, vi)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
 {
-  int   hlen, vlen, h, v;
+  Int   hlen, vlen, h, v;
   hlen = 0;
   for (h = 0; h < hinb; h++)
     hlen += hi[h].len;
@@ -701,9 +705,9 @@ inter_len(hinb, hi, vinb, vi)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   float *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -716,23 +720,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/psgemr2.c
+++ b/REDIST/SRC/psgemr2.c
@@ -23,20 +23,20 @@
 #define Clacpy Csgelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Csgerv2d();
 /* lapack */
 void  slacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 sgescanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpsgemr2do();
 extern void Cpsgemr2d();
 /* some defines for Cpsgemr2do */
@@ -112,7 +112,7 @@ extern void Cpsgemr2d();
 void
 setmemory(adpointer, blocksize)
   float **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -137,24 +137,24 @@ freememory(ptrtobefreed)
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -166,8 +166,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {

--- a/REDIST/SRC/pstrmr.c
+++ b/REDIST/SRC/pstrmr.c
@@ -173,20 +173,20 @@
 #define Clacpy Cstrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -200,7 +200,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -221,12 +221,12 @@ extern void Csgerv2d();
 /* lapack */
 void  slacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 strscanD0
@@ -238,7 +238,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpstrmr2do();
 extern void Cpstrmr2d();
 /* some defines for Cpstrmr2do */
@@ -259,8 +259,8 @@ void
 fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   float *A, *B;
 {
   Cpstrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -271,18 +271,18 @@ void
 fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   float *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpstrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -294,15 +294,15 @@ Cpstrmr2do(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpstrmr2d(uplo, diag, m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -319,22 +319,22 @@ Cpstrmr2d(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   float *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   float *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -365,7 +365,7 @@ Cpstrmr2d(uplo, diag, m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -400,8 +400,8 @@ Cpstrmr2d(uplo, diag, m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -447,7 +447,7 @@ Cpstrmr2d(uplo, diag, m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -501,9 +501,9 @@ Cpstrmr2d(uplo, diag, m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -540,8 +540,8 @@ Cpstrmr2d(uplo, diag, m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Csgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Csgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -557,12 +557,12 @@ Cpstrmr2d(uplo, diag, m, n,
 		 v_inter, vinter_nb, h_inter, hinter_nb, ptrNULL);
 	  if (recvsize > 0) {
 	    if (step == myrang && mesending) {
-	      Clacpy(recvsize, 1,
+	      Clacpy(recvsize, (Int)1,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Csgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Csgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -594,13 +594,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -651,9 +651,9 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   float *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -666,23 +666,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pstrmr2.c
+++ b/REDIST/SRC/pstrmr2.c
@@ -23,20 +23,20 @@
 #define Clacpy Cstrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -50,7 +50,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -71,12 +71,12 @@ extern void Csgerv2d();
 /* lapack */
 void  slacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 strscanD0
@@ -88,7 +88,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpstrmr2do();
 extern void Cpstrmr2d();
 /* some defines for Cpstrmr2do */
@@ -112,7 +112,7 @@ extern void Cpstrmr2d();
 void
 setmemory(adpointer, blocksize)
   float **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -137,28 +137,28 @@ freememory(ptrtobefreed)
 /* return the number of elements int the column after i and the distance of
  * the first one from i, i,j can be negative out of borns, the number of
  * elements returned can be negative (means 0) */
-static2 int
+static2 Int
 insidemat(uplo, diag, i, j, m, n, offset)
-  int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
+  Int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
   char *uplo, *diag;
-  int  *offset;
+  Int  *offset;
 {
   /* tests outside mxn */
   assert(j >= 0 && j < n);
   assert(i >= 0);
   if (toupper(*uplo) == 'U') {
-    int   nbline;	/* number of lines in the j_th column */
-    int   virtualnbline;	/* number of line if we were not limited by m */
+    Int   nbline;	/* number of lines in the j_th column */
+    Int   virtualnbline;	/* number of line if we were not limited by m */
     *offset = 0;
     virtualnbline = max(m - n, 0) + j + (toupper(*diag) == 'N');
     nbline = min(virtualnbline, m);
     return nbline - i;
   } else {
-    int   firstline;	/* first line in the j_th column */
-    int   diagcol;	/* column where the diag begin */
-    int   virtualline;	/* virtual first line if the matrix was extended with
+    Int   firstline;	/* first line in the j_th column */
+    Int   diagcol;	/* column where the diag begin */
+    Int   virtualline;	/* virtual first line if the matrix was extended with
 			 * negative indices */
-    int   off;
+    Int   off;
     diagcol = max(n - m, 0);;
     virtualline = j - diagcol + (toupper(*diag) == 'U');
     firstline = max(0, virtualline);
@@ -180,13 +180,13 @@ intersect(uplo, diag,
 	  m, n,
 	  ma, ia, ja, templateheight0, templatewidth0,
 	  mb, ib, jb, templateheight1, templatewidth1)
-  int   action, *ptrsizebuff;
-  int   j, start, end;
+  Int   action, *ptrsizebuff;
+  Int   j, start, end;
   float **pptrbuff, *ptrblock;
-  int   templateheight0, templatewidth0;
-  int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   templateheight1, templatewidth1;
   MDESC *ma, *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
   char *uplo, *diag;
 /* Execute the action on the local memory for the current interval and
  * increment pptrbuff and ptrsizebuff of the intervalsize */
@@ -195,8 +195,8 @@ intersect(uplo, diag,
 {
   /* int       un = 1; only when we use dcopy instead of memcpy */
   float *ptrstart;
-  int   offset, nbline;
-  int   intervalsize;
+  Int   offset, nbline;
+  Int   intervalsize;
   assert(start < end);
   assert(j >= 0 && j < n);
   nbline =
@@ -239,24 +239,24 @@ intersect(uplo, diag,
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -268,8 +268,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {
@@ -317,24 +317,24 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
        v_inter, vinter_nb,
        h_inter, hinter_nb,
        ptrblock)
-  int   action,	/* # of the action done on the intersected intervals  */
+  Int   action,	/* # of the action done on the intersected intervals  */
        *ptrsizebuff;	/* size of the communication ptrbuffer (chosen to be
 			 * an output parameter in every cases) */
   float *ptrbuff	/* address of the communication ptrbuffer (a
 			 * suffisant memory space is supposed to be allocated
       before the call) */ , *ptrblock;
-  int   p0, q0, p1, q1;
+  Int   p0, q0, p1, q1;
   IDESC *v_inter, *h_inter;
-  int   vinter_nb, hinter_nb;
-  int   m, n;
-  int   ia, ja, ib, jb;
+  Int   vinter_nb, hinter_nb;
+  Int   m, n;
+  Int   ia, ja, ib, jb;
   MDESC *ma, *mb;
   char *uplo, *diag;
 {/* Rmk: the a+au type addresses are strict bounds as a+au does not belong to
   * the [a..a+au-1] interval of length au */
-  int   templateheight1, templatewidth1;
-  int   templateheight0, templatewidth0;
-  int   h, v;	/* for scanning the intervals */
+  Int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   h, v;	/* for scanning the intervals */
   /* initializations */
   templateheight1 = p1 * mb->nbrow;
   templateheight0 = p0 * ma->nbrow;
@@ -346,7 +346,7 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
   (*ptrsizebuff) = 0;
   for (h = 0; h < hinter_nb; h++)
     for (v = 0; v < vinter_nb; v++) {
-      int   j;
+      Int   j;
       for (j = 0; j < h_inter[h].len; j++)
 	intersect(uplo, diag, j + h_inter[h].gstart,
 		  v_inter[v].gstart, v_inter[v].gstart + v_inter[v].len,

--- a/REDIST/SRC/pzgemr.c
+++ b/REDIST/SRC/pzgemr.c
@@ -161,20 +161,20 @@ typedef struct {
   double r, i;
 }     dcomplex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -188,7 +188,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -209,12 +209,12 @@ extern void Czgerv2d();
 /* lapack */
 void  zlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 zgescanD0
@@ -226,7 +226,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpzgemr2do();
 extern void Cpzgemr2d();
 /* some defines for Cpzgemr2do */
@@ -246,8 +246,8 @@ extern void Cpzgemr2d();
 void 
 fortran_mr2d(m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   dcomplex *A, *B;
 {
   Cpzgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -257,18 +257,18 @@ fortran_mr2d(m, n, A, ia, ja, desc_A,
 void 
 fortran_mr2dnew(m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   dcomplex *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpzgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -279,15 +279,15 @@ Cpzgemr2do(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpzgemr2d(m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -303,22 +303,22 @@ Cpzgemr2d(m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   dcomplex *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   dcomplex *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -349,7 +349,7 @@ Cpzgemr2d(m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -384,8 +384,8 @@ Cpzgemr2d(m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -431,7 +431,7 @@ Cpzgemr2d(m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -485,9 +485,9 @@ Cpzgemr2d(m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -522,8 +522,8 @@ Cpzgemr2d(m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Czgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Czgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -537,12 +537,12 @@ Cpzgemr2d(m, n,
 	  recvsize = inter_len(hinter_nb, h_inter, vinter_nb, v_inter);
 	  if (recvsize > 0) {
 	    if (step == myrang && mesending) {
-	      Clacpy(recvsize, 1,
+	      Clacpy(recvsize, (Int)1,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Czgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Czgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -573,13 +573,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -630,8 +630,8 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 #define Mlacpy(mo,no,ao,ldao,bo,ldbo) \
 { \
 dcomplex *_a,*_b; \
-int _m,_n,_lda,_ldb; \
-    int _i,_j; \
+Int _m,_n,_lda,_ldb; \
+    Int _i,_j; \
     _m = (mo);_n = (no); \
     _a = (ao);_b = (bo); \
     _lda = (ldao) - _m; \
@@ -644,14 +644,14 @@ int _m,_n,_lda,_ldb; \
       _a += _lda; \
     } \
 }
-static2 int 
+static2 Int 
 block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *ma;
   dcomplex *buff, *ptra;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   dcomplex *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -668,12 +668,12 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
 }
 static2 void 
 buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
   MDESC *mb;
   dcomplex *buff, *ptrb;
 {
-  int   h, v, sizebuff;
+  Int   h, v, sizebuff;
   dcomplex *ptr2;
   sizebuff = 0;
   for (h = 0; h < hinb; h++) {
@@ -687,12 +687,12 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
     }
   }
 }
-static2 int 
+static2 Int 
 inter_len(hinb, hi, vinb, vi)
-  int   hinb, vinb;
+  Int   hinb, vinb;
   IDESC *hi, *vi;
 {
-  int   hlen, vlen, h, v;
+  Int   hlen, vlen, h, v;
   hlen = 0;
   for (h = 0; h < hinb; h++)
     hlen += hi[h].len;
@@ -704,9 +704,9 @@ inter_len(hinb, hi, vinb, vi)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   dcomplex *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -719,23 +719,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pzgemr2.c
+++ b/REDIST/SRC/pzgemr2.c
@@ -26,20 +26,20 @@ typedef struct {
   double r, i;
 }     dcomplex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -53,7 +53,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -74,12 +74,12 @@ extern void Czgerv2d();
 /* lapack */
 void  zlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 zgescanD0
@@ -91,7 +91,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpzgemr2do();
 extern void Cpzgemr2d();
 /* some defines for Cpzgemr2do */
@@ -115,7 +115,7 @@ extern void Cpzgemr2d();
 void
 setmemory(adpointer, blocksize)
   dcomplex **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -140,24 +140,24 @@ freememory(ptrtobefreed)
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -169,8 +169,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {

--- a/REDIST/SRC/pztrmr.c
+++ b/REDIST/SRC/pztrmr.c
@@ -176,20 +176,20 @@ typedef struct {
   double r, i;
 }     dcomplex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -203,7 +203,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -224,12 +224,12 @@ extern void Czgerv2d();
 /* lapack */
 void  zlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 ztrscanD0
@@ -241,7 +241,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpztrmr2do();
 extern void Cpztrmr2d();
 /* some defines for Cpztrmr2do */
@@ -262,8 +262,8 @@ void
 fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
 	     B, ib, jb, desc_B)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   dcomplex *A, *B;
 {
   Cpztrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
@@ -274,18 +274,18 @@ void
 fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
 		B, ib, jb, desc_B, gcontext)
   char *uplo, *diag;
-  int  *ia, *ib, *ja, *jb, *m, *n;
-  int   desc_A[DESCLEN], desc_B[DESCLEN];
+  Int  *ia, *ib, *ja, *jb, *m, *n;
+  Int   desc_A[DESCLEN], desc_B[DESCLEN];
   dcomplex *A, *B;
-  int  *gcontext;
+  Int  *gcontext;
 {
   Cpztrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
   return;
 }
 static2 void init_chenille();
-static2 int inter_len();
-static2 int block2buff();
+static2 Int inter_len();
+static2 Int block2buff();
 static2 void buff2block();
 static2 void gridreshape();
 void
@@ -297,15 +297,15 @@ Cpztrmr2do(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
 {
-  int   dummy, nprocs;
-  int   gcontext;
+  Int   dummy, nprocs;
+  Int   gcontext;
   /* first we initialize a global grid which serve as a reference to
    * communicate from grid a to grid b */
   Cblacs_pinfo(&dummy, &nprocs);
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", 1, nprocs);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", (Int)1, nprocs);
   Cpztrmr2d(uplo, diag, m, n, ptrmyblock, ia, ja, ma,
 	    ptrmynewblock, ib, jb, mb, gcontext);
   Cblacs_gridexit(gcontext);
@@ -322,22 +322,22 @@ Cpztrmr2d(uplo, diag, m, n,
 /* pointers to the memory location of the matrix and the redistributed matrix */
   MDESC *ma;
   MDESC *mb;
-  int   ia, ja, ib, jb, m, n, globcontext;
+  Int   ia, ja, ib, jb, m, n, globcontext;
 {
   dcomplex *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   dcomplex *recvptr;
   MDESC newa, newb;
-  int  *proc0, *proc1, *param;
-  int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
-  int   i, j;
-  int   nprow, npcol, gcontext;
-  int   recvsize, sendsize;
+  Int  *proc0, *proc1, *param;
+  Int   mypnum, myprow0, mypcol0, myprow1, mypcol1, nprocs;
+  Int   i, j;
+  Int   nprow, npcol, gcontext;
+  Int   recvsize, sendsize;
   IDESC *h_inter;	/* to store the horizontal intersections */
   IDESC *v_inter;	/* to store the vertical intersections */
-  int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
-  int   dummy;
-  int   p0, q0, p1, q1;
-  int  *ra, *ca;
+  Int   hinter_nb, vinter_nb;	/* number of intrsections in both directions */
+  Int   dummy;
+  Int   p0, q0, p1, q1;
+  Int  *ra, *ca;
   /* end of variables */
   /* To simplify further calcul we change the matrix indexation from
    * 1..m,1..n (fortran) to 0..m-1,0..n-1 */
@@ -368,7 +368,7 @@ Cpztrmr2d(uplo, diag, m, n,
   assert((myprow1 < p1 && mypcol1 < q1) || (myprow1 == -1 && mypcol1 == -1));
   /* exchange the missing parameters among the processors: shape of grids and
    * location of the processors */
-  param = (int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(int));
+  param = (Int *) mr2d_malloc(3 * (nprocs * 2 + NBPARAM) * sizeof(Int));
   ra = param + nprocs * 2 + NBPARAM;
   ca = param + (nprocs * 2 + NBPARAM) * 2;
   for (i = 0; i < nprocs * 2 + NBPARAM; i++)
@@ -403,8 +403,8 @@ Cpztrmr2d(uplo, diag, m, n,
     param[18] = ib;
     param[19] = jb;
   }
-  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, 1, param, 2 * nprocs + NBPARAM,
-	   ra, ca, 2 * nprocs + NBPARAM, -1, -1);
+  Cigamn2d(gcontext, "All", "H", 2 * nprocs + NBPARAM, (Int)1, param, 2 * nprocs + NBPARAM,
+	   ra, ca, 2 * nprocs + NBPARAM, (Int)-1, (Int)-1);
   newa = *ma;
   newb = *mb;
   ma = &newa;
@@ -450,7 +450,7 @@ Cpztrmr2d(uplo, diag, m, n,
   paramcheck(mb, ib, jb, m, n, p1, q1, gcontext);
   /* we change the problem so that ia < a->nbrow ... andia + m = a->m ... */
   {
-    int   decal;
+    Int   decal;
     ia = changeorigin(myprow0, ma->sprow, p0,
 		      ma->nbrow, ia, &decal, &ma->sprow);
     ptrmyblock += decal;
@@ -504,9 +504,9 @@ Cpztrmr2d(uplo, diag, m, n,
    * of recvbuff the right place (scanD)(RECVBUFF)) */
   recvptr = ptrrecvbuff;
   {
-    int   tot, myrang, step, sens;
-    int  *sender, *recver;
-    int   mesending, merecving;
+    Int   tot, myrang, step, sens;
+    Int  *sender, *recver;
+    Int   mesending, merecving;
     tot = max(p0 * q0, p1 * q1);
     init_chenille(mypnum, nprocs, p0 * q0, proc0, p1 * q1, proc1,
 		  &sender, &recver, &myrang);
@@ -543,8 +543,8 @@ Cpztrmr2d(uplo, diag, m, n,
 	  if (sendsize > 0
 	      && (step != myrang || !merecving)
 		) {
-	    Czgesd2d(gcontext, sendsize, 1, ptrsendbuff, sendsize,
-		     0, proc1[i * q1 + j]);
+	    Czgesd2d(gcontext, sendsize, (Int)1, ptrsendbuff, sendsize,
+		     (Int)0, proc1[i * q1 + j]);
 	  }	/* sendsize > 0 */
 	}	/* if (mesending ... */
 	if (merecving && sender[step] >= 0 &&
@@ -564,8 +564,8 @@ Cpztrmr2d(uplo, diag, m, n,
 		     ptrsendbuff, recvsize,
 		     ptrrecvbuff, recvsize);
 	    } else {
-	      Czgerv2d(gcontext, recvsize, 1, ptrrecvbuff, recvsize,
-		       0, proc0[i * q0 + j]);
+	      Czgerv2d(gcontext, recvsize, (Int)1, ptrrecvbuff, recvsize,
+		       (Int)0, proc0[i * q0 + j]);
 	    }
 	  }	/* recvsize > 0 */
 	}	/* if (merecving ...) */
@@ -597,13 +597,13 @@ after_comm:
 }/* distrib */
 static2 void 
 init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  int   nprocs, mypnum, n0, n1;
-  int  *proc0, *proc1, **psend, **precv, *myrang;
+  Int   nprocs, mypnum, n0, n1;
+  Int  *proc0, *proc1, **psend, **precv, *myrang;
 {
-  int   ns, nr, i, tot;
-  int  *sender, *recver, *g0, *g1;
+  Int   ns, nr, i, tot;
+  Int  *sender, *recver, *g0, *g1;
   tot = max(n0, n1);
-  sender = (int *) mr2d_malloc((nprocs + tot) * sizeof(int) * 2);
+  sender = (Int *) mr2d_malloc((nprocs + tot) * sizeof(Int) * 2);
   recver = sender + tot;
   *psend = sender;
   *precv = recver;
@@ -654,9 +654,9 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
 void 
 Clacpy(m, n, a, lda, b, ldb)
   dcomplex *a, *b;
-  int   m, n, lda, ldb;
+  Int   m, n, lda, ldb;
 {
-  int   i, j;
+  Int   i, j;
   lda -= m;
   ldb -= m;
   assert(lda >= 0 && ldb >= 0);
@@ -669,23 +669,23 @@ Clacpy(m, n, a, lda, b, ldb)
 }
 static2 void 
 gridreshape(ctxtp)
-  int  *ctxtp;
+  Int  *ctxtp;
 {
-  int   ori, final;	/* original context, and new context created, with
+  Int   ori, final;	/* original context, and new context created, with
 			 * line form */
-  int   nprow, npcol, myrow, mycol;
-  int  *usermap;
-  int   i, j;
+  Int   nprow, npcol, myrow, mycol;
+  Int  *usermap;
+  Int   i, j;
   ori = *ctxtp;
   Cblacs_gridinfo(ori, &nprow, &npcol, &myrow, &mycol);
-  usermap = mr2d_malloc(sizeof(int) * nprow * npcol);
+  usermap = mr2d_malloc(sizeof(Int) * nprow * npcol);
   for (i = 0; i < nprow; i++)
     for (j = 0; j < npcol; j++) {
       usermap[i + j * nprow] = Cblacs_pnum(ori, i, j);
     }
   /* Cblacs_get(0, 0, &final); */
-  Cblacs_get(ori, 10, &final);
-  Cblacs_gridmap(&final, usermap, 1, 1, nprow * npcol);
+  Cblacs_get(ori, (Int)10, &final);
+  Cblacs_gridmap(&final, usermap, (Int)1, (Int)1, nprow * npcol);
   *ctxtp = final;
   free(usermap);
 }

--- a/REDIST/SRC/pztrmr2.c
+++ b/REDIST/SRC/pztrmr2.c
@@ -26,20 +26,20 @@ typedef struct {
   double r, i;
 }     dcomplex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -53,7 +53,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -74,12 +74,12 @@ extern void Czgerv2d();
 /* lapack */
 void  zlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 ztrscanD0
@@ -91,7 +91,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpztrmr2do();
 extern void Cpztrmr2d();
 /* some defines for Cpztrmr2do */
@@ -115,7 +115,7 @@ extern void Cpztrmr2d();
 void
 setmemory(adpointer, blocksize)
   dcomplex **adpointer;
-  int   blocksize;
+  Int   blocksize;
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -140,28 +140,28 @@ freememory(ptrtobefreed)
 /* return the number of elements int the column after i and the distance of
  * the first one from i, i,j can be negative out of borns, the number of
  * elements returned can be negative (means 0) */
-static2 int
+static2 Int
 insidemat(uplo, diag, i, j, m, n, offset)
-  int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
+  Int   m, n, i, j;	/* coordonnees de depart, taille de la sous-matrice */
   char *uplo, *diag;
-  int  *offset;
+  Int  *offset;
 {
   /* tests outside mxn */
   assert(j >= 0 && j < n);
   assert(i >= 0);
   if (toupper(*uplo) == 'U') {
-    int   nbline;	/* number of lines in the j_th column */
-    int   virtualnbline;	/* number of line if we were not limited by m */
+    Int   nbline;	/* number of lines in the j_th column */
+    Int   virtualnbline;	/* number of line if we were not limited by m */
     *offset = 0;
     virtualnbline = max(m - n, 0) + j + (toupper(*diag) == 'N');
     nbline = min(virtualnbline, m);
     return nbline - i;
   } else {
-    int   firstline;	/* first line in the j_th column */
-    int   diagcol;	/* column where the diag begin */
-    int   virtualline;	/* virtual first line if the matrix was extended with
+    Int   firstline;	/* first line in the j_th column */
+    Int   diagcol;	/* column where the diag begin */
+    Int   virtualline;	/* virtual first line if the matrix was extended with
 			 * negative indices */
-    int   off;
+    Int   off;
     diagcol = max(n - m, 0);;
     virtualline = j - diagcol + (toupper(*diag) == 'U');
     firstline = max(0, virtualline);
@@ -183,13 +183,13 @@ intersect(uplo, diag,
 	  m, n,
 	  ma, ia, ja, templateheight0, templatewidth0,
 	  mb, ib, jb, templateheight1, templatewidth1)
-  int   action, *ptrsizebuff;
-  int   j, start, end;
+  Int   action, *ptrsizebuff;
+  Int   j, start, end;
   dcomplex **pptrbuff, *ptrblock;
-  int   templateheight0, templatewidth0;
-  int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   templateheight1, templatewidth1;
   MDESC *ma, *mb;
-  int   ia, ja, ib, jb, m, n;
+  Int   ia, ja, ib, jb, m, n;
   char *uplo, *diag;
 /* Execute the action on the local memory for the current interval and
  * increment pptrbuff and ptrsizebuff of the intervalsize */
@@ -198,8 +198,8 @@ intersect(uplo, diag,
 {
   /* int       un = 1; only when we use dcopy instead of memcpy */
   dcomplex *ptrstart;
-  int   offset, nbline;
-  int   intervalsize;
+  Int   offset, nbline;
+  Int   intervalsize;
   assert(start < end);
   assert(j >= 0 && j < n);
   nbline =
@@ -242,24 +242,24 @@ intersect(uplo, diag,
  * intersections on the local processor. result must be long enough to
  * contains the result that are stocked in IDESC structure, the function
  * returns the number of intersections found */
-int 
+Int 
 scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
 	       result)
   char  type;
-  int   ja, jb, n, q0, q1, col0, col1;
+  Int   ja, jb, n, q0, q1, col0, col1;
   MDESC *ma, *mb;
   IDESC *result;
 {
-  int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
-  int   l;	/* local indice on the beginning of the interval */
+  Int   offset, j0, j1, templatewidth0, templatewidth1, nbcol0, nbcol1;
+  Int   l;	/* local indice on the beginning of the interval */
   assert(type == 'c' || type == 'r');
   nbcol0 = (type == 'c' ? ma->nbcol : ma->nbrow);
   nbcol1 = (type == 'c' ? mb->nbcol : mb->nbrow);
   templatewidth0 = q0 * nbcol0;
   templatewidth1 = q1 * nbcol1;
   {
-    int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
-    int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
+    Int   sp0 = (type == 'c' ? ma->spcol : ma->sprow);
+    Int   sp1 = (type == 'c' ? mb->spcol : mb->sprow);
     j0 = SHIFT(col0, sp0, q0) * nbcol0 - ja;
     j1 = SHIFT(col1, sp1, q1) * nbcol1 - jb;
   }
@@ -271,8 +271,8 @@ scan_intervals(type, ja, jb, n, ma, mb, q0, q1, col0, col1,
   assert(j0 + nbcol0 > 0);
   assert(j1 + nbcol1 > 0);
   while ((j0 < n) && (j1 < n)) {
-    int   end0, end1;
-    int   start, end;
+    Int   end0, end1;
+    Int   start, end;
     end0 = j0 + nbcol0;
     end1 = j1 + nbcol1;
     if (end0 <= j1) {
@@ -320,24 +320,24 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
        v_inter, vinter_nb,
        h_inter, hinter_nb,
        ptrblock)
-  int   action,	/* # of the action done on the intersected intervals  */
+  Int   action,	/* # of the action done on the intersected intervals  */
        *ptrsizebuff;	/* size of the communication ptrbuffer (chosen to be
 			 * an output parameter in every cases) */
   dcomplex *ptrbuff	/* address of the communication ptrbuffer (a
 			 * suffisant memory space is supposed to be allocated
       before the call) */ , *ptrblock;
-  int   p0, q0, p1, q1;
+  Int   p0, q0, p1, q1;
   IDESC *v_inter, *h_inter;
-  int   vinter_nb, hinter_nb;
-  int   m, n;
-  int   ia, ja, ib, jb;
+  Int   vinter_nb, hinter_nb;
+  Int   m, n;
+  Int   ia, ja, ib, jb;
   MDESC *ma, *mb;
   char *uplo, *diag;
 {/* Rmk: the a+au type addresses are strict bounds as a+au does not belong to
   * the [a..a+au-1] interval of length au */
-  int   templateheight1, templatewidth1;
-  int   templateheight0, templatewidth0;
-  int   h, v;	/* for scanning the intervals */
+  Int   templateheight1, templatewidth1;
+  Int   templateheight0, templatewidth0;
+  Int   h, v;	/* for scanning the intervals */
   /* initializations */
   templateheight1 = p1 * mb->nbrow;
   templateheight0 = p0 * ma->nbrow;
@@ -349,7 +349,7 @@ scanD0(uplo, diag, action, ptrbuff, ptrsizebuff,
   (*ptrsizebuff) = 0;
   for (h = 0; h < hinter_nb; h++)
     for (v = 0; v < vinter_nb; v++) {
-      int   j;
+      Int   j;
       for (j = 0; j < h_inter[h].len; j++)
 	intersect(uplo, diag, j + h_inter[h].gstart,
 		  v_inter[v].gstart, v_inter[v].gstart + v_inter[v].len,

--- a/REDIST/SRC/redist.h
+++ b/REDIST/SRC/redist.h
@@ -7,3 +7,6 @@
 #ifdef CRAY
 #define float double
 #endif
+#ifndef Int
+#define Int int
+#endif

--- a/REDIST/TESTING/pcgemrdrv.c
+++ b/REDIST/TESTING/pcgemrdrv.c
@@ -79,20 +79,20 @@ typedef struct {
   float r, i;
 }     complex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -106,7 +106,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -127,12 +127,12 @@ extern void Ccgerv2d();
 /* lapack */
 void  clacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 cgescanD0
@@ -144,7 +144,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpcgemr2do();
 extern void Cpcgemr2d();
 /* some defines for Cpcgemr2do */
@@ -167,10 +167,10 @@ extern void Cpcgemr2d();
 static2 void
 initblock(block, m, n)
   complex *block;
-  int   m, n;
+  Int   m, n;
 {
   complex *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata).r = i;
@@ -192,10 +192,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -212,7 +212,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -220,16 +220,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -253,23 +253,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   complex *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
 #ifdef UsingMpiBlacs
@@ -284,8 +284,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("GEMR2D.dat", "r")) == NULL) {
@@ -296,9 +296,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -316,7 +316,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -361,9 +361,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[19] = n;
       parameters[20] = mb.m;
       parameters[21] = mb.n;
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -389,9 +389,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       ma.desctype = BLOCK_CYCLIC_2D;
       mb.desctype = BLOCK_CYCLIC_2D;
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -439,8 +439,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -470,7 +470,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -495,6 +495,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pctrmrdrv.c
+++ b/REDIST/TESTING/pctrmrdrv.c
@@ -79,20 +79,20 @@ typedef struct {
   float r, i;
 }     complex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -106,7 +106,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -127,12 +127,12 @@ extern void Ccgerv2d();
 /* lapack */
 void  clacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 ctrscanD0
@@ -144,7 +144,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpctrmr2do();
 extern void Cpctrmr2d();
 /* some defines for Cpctrmr2do */
@@ -167,10 +167,10 @@ extern void Cpctrmr2d();
 static2 void
 initblock(block, m, n)
   complex *block;
-  int   m, n;
+  Int   m, n;
 {
   complex *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata).r = i;
@@ -192,10 +192,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -212,7 +212,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -220,16 +220,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -253,23 +253,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   char *uplo, *diag;
   complex *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
@@ -285,8 +285,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("TRMR2D.dat", "r")) == NULL) {
@@ -297,9 +297,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -317,7 +317,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -369,9 +369,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[21] = mb.n;
       parameters[22] = *uplo == 'U';
       parameters[23] = *diag == 'U';
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -399,9 +399,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       uplo = parameters[22] ? "UPPER" : "LOWER";
       diag = parameters[23] ? "UNIT" : "NONUNIT";
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -449,8 +449,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -484,7 +484,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -509,6 +509,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pdgemrdrv.c
+++ b/REDIST/TESTING/pdgemrdrv.c
@@ -76,20 +76,20 @@
 #define Clacpy Cdgelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -103,7 +103,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -124,12 +124,12 @@ extern void Cdgerv2d();
 /* lapack */
 void  dlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 dgescanD0
@@ -141,7 +141,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpdgemr2do();
 extern void Cpdgemr2d();
 /* some defines for Cpdgemr2do */
@@ -164,10 +164,10 @@ extern void Cpdgemr2d();
 static2 void
 initblock(block, m, n)
   double *block;
-  int   m, n;
+  Int   m, n;
 {
   double *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata) = i;
@@ -189,10 +189,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -209,7 +209,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -217,16 +217,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -250,23 +250,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   double *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
 #ifdef UsingMpiBlacs
@@ -281,8 +281,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("GEMR2D.dat", "r")) == NULL) {
@@ -293,9 +293,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -313,7 +313,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -358,9 +358,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[19] = n;
       parameters[20] = mb.m;
       parameters[21] = mb.n;
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -386,9 +386,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       ma.desctype = BLOCK_CYCLIC_2D;
       mb.desctype = BLOCK_CYCLIC_2D;
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -436,8 +436,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -467,7 +467,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -492,6 +492,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pdtrmrdrv.c
+++ b/REDIST/TESTING/pdtrmrdrv.c
@@ -76,20 +76,20 @@
 #define Clacpy Cdtrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -103,7 +103,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -124,12 +124,12 @@ extern void Cdgerv2d();
 /* lapack */
 void  dlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 dtrscanD0
@@ -141,7 +141,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpdtrmr2do();
 extern void Cpdtrmr2d();
 /* some defines for Cpdtrmr2do */
@@ -164,10 +164,10 @@ extern void Cpdtrmr2d();
 static2 void
 initblock(block, m, n)
   double *block;
-  int   m, n;
+  Int   m, n;
 {
   double *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata) = i;
@@ -189,10 +189,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -209,7 +209,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -217,16 +217,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -250,23 +250,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   char *uplo, *diag;
   double *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
@@ -282,8 +282,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("TRMR2D.dat", "r")) == NULL) {
@@ -294,9 +294,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -314,7 +314,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -366,9 +366,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[21] = mb.n;
       parameters[22] = *uplo == 'U';
       parameters[23] = *diag == 'U';
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -396,9 +396,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       uplo = parameters[22] ? "UPPER" : "LOWER";
       diag = parameters[23] ? "UNIT" : "NONUNIT";
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -446,8 +446,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -481,7 +481,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -506,6 +506,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pigemrdrv.c
+++ b/REDIST/TESTING/pigemrdrv.c
@@ -36,7 +36,7 @@
  * - memory requirements : this procedure requires approximately 3 times the
  * memory space of the initial data block in grid 0 (initial block, copy for
  * test and second redistribution result) and 1 time the memory space of the
- * result data block in grid 1. with  the element size = sizeof(int) bytes,
+ * result data block in grid 1. with  the element size = sizeof(Int) bytes,
  * 
  * 
  * - use the procedures of the files:
@@ -75,20 +75,20 @@
 #define Clacpy Cigelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -102,7 +102,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -123,12 +123,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 igescanD0
@@ -140,7 +140,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpigemr2do();
 extern void Cpigemr2d();
 /* some defines for Cpigemr2do */
@@ -162,11 +162,11 @@ extern void Cpigemr2d();
  * not very random) */
 static2 void
 initblock(block, m, n)
-  int  *block;
-  int   m, n;
+  Int  *block;
+  Int   m, n;
 {
-  int  *pdata;
-  int   i;
+  Int  *pdata;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata) = i;
@@ -188,10 +188,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -208,7 +208,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -216,16 +216,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -249,25 +249,25 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
-  int  *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
+  Int  *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
 #ifdef UsingMpiBlacs
    MPI_Init(&argc, &argv);
 #endif
@@ -280,8 +280,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("GEMR2D.dat", "r")) == NULL) {
@@ -292,9 +292,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -312,7 +312,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -357,9 +357,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[19] = n;
       parameters[20] = mb.m;
       parameters[21] = mb.n;
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -385,9 +385,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       ma.desctype = BLOCK_CYCLIC_2D;
       mb.desctype = BLOCK_CYCLIC_2D;
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -435,8 +435,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -465,7 +465,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -490,6 +490,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pitrmrdrv.c
+++ b/REDIST/TESTING/pitrmrdrv.c
@@ -36,7 +36,7 @@
  * - memory requirements : this procedure requires approximately 3 times the
  * memory space of the initial data block in grid 0 (initial block, copy for
  * test and second redistribution result) and 1 time the memory space of the
- * result data block in grid 1. with  the element size = sizeof(int) bytes,
+ * result data block in grid 1. with  the element size = sizeof(Int) bytes,
  * 
  * 
  * - use the procedures of the files:
@@ -75,20 +75,20 @@
 #define Clacpy Citrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -102,7 +102,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -123,12 +123,12 @@ extern void Cigerv2d();
 /* lapack */
 void  ilacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 itrscanD0
@@ -140,7 +140,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpitrmr2do();
 extern void Cpitrmr2d();
 /* some defines for Cpitrmr2do */
@@ -162,11 +162,11 @@ extern void Cpitrmr2d();
  * not very random) */
 static2 void
 initblock(block, m, n)
-  int  *block;
-  int   m, n;
+  Int  *block;
+  Int   m, n;
 {
-  int  *pdata;
-  int   i;
+  Int  *pdata;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata) = i;
@@ -188,10 +188,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -208,7 +208,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -216,16 +216,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -249,26 +249,26 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   char *uplo, *diag;
-  int  *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
+  Int  *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
 #ifdef UsingMpiBlacs
    MPI_Init(&argc, &argv);
 #endif
@@ -281,8 +281,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("TRMR2D.dat", "r")) == NULL) {
@@ -293,9 +293,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -313,7 +313,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -365,9 +365,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[21] = mb.n;
       parameters[22] = *uplo == 'U';
       parameters[23] = *diag == 'U';
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -395,9 +395,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       uplo = parameters[22] ? "UPPER" : "LOWER";
       diag = parameters[23] ? "UNIT" : "NONUNIT";
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -421,7 +421,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       initblock(ptrmyblock, 1, blocksize0);
       setmemory(&ptrmyblockcopy, blocksize0);
       memcpy((char *) ptrmyblockcopy, (char *) ptrmyblock,
-	     blocksize0 * sizeof(int));
+	     blocksize0 * sizeof(Int));
       setmemory(&ptrmyblockvide, blocksize0);
       for (i = 0; i < blocksize0; i++)
 	ptrmyblockvide[i] = -1;
@@ -445,8 +445,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -479,7 +479,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -504,6 +504,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/psgemrdrv.c
+++ b/REDIST/TESTING/psgemrdrv.c
@@ -75,20 +75,20 @@
 #define Clacpy Csgelacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -102,7 +102,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -123,12 +123,12 @@ extern void Csgerv2d();
 /* lapack */
 void  slacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 sgescanD0
@@ -140,7 +140,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpsgemr2do();
 extern void Cpsgemr2d();
 /* some defines for Cpsgemr2do */
@@ -163,10 +163,10 @@ extern void Cpsgemr2d();
 static2 void
 initblock(block, m, n)
   float *block;
-  int   m, n;
+  Int   m, n;
 {
   float *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata) = i;
@@ -188,10 +188,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -208,7 +208,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -216,16 +216,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -249,23 +249,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   float *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
 #ifdef UsingMpiBlacs
@@ -280,8 +280,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("GEMR2D.dat", "r")) == NULL) {
@@ -292,9 +292,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -312,7 +312,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -357,9 +357,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[19] = n;
       parameters[20] = mb.m;
       parameters[21] = mb.n;
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -385,9 +385,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       ma.desctype = BLOCK_CYCLIC_2D;
       mb.desctype = BLOCK_CYCLIC_2D;
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -435,8 +435,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -463,7 +463,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -488,6 +488,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pstrmrdrv.c
+++ b/REDIST/TESTING/pstrmrdrv.c
@@ -75,20 +75,20 @@
 #define Clacpy Cstrlacpy
 void  Clacpy();
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -102,7 +102,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -123,12 +123,12 @@ extern void Csgerv2d();
 /* lapack */
 void  slacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 strscanD0
@@ -140,7 +140,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpstrmr2do();
 extern void Cpstrmr2d();
 /* some defines for Cpstrmr2do */
@@ -163,10 +163,10 @@ extern void Cpstrmr2d();
 static2 void
 initblock(block, m, n)
   float *block;
-  int   m, n;
+  Int   m, n;
 {
   float *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata) = i;
@@ -188,10 +188,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -208,7 +208,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -216,16 +216,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -249,23 +249,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   char *uplo, *diag;
   float *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
@@ -281,8 +281,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("TRMR2D.dat", "r")) == NULL) {
@@ -293,9 +293,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -313,7 +313,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -365,9 +365,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[21] = mb.n;
       parameters[22] = *uplo == 'U';
       parameters[23] = *diag == 'U';
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -395,9 +395,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       uplo = parameters[22] ? "UPPER" : "LOWER";
       diag = parameters[23] ? "UNIT" : "NONUNIT";
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -445,8 +445,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -477,7 +477,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -502,6 +502,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pzgemrdrv.c
+++ b/REDIST/TESTING/pzgemrdrv.c
@@ -79,20 +79,20 @@ typedef struct {
   double r, i;
 }     dcomplex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   lstart;
-  int   len;
+  Int   lstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -106,7 +106,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -127,12 +127,12 @@ extern void Czgerv2d();
 /* lapack */
 void  zlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 zgescanD0
@@ -144,7 +144,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpzgemr2do();
 extern void Cpzgemr2d();
 /* some defines for Cpzgemr2do */
@@ -167,10 +167,10 @@ extern void Cpzgemr2d();
 static2 void
 initblock(block, m, n)
   dcomplex *block;
-  int   m, n;
+  Int   m, n;
 {
   dcomplex *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata).r = i;
@@ -192,10 +192,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -212,7 +212,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -220,16 +220,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -253,23 +253,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   dcomplex *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
 #ifdef UsingMpiBlacs
@@ -284,8 +284,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("GEMR2D.dat", "r")) == NULL) {
@@ -296,9 +296,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -316,7 +316,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -361,9 +361,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[19] = n;
       parameters[20] = mb.m;
       parameters[21] = mb.n;
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -389,9 +389,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       ma.desctype = BLOCK_CYCLIC_2D;
       mb.desctype = BLOCK_CYCLIC_2D;
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -439,8 +439,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -470,7 +470,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -495,6 +495,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/pztrmrdrv.c
+++ b/REDIST/TESTING/pztrmrdrv.c
@@ -79,20 +79,20 @@ typedef struct {
   double r, i;
 }     dcomplex;
 typedef struct {
-  int   desctype;
-  int   ctxt;
-  int   m;
-  int   n;
-  int   nbrow;
-  int   nbcol;
-  int   sprow;
-  int   spcol;
-  int   lda;
+  Int   desctype;
+  Int   ctxt;
+  Int   m;
+  Int   n;
+  Int   nbrow;
+  Int   nbcol;
+  Int   sprow;
+  Int   spcol;
+  Int   lda;
 }     MDESC;
 #define BLOCK_CYCLIC_2D 1
 typedef struct {
-  int   gstart;
-  int   len;
+  Int   gstart;
+  Int   len;
 }     IDESC;
 #define SHIFT(row,sprow,nbrow) ((row)-(sprow)+ ((row) >= (sprow) ? 0 : (nbrow)))
 #define max(A,B) ((A)>(B)?(A):(B))
@@ -106,7 +106,7 @@ typedef struct {
 #endif
 /* Cblacs */
 extern void Cblacs_pcoord();
-extern int Cblacs_pnum();
+extern Int Cblacs_pnum();
 extern void Csetpvmtids();
 extern void Cblacs_get();
 extern void Cblacs_pinfo();
@@ -127,12 +127,12 @@ extern void Czgerv2d();
 /* lapack */
 void  zlacpy_();
 /* aux fonctions */
-extern int localindice();
+extern Int localindice();
 extern void *mr2d_malloc();
-extern int ppcm();
-extern int localsize();
-extern int memoryblocksize();
-extern int changeorigin();
+extern Int ppcm();
+extern Int localsize();
+extern Int memoryblocksize();
+extern Int changeorigin();
 extern void paramcheck();
 /* tools and others function */
 #define scanD0 ztrscanD0
@@ -144,7 +144,7 @@ extern void scanD0();
 extern void dispmat();
 extern void setmemory();
 extern void freememory();
-extern int scan_intervals();
+extern Int scan_intervals();
 extern void Cpztrmr2do();
 extern void Cpztrmr2d();
 /* some defines for Cpztrmr2do */
@@ -167,10 +167,10 @@ extern void Cpztrmr2d();
 static2 void
 initblock(block, m, n)
   dcomplex *block;
-  int   m, n;
+  Int   m, n;
 {
   dcomplex *pdata;
-  int   i;
+  Int   i;
   pdata = block;
   for (i = 0; i < m * n; i++, pdata++) {
     (*pdata).r = i;
@@ -192,10 +192,10 @@ va_dcl
   FILE *f;
 #endif
   va_list ap;
-  int   i;
-  static int nbline;
+  Int   i;
+  static Int nbline;
   char *ptr, *next;
-  int  *var;
+  Int  *var;
   static char buffer[200];
 #ifdef __STDC__
   va_start(ap, f);
@@ -212,7 +212,7 @@ va_dcl
     nbline += 1;
   } while (buffer[0] == '#');
   ptr = buffer;
-  var = va_arg(ap, int *);
+  var = va_arg(ap, Int *);
   while (var != NULL) {
     *var = strtol(ptr, &next, 10);
     if (ptr == next) {
@@ -220,16 +220,16 @@ va_dcl
       exit(1);
     }
     ptr = next;
-    var = va_arg(ap, int *);
+    var = va_arg(ap, Int *);
   }
   va_end(ap);
 }
 void 
 initforpvm(argc, argv)
-  int   argc;
+  Int   argc;
   char *argv[];
 {
-  int   pnum, nproc;
+  Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
   if (nproc < 1) {	/* we are with PVM */
     if (pnum == 0) {
@@ -253,23 +253,23 @@ main(argc, argv)
    * with the initial one. */
   /* Data file */
   FILE *fp;
-  int   nbre, nbremax;
+  Int   nbre, nbremax;
   /* Data distribution 0 parameters */
-  int   p0,	/* # of rows in the processor grid */
+  Int   p0,	/* # of rows in the processor grid */
         q0;	/* # of columns in the processor grid */
   /* Data distribution 1 parameters */
-  int   p1, q1;
+  Int   p1, q1;
   /* # of parameter to be read on the keyboard */
 #define nbparameter 24
   /* General variables */
-  int   blocksize0;
-  int   mypnum, nprocs;
-  int   parameters[nbparameter], nberrors;
-  int   i;
-  int   ia, ja, ib, jb, m, n;
-  int   gcontext, context0, context1;
-  int   myprow1, myprow0, mypcol0, mypcol1;
-  int   dummy;
+  Int   blocksize0;
+  Int   mypnum, nprocs;
+  Int   parameters[nbparameter], nberrors;
+  Int   i;
+  Int   ia, ja, ib, jb, m, n;
+  Int   gcontext, context0, context1;
+  Int   myprow1, myprow0, mypcol0, mypcol1;
+  Int   dummy;
   MDESC ma, mb;
   char *uplo, *diag;
   dcomplex *ptrmyblock, *ptrsavemyblock, *ptrmyblockcopy, *ptrmyblockvide;
@@ -285,8 +285,8 @@ main(argc, argv)
   /* Read physical parameters */
   Cblacs_pinfo(&mypnum, &nprocs);
   /* initialize BLACS for the parameter communication */
-  Cblacs_get(0, 0, &gcontext);
-  Cblacs_gridinit(&gcontext, "R", nprocs, 1);
+  Cblacs_get((Int)0, (Int)0, &gcontext);
+  Cblacs_gridinit(&gcontext, "R", nprocs, (Int)1);
   Cblacs_gridinfo(gcontext, &dummy, &dummy, &mypnum, &dummy);
   if (mypnum == 0) {
     if ((fp = fopen("TRMR2D.dat", "r")) == NULL) {
@@ -297,9 +297,9 @@ main(argc, argv)
     getparam(fp, &nbre, NULL);
     printf("////////// %d tests \n\n", nbre);
     parameters[0] = nbre;
-    Cigebs2d(gcontext, "All", "H", 1, 1, parameters, 1);
+    Cigebs2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1);
   } else {
-    Cigebr2d(gcontext, "All", "H", 1, 1, parameters, 1, 0, 0);
+    Cigebr2d(gcontext, "All", "H", (Int)1, (Int)1, parameters, (Int)1, (Int)0, (Int)0);
     nbre = parameters[0];
   };
   if (mypnum == 0) {
@@ -317,7 +317,7 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
      * grid at each iteration */
     /* Read processors grid and matrices parameters */
     if (mypnum == 0) {
-      int   u, d;
+      Int   u, d;
       getparam(fp,
 	       &m, &n,
 	       &ma.m, &ma.n, &ma.sprow, &ma.spcol,
@@ -369,9 +369,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       parameters[21] = mb.n;
       parameters[22] = *uplo == 'U';
       parameters[23] = *diag == 'U';
-      Cigebs2d(gcontext, "All", "H", 1, nbparameter, parameters, 1);
+      Cigebs2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1);
     } else {
-      Cigebr2d(gcontext, "All", "H", 1, nbparameter, parameters, 1, 0, 0);
+      Cigebr2d(gcontext, "All", "H", (Int)1, nbparameter, parameters, (Int)1, (Int)0, (Int)0);
       p0 = parameters[0];
       q0 = parameters[1];
       ma.nbrow = parameters[2];
@@ -399,9 +399,9 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
       uplo = parameters[22] ? "UPPER" : "LOWER";
       diag = parameters[23] ? "UNIT" : "NONUNIT";
     };
-    Cblacs_get(0, 0, &context0);
+    Cblacs_get((Int)0, (Int)0, &context0);
     Cblacs_gridinit(&context0, "R", p0, q0);
-    Cblacs_get(0, 0, &context1);
+    Cblacs_get((Int)0, (Int)0, &context1);
     Cblacs_gridinit(&context1, "R", p1, q1);
     Cblacs_gridinfo(context0, &dummy, &dummy, &myprow0, &mypcol0);
     if (myprow0 >= p0 || mypcol0 >= q0)
@@ -449,8 +449,8 @@ m1  n1  sr1 sc1 i1  j1  p1  q1 nbr1 nbc1\n\n");
     if (myprow0 >= 0 && mypcol0 >= 0) {
       /* only for the processors that do have data at the begining */
       for (i = 0; i < blocksize0; i++) {
-	int   li, lj, gi, gj;
-	int   in;
+	Int   li, lj, gi, gj;
+	Int   in;
 	in = 1;
 	li = i % ma.lda;
 	lj = i / ma.lda;
@@ -484,7 +484,7 @@ Number of redistribution errors = %d \n",
       }
     }
     /* Look at the errors on all the processors at this point. */
-    Cigsum2d(gcontext, "All", "H", 1, 1, &nberrors, 1, 0, 0);
+    Cigsum2d(gcontext, "All", "H", (Int)1, (Int)1, &nberrors, (Int)1, (Int)0, (Int)0);
     if (mypnum == 0)
       if (nberrors)
 	printf("  => Total number of redistribution errors = %d \n",
@@ -509,6 +509,6 @@ Number of redistribution errors = %d \n",
   if (mypnum == 0) {
     fclose(fp);
   };
-  Cblacs_exit(0);
+  Cblacs_exit((Int)0);
   return 0;
 }/* main */

--- a/REDIST/TESTING/redist.h
+++ b/REDIST/TESTING/redist.h
@@ -7,3 +7,6 @@
 #ifdef CRAY
 #define float double
 #endif
+#ifndef Int
+#define Int int
+#endif

--- a/SRC/getpbbuf.c
+++ b/SRC/getpbbuf.c
@@ -4,7 +4,7 @@ char * getpbbuf( mess, length )
 /*
 *  .. Scalar Arguments ..
 */
-   int         length;
+   Int         length;
 /*
 *  .. Array Arguments ..
 */
@@ -22,7 +22,7 @@ char * getpbbuf( mess, length )
 *  .. Local Scalars ..
 */
    static char * pblasbuf = NULL;
-   static int  pbbuflen = 0, mone = -1;
+   static Int  pbbuflen = 0, mone = -1;
 /* ..
 *  .. External Functions ..
 */

--- a/SRC/pbchkvect.c
+++ b/SRC/pbchkvect.c
@@ -17,12 +17,12 @@ void pbchkvect( n, npos0, ix, jx, desc_X, incx, dpos0, iix, jjx, ixrow,
 /*
 *  .. Scalar Arguments ..
 */
-   int         dpos0, * iix, incx, * info, ix, * ixcol, * ixrow, * jjx,
+   Int         dpos0, * iix, incx, * info, ix, * ixcol, * ixrow, * jjx,
                jx, myrow, mycol, npcol, nprow, n, npos0;
 /*
 *  .. Array Arguments ..
 */
-   int         desc_X[];
+   Int         desc_X[];
 {
 /*
 *
@@ -114,7 +114,7 @@ void pbchkvect( n, npos0, ix, jx, desc_X, incx, dpos0, iix, jjx, ixrow,
 /* ..
 *  .. Local Scalars ..
 */
-   int         descpos, ExtraColBlock, ExtraRowBlock, icpos, ixpos,
+   Int         descpos, ExtraColBlock, ExtraRowBlock, icpos, ixpos,
                jxpos, MyColBlock, MyColDist, MyRowBlock, MyRowDist,
                NColBlock, np, npos, nq, NRowBlock;
 /* ..

--- a/SRC/pblas.h
+++ b/SRC/pblas.h
@@ -89,6 +89,10 @@
 * ========================================================================
 */
 
+#ifndef Int
+#define Int int
+#endif
+
 typedef struct { float  re, im; } complex;
 typedef struct { double re, im; } complex16;
 
@@ -101,7 +105,7 @@ typedef struct { double re, im; } complex16;
 #define C2F_CHAR(a)     ( _cptofcd( (a), 1 ) )
                                           /* Type of FORTRAN functions */
 #define F_VOID_FCT      void   fortran                   /* Subroutine */
-#define F_INTG_FCT      int    fortran             /* INTEGER function */
+#define F_INTG_FCT      Int    fortran             /* INTEGER function */
 #define F_DBLE_FCT      double fortran    /* DOUBLE PRECISION function */
 
 #else
@@ -112,7 +116,7 @@ typedef char *          F_CHAR;
 #define C2F_CHAR(a)     (a)
                                           /* Type of FORTRAN functions */
 #define F_VOID_FCT      void                             /* Subroutine */
-#define F_INTG_FCT      int                        /* INTEGER function */
+#define F_INTG_FCT      Int                        /* INTEGER function */
 #define F_DBLE_FCT      double            /* DOUBLE PRECISION function */
 
 #endif

--- a/SRC/pcrot.c
+++ b/SRC/pcrot.c
@@ -18,14 +18,14 @@ void pcrot_( n, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y, incy, c, s )
 /*
 *  .. Scalar Arguments ..
 */
-   int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
+   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
    float       * c;
    complex     * s;
 /*
 *  ..
 *  .. Array Arguments ..
 */
-   int         desc_X[], desc_Y[];
+   Int         desc_X[], desc_Y[];
    complex     X[], Y[];
 {
 /*
@@ -182,7 +182,7 @@ void pcrot_( n, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y, incy, c, s )
 *
 *  .. Local Scalars ..
 */
-   int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
+   Int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
                jjy, lcm, lcmp, mycol, myrow, nn, np, np0,
                nprow, npcol, nq, nz, ione=1, tmp1, wksz;
    complex     xwork[1], ywork[1], zero;

--- a/SRC/pdlaiect.c
+++ b/SRC/pdlaiect.c
@@ -14,12 +14,13 @@
  * Include Files
  */
 #include "pxsyevx.h"
+#include "pblas.h"
 #include <stdio.h>
 #include <math.h>
 #define  proto(x)	()
 
 
-void pdlasnbt_( int *ieflag )
+void pdlasnbt_( Int *ieflag )
 {
 /* 
 *
@@ -55,8 +56,8 @@ void pdlasnbt_( int *ieflag )
 *  .. Local Scalars ..
 */
    double x;
-   int         negone=-1, errornum;
-   unsigned int *ix; 
+   Int         negone=-1, errornum;
+   unsigned Int *ix; 
 /* ..
 *  .. Executable Statements ..
 */
@@ -64,12 +65,12 @@ void pdlasnbt_( int *ieflag )
 #ifdef NO_IEEE
    *ieflag = 0;
 #else
-   if(sizeof(int) != 4){
+   if(sizeof(Int) != 4){
       *ieflag = 0;
       return;
    }
    x = (double) -1.0;
-   ix = (unsigned int *) &x;
+   ix = (unsigned Int *) &x;
    if(( *ix == 0xbff00000) && ( *(ix+1) == 0x0) ) 
    {
       *ieflag = 1;
@@ -81,7 +82,7 @@ void pdlasnbt_( int *ieflag )
 #endif
 }
 
-void pdlaiectb_( double *sigma, int *n, double *d, int *count )
+void pdlaiectb_( double *sigma, Int *n, double *d, Int *count )
 {
 /* 
 *
@@ -131,7 +132,7 @@ void pdlaiectb_( double *sigma, int *n, double *d, int *count )
 *  .. Local Scalars ..
 */
    double      lsigma, tmp, *pd, *pe2;
-   int         i;
+   Int         i;
 /* ..
 *  .. Executable Statements ..
 */
@@ -139,15 +140,15 @@ void pdlaiectb_( double *sigma, int *n, double *d, int *count )
    lsigma = *sigma;
    pd = d; pe2 = d+1;
    tmp = *pd - lsigma; pd += 2;
-   *count = (*((int *)&tmp) >> 31) & 1;
+   *count = (*((Int *)&tmp) >> 31) & 1;
    for(i = 1;i < *n;i++){
       tmp = *pd - *pe2/tmp - lsigma;
       pd += 2; pe2 += 2;
-      *count += ((*((int *)&tmp)) >> 31) & 1;
+      *count += ((*((Int *)&tmp)) >> 31) & 1;
    }
 }
 
-void pdlaiectl_( double *sigma, int *n, double *d, int *count )
+void pdlaiectl_( double *sigma, Int *n, double *d, Int *count )
 {
 /* 
 *
@@ -197,7 +198,7 @@ void pdlaiectl_( double *sigma, int *n, double *d, int *count )
 *  .. Local Scalars ..
 */
    double      lsigma, tmp, *pd, *pe2;
-   int         i;
+   Int         i;
 /* ..
 *  .. Executable Statements ..
 */
@@ -205,15 +206,15 @@ void pdlaiectl_( double *sigma, int *n, double *d, int *count )
    lsigma = *sigma;
    pd = d; pe2 = d+1;
    tmp = *pd - lsigma; pd += 2;
-   *count = (*(((int *)&tmp)+1) >> 31) & 1;
+   *count = (*(((Int *)&tmp)+1) >> 31) & 1;
    for(i = 1;i < *n;i++){
       tmp = *pd - *pe2/tmp - lsigma;
       pd += 2; pe2 += 2;
-      *count += (*(((int *)&tmp)+1) >> 31) & 1;
+      *count += (*(((Int *)&tmp)+1) >> 31) & 1;
    }
 }
 
-void pdlachkieee_( int *isieee, double *rmax, double *rmin )
+void pdlachkieee_( Int *isieee, double *rmax, double *rmin )
 {
 /* 
 *
@@ -250,7 +251,7 @@ void pdlachkieee_( int *isieee, double *rmax, double *rmin )
 *  .. Local Scalars ..
 */
    double x, pinf, pzero, ninf, nzero;
-   int         ieflag, *ix, sbit1, sbit2, negone=-1, errornum;
+   Int         ieflag, *ix, sbit1, sbit2, negone=-1, errornum;
 /* ..
 *  .. Executable Statements ..
 */
@@ -267,11 +268,11 @@ void pdlachkieee_( int *isieee, double *rmax, double *rmin )
       return ;
    }
    if( ieflag == 1 ){
-      sbit1 = (*((int *)&pzero) >> 31) & 1;
-      sbit2 = (*((int *)&pinf) >> 31) & 1;
+      sbit1 = (*((Int *)&pzero) >> 31) & 1;
+      sbit2 = (*((Int *)&pinf) >> 31) & 1;
    }else if(ieflag == 2){
-      sbit1 = (*(((int *)&pzero)+1) >> 31) & 1;
-      sbit2 = (*(((int *)&pinf)+1) >> 31) & 1;
+      sbit1 = (*(((Int *)&pzero)+1) >> 31) & 1;
+      sbit2 = (*(((Int *)&pinf)+1) >> 31) & 1;
    }
    if( sbit1 == 1 ){
       printf("Sign of positive infinity is incorrect\n");
@@ -291,11 +292,11 @@ void pdlachkieee_( int *isieee, double *rmax, double *rmin )
       *isieee = 0;
    }
    if( ieflag == 1 ){
-      sbit1 = (*((int *)&nzero) >> 31) & 1;
-      sbit2 = (*((int *)&ninf) >> 31) & 1;
+      sbit1 = (*((Int *)&nzero) >> 31) & 1;
+      sbit2 = (*((Int *)&ninf) >> 31) & 1;
    }else if(ieflag == 2){
-      sbit1 = (*(((int *)&nzero)+1) >> 31) & 1;
-      sbit2 = (*(((int *)&ninf)+1) >> 31) & 1;
+      sbit1 = (*(((Int *)&nzero)+1) >> 31) & 1;
+      sbit2 = (*(((Int *)&ninf)+1) >> 31) & 1;
    }
    if( sbit1 == 0 ){
       printf("Sign of negative infinity is incorrect\n");

--- a/SRC/pslaiect.c
+++ b/SRC/pslaiect.c
@@ -14,12 +14,13 @@
  * Include Files
  */
 #include "pxsyevx.h"
+#include "pblas.h"
 #include <stdio.h>
 #include <math.h>
 #define  proto(x)	()
 
 
-void pslasnbt_( int *ieflag )
+void pslasnbt_( Int *ieflag )
 {
 /* 
 *
@@ -52,8 +53,8 @@ void pslasnbt_( int *ieflag )
 *  .. Local Scalars ..
 */
    float x;
-   int         negone=-1, errornum;
-   unsigned int *ix; 
+   Int         negone=-1, errornum;
+   unsigned Int *ix; 
 /* ..
 *  .. Executable Statements ..
 */
@@ -61,12 +62,12 @@ void pslasnbt_( int *ieflag )
 #ifdef NO_IEEE
    *ieflag = 0;
 #else
-   if(sizeof(int) != 4){
+   if(sizeof(Int) != 4){
       *ieflag = 0;
       return;
    }
    x = (float) -1.0;
-   ix = (unsigned int *) &x;
+   ix = (unsigned Int *) &x;
    if( *ix == 0xbff00000 )
    {
       *ieflag = 1;
@@ -76,7 +77,7 @@ void pslasnbt_( int *ieflag )
 #endif
 }
 
-void pslaiect_( float *sigma, int *n, float *d, int *count )
+void pslaiect_( float *sigma, Int *n, float *d, Int *count )
 {
 /* 
 *
@@ -125,7 +126,7 @@ void pslaiect_( float *sigma, int *n, float *d, int *count )
 *  .. Local Scalars ..
 */
    float       lsigma, tmp, *pd, *pe2;
-   int         i;
+   Int         i;
 /* ..
 *  .. Executable Statements ..
 */
@@ -133,15 +134,15 @@ void pslaiect_( float *sigma, int *n, float *d, int *count )
    lsigma = *sigma;
    pd = d; pe2 = d+1;
    tmp = *pd - lsigma; pd += 2;
-   *count = (*((int *)&tmp) >> 31) & 1;
+   *count = (*((Int *)&tmp) >> 31) & 1;
    for(i = 1;i < *n;i++){
       tmp = *pd - *pe2/tmp - lsigma;
       pd += 2; pe2 += 2;
-      *count += ((*((int *)&tmp)) >> 31) & 1;
+      *count += ((*((Int *)&tmp)) >> 31) & 1;
    }
 }
 
-void pslachkieee_( int *isieee, float *rmax, float *rmin )
+void pslachkieee_( Int *isieee, float *rmax, float *rmin )
 {
 /* 
 *
@@ -178,7 +179,7 @@ void pslachkieee_( int *isieee, float *rmax, float *rmin )
 *  .. Local Scalars ..
 */
    float x, pinf, pzero, ninf, nzero;
-   int         ieflag, *ix, sbit1, sbit2, negone=-1, errornum;
+   Int         ieflag, *ix, sbit1, sbit2, negone=-1, errornum;
 /* ..
 *  .. Executable Statements ..
 */
@@ -195,8 +196,8 @@ void pslachkieee_( int *isieee, float *rmax, float *rmin )
       return ;
    }
    if( ieflag == 1 ){
-      sbit1 = (*((int *)&pzero) >> 31) & 1;
-      sbit2 = (*((int *)&pinf) >> 31) & 1;
+      sbit1 = (*((Int *)&pzero) >> 31) & 1;
+      sbit2 = (*((Int *)&pinf) >> 31) & 1;
    }
    if( sbit1 == 1 ){
       printf("Sign of positive infinity is incorrect\n");
@@ -216,8 +217,8 @@ void pslachkieee_( int *isieee, float *rmax, float *rmin )
       *isieee = 0;
    }
    if( ieflag == 1 ){
-      sbit1 = (*((int *)&nzero) >> 31) & 1;
-      sbit2 = (*((int *)&ninf) >> 31) & 1;
+      sbit1 = (*((Int *)&nzero) >> 31) & 1;
+      sbit2 = (*((Int *)&ninf) >> 31) & 1;
    }
    if( sbit1 == 0 ){
       printf("Sign of negative infinity is incorrect\n");

--- a/SRC/pzaxpy.c
+++ b/SRC/pzaxpy.c
@@ -17,12 +17,12 @@ void pzaxpy_( n, alpha, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y,
 /*
 *  .. Scalar Arguments ..
 */
-   int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
+   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
    complex16   * alpha;
 /* ..
 *  .. Array Arguments ..
 */
-   int         desc_X[], desc_Y[];
+   Int         desc_X[], desc_Y[];
    complex16   X[], Y[];
 {
 /*
@@ -171,7 +171,7 @@ void pzaxpy_( n, alpha, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y,
 *
 *  .. Local Scalars ..
 */
-   int         ictxt, info, iix, iiy, ixcol, ixrow, iycol, iyrow, jjx,
+   Int         ictxt, info, iix, iiy, ixcol, ixrow, iycol, iyrow, jjx,
                jjy, lcm, lcmp, lcmq, mycol, myrow, nn, np, np0, nprow,
                npcol, nq, nq0, nz, ione=1, tmp1, wksz;
    complex16   one, tmp, zero;

--- a/SRC/pzdotc.c
+++ b/SRC/pzdotc.c
@@ -17,12 +17,12 @@ void pzdotc_( n, dotc, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y,
 /*
 *  .. Scalar Arguments ..
 */
-   int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
+   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
    complex16   * dotc;
 /* ..
 *  .. Array Arguments ..
 */
-   int         desc_X[], desc_Y[];
+   Int         desc_X[], desc_Y[];
    complex16   X[], Y[];
 {
 /*
@@ -172,7 +172,7 @@ void pzdotc_( n, dotc, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y,
 *  .. Local Scalars ..
 */
    char        * cbtop, * cctop, * rbtop, * rctop;
-   int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
+   Int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
                jjy, lcm, lcmp, mone=-1, mycol, myrow, nn, np, np0,
                nprow, npcol, nq, nz, ione=1, tmp1, wksz;
    complex16   xwork[1], ywork[1], zero;

--- a/SRC/pzdotu.c
+++ b/SRC/pzdotu.c
@@ -17,12 +17,12 @@ void pzdotu_( n, dotu, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y,
 /*
 *  .. Scalar Arguments ..
 */
-   int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
+   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
    complex16   * dotu;
 /* ..
 *  .. Array Arguments ..
 */
-   int         desc_X[], desc_Y[];
+   Int         desc_X[], desc_Y[];
    complex16   X[], Y[];
 {
 /*
@@ -172,7 +172,7 @@ void pzdotu_( n, dotu, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y,
 *  .. Local Scalars ..
 */
    char        * cbtop, * cctop, * rbtop, * rctop;
-   int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
+   Int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
                jjy, lcm, lcmp, mone=-1, mycol, myrow, nn, np, np0,
                nprow, npcol, nq, nz, ione=1, tmp1, wksz;
    complex16   xwork[1], ywork[1], zero;

--- a/SRC/pzrot.c
+++ b/SRC/pzrot.c
@@ -18,14 +18,14 @@ void pzrot_( n, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y, incy, c, s )
 /*
 *  .. Scalar Arguments ..
 */
-   int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
+   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
    double      * c;
    complex16   * s;
 /*
 *  ..
 *  .. Array Arguments ..
 */
-   int         desc_X[], desc_Y[];
+   Int         desc_X[], desc_Y[];
    complex16   X[], Y[];
 {
 /*
@@ -182,7 +182,7 @@ void pzrot_( n, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y, incy, c, s )
 *
 *  .. Local Scalars ..
 */
-   int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
+   Int         ictxt, iix, iiy, info, ixcol, ixrow, iycol, iyrow, jjx,
                jjy, lcm, lcmp, mycol, myrow, nn, np, np0,
                nprow, npcol, nq, nz, ione=1, tmp1, wksz;
    complex16   xwork[1], ywork[1], zero;

--- a/SRC/tools.h
+++ b/SRC/tools.h
@@ -1,7 +1,7 @@
 #include "./pblas.h"
 
 #ifdef __STDC__
-typedef void (*CPYPTR)(int, int, float *, int, float *, int);
+typedef void (*CPYPTR)(Int, Int, float *, Int, float *, Int);
 #define SLVOID void
 #else
 typedef void (*CPYPTR)();

--- a/TOOLS/SL_gridreshape.c
+++ b/TOOLS/SL_gridreshape.c
@@ -1,11 +1,15 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-int SL_Cgridreshape(ctxt, pstart, row_major_in, row_major_out, P, Q)
-int ctxt, pstart, row_major_in, row_major_out, P, Q;
+#ifndef Int
+#define Int int
+#endif
+
+Int SL_Cgridreshape(ctxt, pstart, row_major_in, row_major_out, P, Q)
+Int ctxt, pstart, row_major_in, row_major_out, P, Q;
 {
-   int Cblacs_pnum();
-   int nctxt, P0, Q0, Np, i, *g;
+   Int Cblacs_pnum();
+   Int nctxt, P0, Q0, Np, i, *g;
 
    Cblacs_gridinfo(ctxt, &P0, &Q0, &i, &Np);
    Np = P * Q;
@@ -14,7 +18,7 @@ int ctxt, pstart, row_major_in, row_major_out, P, Q;
       fprintf(stderr, "Illegal reshape command in %s\n",__FILE__);
       Cblacs_abort(ctxt, -22);
    }
-   g = (int *) malloc(Np * sizeof(int));
+   g = (Int *) malloc(Np * sizeof(Int));
    if (!g)
    {
       fprintf(stderr, "Cannot allocate memory in %s\n",__FILE__);
@@ -45,29 +49,29 @@ int ctxt, pstart, row_major_in, row_major_out, P, Q;
    return(nctxt);
 }
 
-int sl_gridreshape_(ctxt, pstart, row_major_in, row_major_out, P, Q)
-int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int sl_gridreshape_(ctxt, pstart, row_major_in, row_major_out, P, Q)
+Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );
 }
 
-int SL_GRIDRESHAPE(ctxt, pstart, row_major_in, row_major_out, P, Q)
-int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int SL_GRIDRESHAPE(ctxt, pstart, row_major_in, row_major_out, P, Q)
+Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );
 }
 
-int sl_gridreshape__(ctxt, pstart, row_major_in, row_major_out, P, Q)
-int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int sl_gridreshape__(ctxt, pstart, row_major_in, row_major_out, P, Q)
+Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );
 }
 
-int sl_gridreshape(ctxt, pstart, row_major_in, row_major_out, P, Q)
-int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int sl_gridreshape(ctxt, pstart, row_major_in, row_major_out, P, Q)
+Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );

--- a/TOOLS/reshape.c
+++ b/TOOLS/reshape.c
@@ -1,8 +1,12 @@
 #include <stdlib.h>
 
+#ifndef Int
+#define Int int
+#endif
+
 void Creshape( context_in, major_in, context_out, major_out,
                     first_proc, nprow_new, npcol_new )
-int context_in, *context_out, first_proc, major_in, major_out, nprow_new, npcol_new;
+Int context_in, *context_out, first_proc, major_in, major_out, nprow_new, npcol_new;
 /* major in, major out represent whether processors go row major (1) or
 column major (2) in the input and output grids */
 {
@@ -10,17 +14,17 @@ column major (2) in the input and output grids */
    /** called subprograms **/
    void proc_inc();
    void Cblacs_gridinfo();
-   int Cblacs_pnum();
+   Int Cblacs_pnum();
    void Cblacs_get();
    void Cblacs_gridmap();
 
    /** variables **/
-   int i, j;
-   int nprow_in, npcol_in, myrow_in, mycol_in;
-   int nprocs_new;
-   int myrow_old, mycol_old, myrow_new, mycol_new;
-   int pnum;
-   int *grid_new;
+   Int i, j;
+   Int nprow_in, npcol_in, myrow_in, mycol_in;
+   Int nprocs_new;
+   Int myrow_old, mycol_old, myrow_new, mycol_new;
+   Int pnum;
+   Int *grid_new;
 
 /********** executable statements ************/
 
@@ -37,7 +41,7 @@ column major (2) in the input and output grids */
    }
 
    /* allocate space for new process mapping */
-   grid_new = (int *) malloc( nprocs_new * sizeof( int ) );
+   grid_new = (Int *) malloc( nprocs_new * sizeof( Int ) );
 
    /* set place in old grid to start grabbing processors for new grid */
    myrow_old = 0; mycol_old = 0;
@@ -76,7 +80,7 @@ column major (2) in the input and output grids */
 /*************************************************************************/
 void reshape( context_in, major_in, context_out, major_out,
                     first_proc, nprow_new, npcol_new )
-int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
+Int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
 {
    Creshape( *context_in, *major_in, context_out, *major_out,
                     *first_proc, *nprow_new, *npcol_new );
@@ -84,7 +88,7 @@ int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *
 /*************************************************************************/
 void RESHAPE( context_in, major_in, context_out, major_out,
                     first_proc, nprow_new, npcol_new )
-int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
+Int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
 {
    Creshape( *context_in, *major_in, context_out, *major_out,
                     *first_proc, *nprow_new, *npcol_new );
@@ -92,14 +96,14 @@ int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *
 /*************************************************************************/
 void reshape_( context_in, major_in, context_out, major_out,
                     first_proc, nprow_new, npcol_new )
-int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
+Int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
 {
    Creshape( *context_in, *major_in, context_out, *major_out,
                     *first_proc, *nprow_new, *npcol_new );
 }
 /*************************************************************************/
 void proc_inc( myrow, mycol, nprow, npcol, major )
-int *myrow, *mycol, nprow, npcol, major;
+Int *myrow, *mycol, nprow, npcol, major;
 {
    if( major == 1) /* row major */
    {


### PR DESCRIPTION
Some scientific Fortran based programs make use of global integer promotion to 8 bytes ("ILP64 mode"), which then requires compatible Fortran integer interface in BLAS, LAPACK and ScaLAPACK. For instance, OpenBLAS provides the 8-byte interface when compiled with an appropriate configuration flag. Intel MKL is offered in both LP64 and ILP64 versions, too.

This voluminous pull request adds the possibility to compile ScaLAPACK with long integers. This is achieved by replacing most `int` declarations by a macro `Int`, which by default evaluates to `int`, but can be overridden by the user in a different way using a compile-time definition. Compiling ScaLAPACK in the ILP64 mode (in Unix-like systems) then requires the following:
- add the flag `-DInt=long` to the C compiler flags
- add the flag `-fdefault-integer-8` (or analogous, compiler-specific) to the Fortran compiler flags
- use BLAS/LAPACK with 8-byte integer interface (e.g. OpenBLAS compiled with `INTERFACE64=1`)

When the above is not done, the build process will work exactly as is did before, resulting in a LP64 library.

Furthermore, the MPI C interface is newly assumed to expect the type `MpiInt`, which is a macro again, by default evaluates to `int`, but can be (in hypothetical and very unlikely circumstances) overridden by the user as well. However, I know of no MPI C library providing other than LP64 interface, so this freedom will be most likely never used.

The test suite, as it is, contains hardcoded sizes of integers (4 bytes). Because ScaLAPACK is a Fortran 77 library, I have not taken the liberty to replace the fixed sizes by calls to the Fortran 95 function `bit_size()`, or the Fortran 2008 function `storage_size()`. Instead, to compile and run the test suite in the ILP64 mode, one needs to replace those hardcoded numbers manually (as stated in the README):
```bash
    sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/EIG/* TESTING/LIN/*
    sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/EIG/* TESTING/LIN/*
```
All tests then succeed except for "xssep", "xsgsep" and "xssyevr", whose workspace handling is unfortunately written with the assumption that the byte size of an integer does not exceed the byte size of a (default, single precision) real, which is not true in case of the ILP64 configuration.

Apart from the ScaLAPACK test suite, I have been using this branch for two years now for large-scale `pdsyevd` runs without any issues. Other functionality is not so well tested.