### PR TITLE
Use CMAKE_Fortran_COMPILER_ID instead of CMAKE_Fortran_COMPILER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ configure_file(
 set(CMAKE_MODULE_PATH "${SCALAPACK_SOURCE_DIR}/CMAKE" ${CMAKE_MODULE_PATH})
 
 if (UNIX)
-   if ( "${CMAKE_Fortran_COMPILER}" MATCHES "ifort" )
-#   set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
+   if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
+      set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
    endif ()
 endif ()
 
@@ -76,8 +76,8 @@ endif()
 
 
 if (UNIX)
-   if ( "${CMAKE_Fortran_COMPILER}" MATCHES "ifort" )
-#   set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
+   if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
+      set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fltconsistency -fp_port" )
    endif ()
 endif ()
 


### PR DESCRIPTION
For checking whether the Intel Fortran compiler is being used, employ the CMake variable `CMAKE_Fortran_COMPILER_ID` rather than the original `CMAKE_Fortran_COMPILER`.

The original code did not support using the ***mpifort*** compiler wrapper with (for instance) ***gfortran***, because ***mpifort*** matched the pattern `"ifort"`, which resulted in addition of compiler flags not supported by ***gfortran***.

On the contrary, for Intel compiler, `CMAKE_Fortran_COMPILER_ID` is set to `"Intel"`, regardless whether it is used directly or inside a MPI wrapper. Similarly, it returns `"GNU"` for ***gfortran***, whether used directly or via ***mpifort***.

Resolve #18 