### PR TITLE
Fix argument mismatches for implicitly defined functions (gcc-10 compat)

### DIFF
--- a/BLACS/TESTING/CMakeLists.txt
+++ b/BLACS/TESTING/CMakeLists.txt
@@ -1,10 +1,14 @@
-set(FTestObj  
+set(FTestObj
    blacstest.f btprim.f tools.f)
+
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    set_source_files_properties(blacstest.f PROPERTIES COMPILE_FLAGS "-std=legacy")
+endif()
 
 add_executable(xFbtest ${FTestObj})
 target_link_libraries(xFbtest scalapack)
 
-set(CTestObj  
+set(CTestObj
    Cbt.c)
 
 set_property(

--- a/PBLAS/TESTING/CMakeLists.txt
+++ b/PBLAS/TESTING/CMakeLists.txt
@@ -10,7 +10,7 @@ set (zpbtcom pzblastst.f dlamch.f ${pbtcom})
 
 set_property(
    SOURCE ${PblasErrorHandler}
-   APPEND PROPERTY COMPILE_DEFINITIONS TestingPblas 
+   APPEND PROPERTY COMPILE_DEFINITIONS TestingPblas
    )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SCALAPACK_BINARY_DIR}/PBLAS/TESTING)
@@ -74,5 +74,6 @@ add_test(dpb3tst ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ./dpb3tst)
 add_test(cpb3tst ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ./cpb3tst)
 add_test(zpb3tst ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ./zpb3tst)
 
-
-
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy" )  # local to this directory
+endif()

--- a/PBLAS/TIMING/CMakeLists.txt
+++ b/PBLAS/TIMING/CMakeLists.txt
@@ -74,5 +74,6 @@ add_test(dpb3tim ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ./dpb3tim)
 add_test(cpb3tim ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ./cpb3tim)
 add_test(zpb3tim ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ./zpb3tim)
 
-
-
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy" )  # local to this directory
+endif()

--- a/SRC/pclarf.f
+++ b/SRC/pclarf.f
@@ -242,7 +242,7 @@
      $                   IOFFV, IPW, IROFF, IVCOL, IVROW, JJC, JJV, LDC,
      $                   LDV, MYCOL, MYROW, MP, NCC, NCV, NPCOL, NPROW,
      $                   NQ, RDEST
-      COMPLEX            TAULOC
+      COMPLEX            TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, CCOPY, CGEBR2D, CGEBS2D,
@@ -336,7 +336,7 @@
 *
                      CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -345,7 +345,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -363,8 +363,8 @@
 *
 *                    sub( C ) := sub( C ) - v * w'
 *
-                     CALL CGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+                     CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -379,9 +379,9 @@
 *
                   IF( MYCOL.EQ.ICCOL ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -398,7 +398,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, V( IOFFV ), 1,
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), V( IOFFV ), 1,
      $                              WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -421,9 +421,9 @@
                      IPW = MP+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -441,7 +441,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, WORK, 1,
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -471,7 +471,7 @@
 *
                   CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -480,7 +480,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -500,8 +500,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL CGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+     $               CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -516,18 +516,18 @@
                   WORK(IPW) = TAU( JJV )
                   CALL CGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MP+1
                   CALL CGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -547,8 +547,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL CGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+     $               CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             END IF
@@ -577,9 +577,9 @@
 *
                   IF( MYROW.EQ.ICROW ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -597,7 +597,7 @@
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( IOFFV.GT.0 .AND. IOFFC.GT.0 )
-     $                     CALL CGERC( MP, NQ, -TAULOC, WORK, 1,
+     $                     CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                                 V( IOFFV ), LDV, C( IOFFC ),
      $                                 LDC )
                      END IF
@@ -621,9 +621,9 @@
                      IPW = NQ+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -641,8 +641,8 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC ), LDC )
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ),
+     $                              1, WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
                   END IF
@@ -667,7 +667,7 @@
 *
                      CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -676,7 +676,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -694,8 +694,8 @@
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                           1, C( IOFFC ), LDC )
+                     CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                           WORK, 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -720,18 +720,18 @@
                   WORK(IPW) = TAU( IIV )
                   CALL CGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQ+1
                   CALL CGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -750,8 +750,8 @@
 *                 sub( C ) := sub( C ) - w * v'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                           1, C( IOFFC ), LDC )
+     $               CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                           WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -770,7 +770,7 @@
 *
                   CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -779,7 +779,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -797,8 +797,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                        C( IOFFC ), LDC )
+                  CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             END IF

--- a/SRC/pclarfc.f
+++ b/SRC/pclarfc.f
@@ -242,7 +242,7 @@
      $                   IOFFV, IPW, IROFF, IVCOL, IVROW, JJC, JJV, LDC,
      $                   LDV, MYCOL, MYROW, MP, NCC, NCV, NPCOL, NPROW,
      $                   NQ, RDEST
-      COMPLEX            TAULOC
+      COMPLEX            TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, CCOPY, CGEBR2D, CGEBS2D,
@@ -336,17 +336,17 @@
 *
                      CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = CONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
                   ELSE
 *
                      CALL CGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAULOC, 1, IVROW, MYCOL )
-                     TAULOC = CONJG( TAULOC )
+                     TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -364,8 +364,8 @@
 *
 *                    sub( C ) := sub( C ) - v * w'
 *
-                     CALL CGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+                     CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -380,9 +380,9 @@
 *
                   IF( MYCOL.EQ.ICCOL ) THEN
 *
-                     TAULOC = CONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -399,7 +399,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, V( IOFFV ), 1,
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), V( IOFFV ), 1,
      $                              WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -422,9 +422,9 @@
                      IPW = MP+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = CONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -442,7 +442,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, WORK, 1,
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -472,17 +472,17 @@
 *
                   CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = CONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
                ELSE
 *
                   CALL CGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1, TAULOC,
      $                          1, IVROW, MYCOL )
-                  TAULOC = CONJG( TAULOC )
+                  TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -500,8 +500,8 @@
 *
 *                 sub( C ) := sub( C ) - v * w'
 *
-                  CALL CGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ), 1,
-     $                        C( IOFFC ), LDC )
+                  CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -516,18 +516,18 @@
                   WORK(IPW) = TAU( JJV )
                   CALL CGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = CONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
                ELSE
 *
                   IPW = MP+1
                   CALL CGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = CONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -545,8 +545,8 @@
 *
 *                 sub( C ) := sub( C ) - v * w'
 *
-                  CALL CGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ), 1,
-     $                        C( IOFFC ), LDC )
+                  CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             END IF
@@ -575,9 +575,9 @@
 *
                   IF( MYROW.EQ.ICROW ) THEN
 *
-                     TAULOC = CONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -594,7 +594,7 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, WORK, 1,
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                              V( IOFFV ), LDV, C( IOFFC ), LDC )
                      END IF
 *
@@ -617,9 +617,9 @@
                      IPW = NQ+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = CONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -637,8 +637,8 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC ), LDC )
+                        CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ),
+     $                              1, WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
                   END IF
@@ -663,17 +663,17 @@
 *
                      CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = CONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
                   ELSE
 *
                      CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC,
      $                             1, MYROW, IVCOL )
-                     TAULOC = CONJG( TAULOC )
+                     TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -691,8 +691,8 @@
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                           1, C( IOFFC ), LDC )
+                     CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                           WORK, 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -716,18 +716,18 @@
                   WORK(IPW) = TAU( IIV )
                   CALL CGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = CONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
                ELSE
 *
                   IPW = NQ+1
                   CALL CGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = CONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -745,8 +745,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                        C( IOFFC ), LDC )
+                  CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -765,17 +765,17 @@
 *
                   CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = CONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
                ELSE
 *
                   CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC, 1,
      $                          MYROW, IVCOL )
-                  TAULOC = CONJG( TAULOC )
+                  TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -793,8 +793,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                        C( IOFFC ), LDC )
+                  CALL CGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             END IF

--- a/SRC/pclarz.f
+++ b/SRC/pclarz.f
@@ -251,7 +251,7 @@
      $                   IVCOL, IVROW, JJC1, JJC2, JJV, LDC, LDV, MPC2,
      $                   MPV, MYCOL, MYROW, NCC, NCV, NPCOL, NPROW,
      $                   NQC2, NQV, RDEST
-      COMPLEX            TAULOC
+      COMPLEX            TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, CAXPY, CCOPY, CGEBR2D,
@@ -370,7 +370,7 @@
 *
                      CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -379,7 +379,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -402,9 +402,9 @@
 *                    sub( C ) := sub( C ) - v * w'
 *
                      IF( MYROW.EQ.ICROW1 )
-     $                  CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                  CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                     CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                     CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                           WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -420,9 +420,9 @@
 *
                   IF( MYCOL.EQ.ICCOL2 ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -445,11 +445,11 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL CAXPY( NQC2, -TAULOC, WORK,
+     $                     CALL CAXPY( NQC2, -TAULOC( 1 ), WORK,
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL CGERC( MPV, NQC2, -TAULOC, V( IOFFV ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL CGERC( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
+     $                              1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -471,9 +471,9 @@
                      IPW = MPV+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -496,10 +496,10 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                     CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                        CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -530,16 +530,16 @@
 *
                   CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
-                  CALL CGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1, TAULOC,
-     $                          1, IVROW, MYCOL )
+                  CALL CGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1,
+     $                          TAULOC( 1 ), 1, IVROW, MYCOL )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -562,10 +562,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -580,18 +580,18 @@
                   WORK( IPW ) = TAU( JJV )
                   CALL CGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MPV+1
                   CALL CGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -614,10 +614,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF
@@ -646,9 +646,9 @@
 *
                   IF( MYROW.EQ.ICROW2 ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -669,13 +669,13 @@
      $                               ICCOL2 )
 *
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL CAXPY( MPC2, -TAULOC, WORK, 1,
+     $                     CALL CAXPY( MPC2, -TAULOC( 1 ), WORK, 1,
      $                                 C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( MPC2.GT.0 .AND. NQV.GT.0 )
-     $                     CALL CGERC( MPC2, NQV, -TAULOC, WORK, 1,
+     $                     CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK, 1,
      $                                 V( IOFFV ), LDV, C( IOFFC2 ),
      $                                 LDC )
                      END IF
@@ -699,9 +699,9 @@
                      IPW = NQV+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -720,13 +720,14 @@
      $                                WORK( IPW ), MAX( 1, MPC2 ),
      $                                RDEST, ICCOL2 )
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
-     $                                 C( IOFFC1 ), 1 )
+     $                     CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ),
+     $                                 1, C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL CGERC( MPC2, NQV, -TAULOC( 1 ),
+     $                              WORK( IPW ), 1, WORK, 1,
+     $                              C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -751,16 +752,16 @@
 *
                      CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
-                     CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC,
-     $                             1, MYROW, IVCOL )
+                     CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1,
+     $                             TAULOC( 1 ), 1, MYROW, IVCOL )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -779,13 +780,13 @@
      $                             WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                             ICCOL2 )
                      IF( MYCOL.EQ.ICCOL1 )
-     $                  CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $                  CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                              C( IOFFC1 ), 1 )
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                           WORK, 1, C( IOFFC2 ), LDC )
+                     CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ),
+     $                           1, WORK, 1, C( IOFFC2 ), LDC )
                   END IF
 *
                END IF
@@ -809,18 +810,18 @@
                   WORK( IPW ) = TAU( IIV )
                   CALL CGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQV+1
                   CALL CGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -840,13 +841,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -865,7 +866,7 @@
 *
                   CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -874,7 +875,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -893,13 +894,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF

--- a/SRC/pclarzc.f
+++ b/SRC/pclarzc.f
@@ -251,7 +251,7 @@
      $                   IVCOL, IVROW, JJC1, JJC2, JJV, LDC, LDV, MPC2,
      $                   MPV, MYCOL, MYROW, NCC, NCV, NPCOL, NPROW,
      $                   NQC2, NQV, RDEST
-      COMPLEX            TAULOC
+      COMPLEX            TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, CAXPY, CCOPY, CGEBR2D,
@@ -370,17 +370,17 @@
 *
                      CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = CONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
                   ELSE
 *
                      CALL CGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAULOC, 1, IVROW, MYCOL )
-                     TAULOC = CONJG( TAULOC )
+                     TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -403,9 +403,9 @@
 *                    sub( C ) := sub( C ) - v * w'
 *
                      IF( MYROW.EQ.ICROW1 )
-     $                  CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                  CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                     CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                     CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                           WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -421,9 +421,9 @@
 *
                   IF( MYCOL.EQ.ICCOL2 ) THEN
 *
-                     TAULOC = CONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -446,11 +446,11 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL CAXPY( NQC2, -TAULOC, WORK,
+     $                     CALL CAXPY( NQC2, -TAULOC( 1 ), WORK,
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL CGERC( MPV, NQC2, -TAULOC, V( IOFFV ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL CGERC( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
+     $                              1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -472,9 +472,9 @@
                      IPW = MPV+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = CONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -497,10 +497,10 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                     CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                        CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -531,17 +531,17 @@
 *
                   CALL CGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = CONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
                ELSE
 *
                   CALL CGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1, TAULOC,
      $                          1, IVROW, MYCOL )
-                  TAULOC = CONJG( TAULOC )
+                  TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -564,10 +564,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -582,18 +582,18 @@
                   WORK( IPW ) = TAU( JJV )
                   CALL CGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = CONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
                ELSE
 *
                   IPW = MPV+1
                   CALL CGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = CONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -616,10 +616,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL CAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL CGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF
@@ -648,9 +648,9 @@
 *
                   IF( MYROW.EQ.ICROW2 ) THEN
 *
-                     TAULOC = CONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -671,12 +671,12 @@
      $                               ICCOL2 )
 *
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL CAXPY( MPC2, -TAULOC, WORK, 1,
+     $                     CALL CAXPY( MPC2, -TAULOC( 1 ), WORK, 1,
      $                                 C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL CGERC( MPC2, NQV, -TAULOC, WORK, 1,
+                        CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK, 1,
      $                              V( IOFFV ), LDV, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -699,9 +699,9 @@
                      IPW = NQV+1
                      CALL CGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = CONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -720,13 +720,14 @@
      $                                WORK( IPW ), MAX( 1, MPC2 ),
      $                                RDEST, ICCOL2 )
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
-     $                                 C( IOFFC1 ), 1 )
+     $                     CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ),
+     $                                 1, C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL CGERC( MPC2, NQV, -TAULOC( 1 ),
+     $                              WORK( IPW ), 1, WORK, 1,
+     $                              C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -751,17 +752,17 @@
 *
                      CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = CONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
                   ELSE
 *
                      CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC,
      $                             1, MYROW, IVCOL )
-                     TAULOC = CONJG( TAULOC )
+                     TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -780,13 +781,13 @@
      $                             WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                             ICCOL2 )
                      IF( MYCOL.EQ.ICCOL1 )
-     $                  CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $                  CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                              C( IOFFC1 ), 1 )
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                           WORK, 1, C( IOFFC2 ), LDC )
+                     CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ),
+     $                           1, WORK, 1, C( IOFFC2 ), LDC )
                   END IF
 *
                END IF
@@ -810,18 +811,18 @@
                   WORK( IPW ) = TAU( IIV )
                   CALL CGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = CONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = CONJG( TAU( IIV ) )
 *
                ELSE
 *
                   IPW = NQV+1
                   CALL CGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = CONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = CONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -841,13 +842,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -866,17 +867,17 @@
 *
                   CALL CGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = CONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = CONJG( TAU( JJV ) )
 *
                ELSE
 *
-                  CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC, 1,
-     $                          MYROW, IVCOL )
-                  TAULOC = CONJG( TAULOC )
+                  CALL CGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1,
+     $                          TAULOC( 1 ), 1, MYROW, IVCOL )
+                  TAULOC( 1 ) = CONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -895,13 +896,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL CAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL CAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL CGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL CGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF

--- a/SRC/pclattrs.f
+++ b/SRC/pclattrs.f
@@ -271,7 +271,8 @@
      $                   JINC, JLAST, LDA, LDX, MB, MYCOL, MYROW, NB,
      $                   NPCOL, NPROW, RSRC
       REAL               BIGNUM, GROW, REC, SMLNUM, TJJ, TMAX, TSCAL,
-     $                   XBND, XJ, XMAX
+     $                   XBND, XJ
+      REAL               XMAX( 1 )
       COMPLEX            CSUMJ, TJJS, USCAL, XJTMP, ZDUM
 *     ..
 *     .. External Functions ..
@@ -391,11 +392,11 @@
 *     Compute a bound on the computed solution vector to see if the
 *     Level 2 PBLAS routine PCTRSV can be used.
 *
-      XMAX = ZERO
+      XMAX( 1 ) = ZERO
       CALL PCAMAX( N, ZDUM, IMAX, X, IX, JX, DESCX, 1 )
-      XMAX = CABS2( ZDUM )
+      XMAX( 1 ) = CABS2( ZDUM )
       CALL SGSUM2D( CONTXT, 'Row', ' ', 1, 1, XMAX, 1, -1, -1 )
-      XBND = XMAX
+      XBND = XMAX( 1 )
 *
       IF( NOTRAN ) THEN
 *
@@ -590,16 +591,16 @@
 *
 *        Use a Level 1 PBLAS solve, scaling intermediate results.
 *
-         IF( XMAX.GT.BIGNUM*HALF ) THEN
+         IF( XMAX( 1 ).GT.BIGNUM*HALF ) THEN
 *
 *           Scale X so that its components are less than or equal to
 *           BIGNUM in absolute value.
 *
-            SCALE = ( BIGNUM*HALF ) / XMAX
+            SCALE = ( BIGNUM*HALF ) / XMAX( 1 )
             CALL PCSSCAL( N, SCALE, X, IX, JX, DESCX, 1 )
-            XMAX = BIGNUM
+            XMAX( 1 ) = BIGNUM
          ELSE
-            XMAX = XMAX*TWO
+            XMAX( 1 ) = XMAX( 1 )*TWO
          END IF
 *
          IF( NOTRAN ) THEN
@@ -651,7 +652,7 @@
                         CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                         XJTMP = XJTMP*REC
                         SCALE = SCALE*REC
-                        XMAX = XMAX*REC
+                        XMAX( 1 ) = XMAX( 1 )*REC
                      END IF
                   END IF
 *                 X( J ) = CLADIV( X( J ), TJJS )
@@ -682,7 +683,7 @@
                      CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
-                     XMAX = XMAX*REC
+                     XMAX( 1 ) = XMAX( 1 )*REC
                   END IF
 *                 X( J ) = CLADIV( X( J ), TJJS )
 *                 XJ = CABS1( X( J ) )
@@ -706,7 +707,7 @@
                   XJTMP = CONE
                   XJ = ONE
                   SCALE = ZERO
-                  XMAX = ZERO
+                  XMAX( 1 ) = ZERO
                END IF
    90          CONTINUE
 *
@@ -715,7 +716,7 @@
 *
                IF( XJ.GT.ONE ) THEN
                   REC = ONE / XJ
-                  IF( CNORM( J ).GT.( BIGNUM-XMAX )*REC ) THEN
+                  IF( CNORM( J ).GT.( BIGNUM-XMAX( 1 ) )*REC ) THEN
 *
 *                    Scale x by 1/(2*abs(x(j))).
 *
@@ -724,7 +725,7 @@
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
                   END IF
-               ELSE IF( XJ*CNORM( J ).GT.( BIGNUM-XMAX ) ) THEN
+               ELSE IF( XJ*CNORM( J ).GT.( BIGNUM-XMAX( 1 ) ) ) THEN
 *
 *                 Scale x by 1/2.
 *
@@ -743,7 +744,7 @@
                      CALL PCAXPY( J-1, ZDUM, A, IA, JA+J-1, DESCA, 1, X,
      $                            IX, JX, DESCX, 1 )
                      CALL PCAMAX( J-1, ZDUM, IMAX, X, IX, JX, DESCX, 1 )
-                     XMAX = CABS1( ZDUM )
+                     XMAX( 1 ) = CABS1( ZDUM )
                      CALL SGSUM2D( CONTXT, 'Row', ' ', 1, 1, XMAX, 1,
      $                             -1, -1 )
                   END IF
@@ -757,7 +758,7 @@
                      CALL PCAXPY( N-J, ZDUM, A, IA+J, JA+J-1, DESCA, 1,
      $                            X, IX+J, JX, DESCX, 1 )
                      CALL PCAMAX( N-J, ZDUM, I, X, IX+J, JX, DESCX, 1 )
-                     XMAX = CABS1( ZDUM )
+                     XMAX( 1 ) = CABS1( ZDUM )
                      CALL SGSUM2D( CONTXT, 'Row', ' ', 1, 1, XMAX, 1,
      $                             -1, -1 )
                   END IF
@@ -785,7 +786,7 @@
                END IF
                XJ = CABS1( XJTMP )
                USCAL = CMPLX( TSCAL )
-               REC = ONE / MAX( XMAX, ONE )
+               REC = ONE / MAX( XMAX( 1 ), ONE )
                IF( CNORM( J ).GT.( BIGNUM-XJ )*REC ) THEN
 *
 *                 If x(j) could overflow, scale x by 1/(2*XMAX).
@@ -820,7 +821,7 @@
                      CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
-                     XMAX = XMAX*REC
+                     XMAX( 1 ) = XMAX( 1 )*REC
                   END IF
                END IF
 *
@@ -924,7 +925,7 @@
                            CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                            XJTMP = XJTMP*REC
                            SCALE = SCALE*REC
-                           XMAX = XMAX*REC
+                           XMAX( 1 ) = XMAX( 1 )*REC
                         END IF
                      END IF
 *                    X( J ) = CLADIV( X( J ), TJJS )
@@ -945,7 +946,7 @@
                         CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                         XJTMP = XJTMP*REC
                         SCALE = SCALE*REC
-                        XMAX = XMAX*REC
+                        XMAX( 1 ) = XMAX( 1 )*REC
                      END IF
 *                    X( J ) = CLADIV( X( J ), TJJS )
                      XJTMP = CLADIV( XJTMP, TJJS )
@@ -966,7 +967,7 @@
                      END IF
                      XJTMP = CONE
                      SCALE = ZERO
-                     XMAX = ZERO
+                     XMAX( 1 ) = ZERO
                   END IF
   110             CONTINUE
                ELSE
@@ -981,7 +982,7 @@
                      X( IROWX ) = XJTMP
                   END IF
                END IF
-               XMAX = MAX( XMAX, CABS1( XJTMP ) )
+               XMAX( 1 ) = MAX( XMAX( 1 ), CABS1( XJTMP ) )
   120       CONTINUE
 *
          ELSE
@@ -1004,7 +1005,7 @@
                END IF
                XJ = CABS1( XJTMP )
                USCAL = TSCAL
-               REC = ONE / MAX( XMAX, ONE )
+               REC = ONE / MAX( XMAX( 1 ), ONE )
                IF( CNORM( J ).GT.( BIGNUM-XJ )*REC ) THEN
 *
 *                 If x(j) could overflow, scale x by 1/(2*XMAX).
@@ -1039,7 +1040,7 @@
                      CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
-                     XMAX = XMAX*REC
+                     XMAX( 1 ) = XMAX( 1 )*REC
                   END IF
                END IF
 *
@@ -1145,7 +1146,7 @@
                            CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                            XJTMP = XJTMP*REC
                            SCALE = SCALE*REC
-                           XMAX = XMAX*REC
+                           XMAX( 1 ) = XMAX( 1 )*REC
                         END IF
                      END IF
 *                    X( J ) = CLADIV( X( J ), TJJS )
@@ -1164,7 +1165,7 @@
                         CALL PCSSCAL( N, REC, X, IX, JX, DESCX, 1 )
                         XJTMP = XJTMP*REC
                         SCALE = SCALE*REC
-                        XMAX = XMAX*REC
+                        XMAX( 1 ) = XMAX( 1 )*REC
                      END IF
 *                    X( J ) = CLADIV( X( J ), TJJS )
                      XJTMP = CLADIV( XJTMP, TJJS )
@@ -1181,7 +1182,7 @@
      $                  X( IROWX ) = CONE
                      XJTMP = CONE
                      SCALE = ZERO
-                     XMAX = ZERO
+                     XMAX( 1 ) = ZERO
                   END IF
   130             CONTINUE
                ELSE
@@ -1194,7 +1195,7 @@
                   IF( ( MYROW.EQ.ITMP1X ) .AND. ( MYCOL.EQ.ITMP2X ) )
      $               X( IROWX ) = XJTMP
                END IF
-               XMAX = MAX( XMAX, CABS1( XJTMP ) )
+               XMAX( 1 ) = MAX( XMAX( 1 ), CABS1( XJTMP ) )
   140       CONTINUE
          END IF
          SCALE = SCALE / TSCAL

--- a/SRC/pclawil.f
+++ b/SRC/pclawil.f
@@ -124,11 +124,10 @@
      $                   MODKM1, MYCOL, MYROW, NPCOL, NPROW, NUM, RIGHT,
      $                   RSRC, UP
       REAL               S
-      COMPLEX            CDUM, H11, H12, H21, H22, H33S, H44S, V1, V2,
-     $                   V3
+      COMPLEX            CDUM, H22, H33S, H44S, V1, V2
 *     ..
 *     .. Local Arrays ..
-      COMPLEX            BUF( 4 )
+      COMPLEX            BUF( 4 ), V3( 1 ), H11( 1 ), H12( 1 ), H21( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, CGERV2D, CGESD2D
@@ -181,18 +180,18 @@
             IF( NPCOL.GT.1 ) THEN
                CALL CGERV2D( CONTXT, 1, 1, V3, 1, MYROW, LEFT )
             ELSE
-               V3 = A( ( ICOL-2 )*LDA+IROW )
+               V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
             END IF
             IF( NUM.GT.1 ) THEN
                CALL CGERV2D( CONTXT, 4, 1, BUF, 4, UP, LEFT )
-               H11 = BUF( 1 )
-               H21 = BUF( 2 )
-               H12 = BUF( 3 )
+               H11( 1 ) = BUF( 1 )
+               H21( 1 ) = BUF( 2 )
+               H12( 1 ) = BUF( 3 )
                H22 = BUF( 4 )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
                H22 = A( ( ICOL-2 )*LDA+IROW-1 )
             END IF
          END IF
@@ -223,22 +222,22 @@
             CALL INFOG2L( M+2, M+2, DESCA, NPROW, NPCOL, MYROW, MYCOL,
      $                    IROW, ICOL, RSRC, JSRC )
             IF( NUM.GT.1 ) THEN
-               CALL CGERV2D( CONTXT, 1, 1, H11, 1, UP, LEFT )
+               CALL CGERV2D( CONTXT, 1, 1, H11( 1 ), 1, UP, LEFT )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
             END IF
             IF( NPROW.GT.1 ) THEN
                CALL CGERV2D( CONTXT, 1, 1, H12, 1, UP, MYCOL )
             ELSE
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
             END IF
             IF( NPCOL.GT.1 ) THEN
-               CALL CGERV2D( CONTXT, 1, 1, H21, 1, MYROW, LEFT )
+               CALL CGERV2D( CONTXT, 1, 1, H21( 1 ), 1, MYROW, LEFT )
             ELSE
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
             END IF
             H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-            V3 = A( ( ICOL-2 )*LDA+IROW )
+            V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
          END IF
       END IF
       IF( ( MYROW.NE.II ) .OR. ( MYCOL.NE.JJ ) )
@@ -247,24 +246,24 @@
       IF( MODKM1.GT.1 ) THEN
          CALL INFOG2L( M+2, M+2, DESCA, NPROW, NPCOL, MYROW, MYCOL,
      $                 IROW, ICOL, RSRC, JSRC )
-         H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-         H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-         H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+         H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+         H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+         H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
          H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-         V3 = A( ( ICOL-2 )*LDA+IROW )
+         V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
       END IF
 *
-      H44S = H44 - H11
-      H33S = H33 - H11
-      V1 = ( H33S*H44S-H43H34 ) / H21 + H12
-      V2 = H22 - H11 - H33S - H44S
-      S = CABS1( V1 ) + CABS1( V2 ) + CABS1( V3 )
+      H44S = H44 - H11( 1 )
+      H33S = H33 - H11( 1 )
+      V1 = ( H33S*H44S-H43H34 ) / H21( 1 ) + H12( 1 )
+      V2 = H22 - H11( 1 ) - H33S - H44S
+      S = CABS1( V1 ) + CABS1( V2 ) + CABS1( V3( 1 ) )
       V1 = V1 / S
       V2 = V2 / S
-      V3 = V3 / S
+      V3( 1 ) = V3( 1 ) / S
       V( 1 ) = V1
       V( 2 ) = V2
-      V( 3 ) = V3
+      V( 3 ) = V3( 1 )
 *
       RETURN
 *

--- a/SRC/pctrevc.f
+++ b/SRC/pctrevc.f
@@ -218,11 +218,12 @@
      $                   ITMP2, J, K, KI, LDT, LDVL, LDVR, LDW, MB,
      $                   MYCOL, MYROW, NB, NPCOL, NPROW, RSRC
       REAL               SELF
-      REAL               OVFL, REMAXD, SCALE, SMIN, SMLNUM, ULP, UNFL
+      REAL               OVFL, REMAXD, SCALE, SMLNUM, ULP, UNFL
       COMPLEX            CDUM, REMAXC, SHIFT
 *     ..
 *     .. Local Arrays ..
       INTEGER            DESCW( DLEN_ )
+      REAL               SMIN( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -355,13 +356,13 @@
      $            GO TO 70
             END IF
 *
-            SMIN = ZERO
+            SMIN( 1 ) = ZERO
             SHIFT = CZERO
             CALL INFOG2L( KI, KI, DESCT, NPROW, NPCOL, MYROW, MYCOL,
      $                    IROW, ICOL, ITMP1, ITMP2 )
             IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                SHIFT = T( ( ICOL-1 )*LDT+IROW )
-               SMIN = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
+               SMIN( 1 ) = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
             END IF
             CALL SGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SMIN, 1, -1, -1 )
             CALL CGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SHIFT, 1, -1, -1 )
@@ -396,8 +397,9 @@
                IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                   T( ( ICOL-1 )*LDT+IROW ) = T( ( ICOL-1 )*LDT+IROW ) -
      $               SHIFT
-                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN ) THEN
-                     T( ( ICOL-1 )*LDT+IROW ) = CMPLX( SMIN )
+                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN( 1 ) )
+     $            THEN
+                     T( ( ICOL-1 )*LDT+IROW ) = CMPLX( SMIN( 1 ) )
                   END IF
                END IF
    50       CONTINUE
@@ -467,13 +469,13 @@
      $            GO TO 110
             END IF
 *
-            SMIN = ZERO
+            SMIN( 1 ) = ZERO
             SHIFT = CZERO
             CALL INFOG2L( KI, KI, DESCT, NPROW, NPCOL, MYROW, MYCOL,
      $                    IROW, ICOL, ITMP1, ITMP2 )
             IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                SHIFT = T( ( ICOL-1 )*LDT+IROW )
-               SMIN = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
+               SMIN( 1 ) = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
             END IF
             CALL SGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SMIN, 1, -1, -1 )
             CALL CGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SHIFT, 1, -1, -1 )
@@ -507,8 +509,8 @@
                IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                   T( ( ICOL-1 )*LDT+IROW ) = T( ( ICOL-1 )*LDT+IROW ) -
      $               SHIFT
-                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN )
-     $               T( ( ICOL-1 )*LDT+IROW ) = CMPLX( SMIN )
+                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN( 1 ) )
+     $               T( ( ICOL-1 )*LDT+IROW ) = CMPLX( SMIN( 1 ) )
                END IF
    90       CONTINUE
 *

--- a/SRC/pdhseqr.f
+++ b/SRC/pdhseqr.f
@@ -259,11 +259,12 @@
      $                   HRSRC4, HCSRC4, LIWKOPT
       LOGICAL            INITZ, LQUERY, WANTT, WANTZ, PAIR, BORDER
       DOUBLE PRECISION   TMP1, TMP2, TMP3, TMP4, DUM1, DUM2, DUM3,
-     $                   DUM4, ELEM1, ELEM2, ELEM3, ELEM4,
+     $                   DUM4, ELEM1, ELEM4,
      $                   CS, SN, ELEM5, TMP, LWKOPT
 *     ..
 *     .. Local Arrays ..
       INTEGER            DESCH2( DLEN_ )
+      DOUBLE PRECISION   ELEM2( 1 ), ELEM3( 1 )
 *     ..
 *     .. External Functions ..
       INTEGER            PILAENVX, NUMROC, ICEIL
@@ -566,28 +567,28 @@
                   IF( MYROW.EQ.HRSRC1 .AND. MYCOL.EQ.HCSRC1 ) THEN
                      ELEM1 = H((JLOC1-1)*LLDH+ILOC1)
                      IF( K.LT.N ) THEN
-                        ELEM3 = H((JLOC1-1)*LLDH+ILOC1+1)
+                        ELEM3( 1 ) = H((JLOC1-1)*LLDH+ILOC1+1)
                      ELSE
-                        ELEM3 = ZERO
+                        ELEM3( 1 ) = ZERO
                      END IF
-                     IF( ELEM3.NE.ZERO ) THEN
-                        ELEM2 = H((JLOC1)*LLDH+ILOC1)
+                     IF( ELEM3( 1 ).NE.ZERO ) THEN
+                        ELEM2( 1 ) = H((JLOC1)*LLDH+ILOC1)
                         ELEM4 = H((JLOC1)*LLDH+ILOC1+1)
-                        CALL DLANV2( ELEM1, ELEM2, ELEM3, ELEM4,
-     $                       WR( K ), WI( K ), WR( K+1 ), WI( K+1 ),
-     $                       SN, CS )
+                        CALL DLANV2( ELEM1, ELEM2( 1 ), ELEM3( 1 ),
+     $                       ELEM4, WR( K ), WI( K ), WR( K+1 ),
+     $                       WI( K+1 ), SN, CS )
                         PAIR = .TRUE.
                      ELSE
                         IF( K.GT.1 ) THEN
                            TMP = H((JLOC1-2)*LLDH+ILOC1)
                            IF( TMP.NE.ZERO ) THEN
                               ELEM1 = H((JLOC1-2)*LLDH+ILOC1-1)
-                              ELEM2 = H((JLOC1-1)*LLDH+ILOC1-1)
-                              ELEM3 = H((JLOC1-2)*LLDH+ILOC1)
+                              ELEM2( 1 ) = H((JLOC1-1)*LLDH+ILOC1-1)
+                              ELEM3( 1 ) = H((JLOC1-2)*LLDH+ILOC1)
                               ELEM4 = H((JLOC1-1)*LLDH+ILOC1)
-                              CALL DLANV2( ELEM1, ELEM2, ELEM3,
-     $                             ELEM4, WR( K-1 ), WI( K-1 ),
-     $                             WR( K ), WI( K ), SN, CS )
+                              CALL DLANV2( ELEM1, ELEM2( 1 ),
+     $                             ELEM3( 1 ), ELEM4, WR( K-1 ),
+     $                             WI( K-1 ), WR( K ), WI( K ), SN, CS )
                            ELSE
                               WR( K ) = ELEM1
                            END IF
@@ -620,12 +621,12 @@
             CALL INFOG2L( K+1, K+1, DESCH, NPROW, NPCOL, MYROW, MYCOL,
      $           ILOC4, JLOC4, HRSRC4, HCSRC4 )
             IF( MYROW.EQ.HRSRC2 .AND. MYCOL.EQ.HCSRC2 ) THEN
-               ELEM2 = H((JLOC2-1)*LLDH+ILOC2)
+               ELEM2( 1 ) = H((JLOC2-1)*LLDH+ILOC2)
                IF( HRSRC1.NE.HRSRC2 .OR. HCSRC1.NE.HCSRC2 )
      $            CALL DGESD2D( ICTXT, 1, 1, ELEM2, 1, HRSRC1, HCSRC1)
             END IF
             IF( MYROW.EQ.HRSRC3 .AND. MYCOL.EQ.HCSRC3 ) THEN
-               ELEM3 = H((JLOC3-1)*LLDH+ILOC3)
+               ELEM3( 1 ) = H((JLOC3-1)*LLDH+ILOC3)
                IF( HRSRC1.NE.HRSRC3 .OR. HCSRC1.NE.HCSRC3 )
      $            CALL DGESD2D( ICTXT, 1, 1, ELEM3, 1, HRSRC1, HCSRC1)
             END IF
@@ -651,8 +652,9 @@
                ELEM5 = WORK(2)
                IF( ELEM5.EQ.ZERO ) THEN
                   IF( WR( K ).EQ.ZERO .AND. WI( K ).EQ.ZERO ) THEN
-                     CALL DLANV2( ELEM1, ELEM2, ELEM3, ELEM4, WR( K ),
-     $                    WI( K ), WR( K+1 ), WI( K+1 ), SN, CS )
+                     CALL DLANV2( ELEM1, ELEM2( 1 ), ELEM3( 1 ), ELEM4,
+     $                    WR( K ), WI( K ), WR( K+1 ), WI( K+1 ), SN,
+     $                    CS )
                   ELSEIF( WR( K+1 ).EQ.ZERO .AND. WI( K+1 ).EQ.ZERO )
      $                 THEN
                      WR( K+1 ) = ELEM4

--- a/SRC/pdlarf.f
+++ b/SRC/pdlarf.f
@@ -241,7 +241,7 @@
      $                   IOFFV, IPW, IROFF, IVCOL, IVROW, JJC, JJV, LDC,
      $                   LDV, MYCOL, MYROW, MP, NCC, NCV, NPCOL, NPROW,
      $                   NQ, RDEST
-      DOUBLE PRECISION   TAULOC
+      DOUBLE PRECISION   TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, DCOPY, DGEBR2D, DGEBS2D,
@@ -335,7 +335,7 @@
 *
                      CALL DGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -344,7 +344,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -362,8 +362,8 @@
 *
 *                    sub( C ) := sub( C ) - v * w'
 *
-                     CALL DGER( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                          1, C( IOFFC ), LDC )
+                     CALL DGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                          WORK( IPW ), 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -378,9 +378,9 @@
 *
                   IF( MYCOL.EQ.ICCOL ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -397,8 +397,8 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL DGER( MP, NQ, -TAULOC, V( IOFFV ), 1, WORK,
-     $                             1, C( IOFFC ), LDC )
+                        CALL DGER( MP, NQ, -TAULOC( 1 ), V( IOFFV ), 1,
+     $                             WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
                   END IF
@@ -420,9 +420,9 @@
                      IPW = MP+1
                      CALL DGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -440,7 +440,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL DGER( MP, NQ, -TAULOC, WORK, 1,
+                        CALL DGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                             WORK( IPW ), 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -470,7 +470,7 @@
 *
                   CALL DGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -479,7 +479,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -499,8 +499,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL DGER( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                          1, C( IOFFC ), LDC )
+     $               CALL DGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                          WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -515,18 +515,18 @@
                   WORK(IPW) = TAU( JJV )
                   CALL DGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MP+1
                   CALL DGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -546,8 +546,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL DGER( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                          1, C( IOFFC ), LDC )
+     $               CALL DGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                          WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             END IF
@@ -576,9 +576,9 @@
 *
                   IF( MYROW.EQ.ICROW ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -596,7 +596,7 @@
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( IOFFV.GT.0 .AND. IOFFC.GT.0 )
-     $                     CALL DGER( MP, NQ, -TAULOC, WORK, 1,
+     $                     CALL DGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                                V( IOFFV ), LDV, C( IOFFC ), LDC )
                      END IF
 *
@@ -619,9 +619,9 @@
                      IPW = NQ+1
                      CALL DGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -639,7 +639,7 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL DGER( MP, NQ, -TAULOC, WORK( IPW ), 1,
+                        CALL DGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
      $                             WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -665,7 +665,7 @@
 *
                      CALL DGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -674,7 +674,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -692,8 +692,8 @@
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL DGER( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                          1, C( IOFFC ), LDC )
+                     CALL DGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                          WORK, 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -718,18 +718,18 @@
                   WORK(IPW) = TAU( IIV )
                   CALL DGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQ+1
                   CALL DGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -748,8 +748,8 @@
 *                 sub( C ) := sub( C ) - w * v'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL DGER( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                          1, C( IOFFC ), LDC )
+     $               CALL DGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                          WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -768,7 +768,7 @@
 *
                   CALL DGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -777,7 +777,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -795,8 +795,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL DGER( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                       C( IOFFC ), LDC )
+                  CALL DGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1, WORK,
+     $                       1, C( IOFFC ), LDC )
                END IF
 *
             END IF

--- a/SRC/pdlarz.f
+++ b/SRC/pdlarz.f
@@ -250,7 +250,7 @@
      $                   IVCOL, IVROW, JJC1, JJC2, JJV, LDC, LDV, MPC2,
      $                   MPV, MYCOL, MYROW, NCC, NCV, NPCOL, NPROW,
      $                   NQC2, NQV, RDEST
-      DOUBLE PRECISION   TAULOC
+      DOUBLE PRECISION   TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, DAXPY, DCOPY, DGEBR2D,
@@ -369,7 +369,7 @@
 *
                      CALL DGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -378,7 +378,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -401,9 +401,9 @@
 *                    sub( C ) := sub( C ) - v * w'
 *
                      IF( MYROW.EQ.ICROW1 )
-     $                  CALL DAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                  CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                     CALL DGER( MPV, NQC2, -TAULOC, WORK, 1,
+                     CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                          WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -419,9 +419,9 @@
 *
                   IF( MYCOL.EQ.ICCOL2 ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -444,11 +444,11 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL DAXPY( NQC2, -TAULOC, WORK,
+     $                     CALL DAXPY( NQC2, -TAULOC( 1 ), WORK,
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL DGER( MPV, NQC2, -TAULOC, V( IOFFV ), 1,
-     $                             WORK, 1, C( IOFFC2 ), LDC )
+                        CALL DGER( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
+     $                             1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -470,9 +470,9 @@
                      IPW = MPV+1
                      CALL DGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -495,10 +495,10 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL DAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                     CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL DGER( MPV, NQC2, -TAULOC, WORK, 1,
+                        CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                             WORK( IPW ), 1, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -529,7 +529,7 @@
 *
                   CALL DGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -538,7 +538,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -561,10 +561,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL DAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL DGER( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -579,18 +579,18 @@
                   WORK( IPW ) = TAU( JJV )
                   CALL DGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MPV+1
                   CALL DGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -613,10 +613,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL DAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL DGER( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF
@@ -645,9 +645,9 @@
 *
                   IF( MYROW.EQ.ICROW2 ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -668,13 +668,13 @@
      $                               ICCOL2 )
 *
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL DAXPY( MPC2, -TAULOC, WORK, 1,
+     $                     CALL DAXPY( MPC2, -TAULOC( 1 ), WORK, 1,
      $                                 C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( MPC2.GT.0 .AND. NQV.GT.0 )
-     $                     CALL DGER( MPC2, NQV, -TAULOC, WORK, 1,
+     $                     CALL DGER( MPC2, NQV, -TAULOC( 1 ), WORK, 1,
      $                                V( IOFFV ), LDV, C( IOFFC2 ),
      $                                LDC )
                      END IF
@@ -698,9 +698,9 @@
                      IPW = NQV+1
                      CALL DGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -719,13 +719,13 @@
      $                                WORK( IPW ), MAX( 1, MPC2 ),
      $                                RDEST, ICCOL2 )
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL DAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
-     $                                 C( IOFFC1 ), 1 )
+     $                     CALL DAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ),
+     $                                 1, C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL DGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                             WORK, 1, C( IOFFC2 ), LDC )
+                        CALL DGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ),
+     $                             1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -750,7 +750,7 @@
 *
                      CALL DGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -759,7 +759,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -778,12 +778,12 @@
      $                             WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                             ICCOL2 )
                      IF( MYCOL.EQ.ICCOL1 )
-     $                  CALL DAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $                  CALL DAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                              C( IOFFC1 ), 1 )
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL DGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
+                     CALL DGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
      $                          WORK, 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -808,18 +808,18 @@
                   WORK( IPW ) = TAU( IIV )
                   CALL DGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQV+1
                   CALL DGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -839,13 +839,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL DAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL DAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL DGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL DGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                       WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -864,7 +864,7 @@
 *
                   CALL DGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -873,7 +873,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -892,13 +892,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL DAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL DAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL DGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL DGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                       WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF

--- a/SRC/pdlawil.f
+++ b/SRC/pdlawil.f
@@ -120,10 +120,10 @@
       INTEGER            CONTXT, DOWN, HBL, ICOL, IROW, JSRC, LDA, LEFT,
      $                   MODKM1, MYCOL, MYROW, NPCOL, NPROW, NUM, RIGHT,
      $                   RSRC, UP
-      DOUBLE PRECISION   H11, H12, H21, H22, H33S, H44S, S, V1, V2, V3
+      DOUBLE PRECISION   H22, H33S, H44S, S, V1, V2
 *     ..
 *     .. Local Arrays ..
-      DOUBLE PRECISION   BUF( 4 )
+      DOUBLE PRECISION   BUF( 4 ), H11( 1 ), H12( 1 ), H21( 1 ), V3( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, DGERV2D, DGESD2D, INFOG2L
@@ -170,18 +170,18 @@
             IF( NPCOL.GT.1 ) THEN
                CALL DGERV2D( CONTXT, 1, 1, V3, 1, MYROW, LEFT )
             ELSE
-               V3 = A( ( ICOL-2 )*LDA+IROW )
+               V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
             END IF
             IF( NUM.GT.1 ) THEN
                CALL DGERV2D( CONTXT, 4, 1, BUF, 4, UP, LEFT )
-               H11 = BUF( 1 )
-               H21 = BUF( 2 )
-               H12 = BUF( 3 )
+               H11( 1 ) = BUF( 1 )
+               H21( 1 ) = BUF( 2 )
+               H12( 1 ) = BUF( 3 )
                H22 = BUF( 4 )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
                H22 = A( ( ICOL-2 )*LDA+IROW-1 )
             END IF
          END IF
@@ -214,20 +214,20 @@
             IF( NUM.GT.1 ) THEN
                CALL DGERV2D( CONTXT, 1, 1, H11, 1, UP, LEFT )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
             END IF
             IF( NPROW.GT.1 ) THEN
                CALL DGERV2D( CONTXT, 1, 1, H12, 1, UP, MYCOL )
             ELSE
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
             END IF
             IF( NPCOL.GT.1 ) THEN
                CALL DGERV2D( CONTXT, 1, 1, H21, 1, MYROW, LEFT )
             ELSE
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
             END IF
             H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-            V3 = A( ( ICOL-2 )*LDA+IROW )
+            V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
          END IF
       END IF
       IF( ( MYROW.NE.II ) .OR. ( MYCOL.NE.JJ ) )
@@ -236,24 +236,24 @@
       IF( MODKM1.GT.1 ) THEN
          CALL INFOG2L( M+2, M+2, DESCA, NPROW, NPCOL, MYROW, MYCOL,
      $                 IROW, ICOL, RSRC, JSRC )
-         H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-         H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-         H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+         H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+         H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+         H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
          H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-         V3 = A( ( ICOL-2 )*LDA+IROW )
+         V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
       END IF
 *
-      H44S = H44 - H11
-      H33S = H33 - H11
-      V1 = ( H33S*H44S-H43H34 ) / H21 + H12
-      V2 = H22 - H11 - H33S - H44S
-      S = ABS( V1 ) + ABS( V2 ) + ABS( V3 )
+      H44S = H44 - H11( 1 )
+      H33S = H33 - H11( 1 )
+      V1 = ( H33S*H44S-H43H34 ) / H21( 1 ) + H12( 1 )
+      V2 = H22 - H11( 1 ) - H33S - H44S
+      S = ABS( V1 ) + ABS( V2 ) + ABS( V3( 1 ) )
       V1 = V1 / S
       V2 = V2 / S
-      V3 = V3 / S
+      V3( 1 ) = V3( 1 ) / S
       V( 1 ) = V1
       V( 2 ) = V2
-      V( 3 ) = V3
+      V( 3 ) = V3( 1 )
 *
       RETURN
 *

--- a/SRC/pdstebz.f
+++ b/SRC/pdstebz.f
@@ -246,14 +246,14 @@
      $                   ITMP2, J, JB, K, LAST, LEXTRA, LREQ, MYCOL,
      $                   MYROW, NALPHA, NBETA, NCMP, NEIGINT, NEXT, NGL,
      $                   NGLOB, NGU, NINT, NPCOL, NPROW, OFFSET,
-     $                   ONEDCONTEXT, P, PREV, REXTRA, RREQ, SELF,
-     $                   TORECV
+     $                   ONEDCONTEXT, P, PREV, REXTRA, RREQ, SELF
       DOUBLE PRECISION   ALPHA, ATOLI, BETA, BNORM, DRECV, DSEND, GL,
      $                   GU, INITVL, INITVU, LSAVE, MID, PIVMIN, RELTOL,
      $                   SAFEMN, TMP1, TMP2, TNORM, ULP
 *     ..
 *     .. Local Arrays ..
       INTEGER            IDUM( 5, 2 )
+      INTEGER            TORECV( 1, 1 )
 *     ..
 *     .. Executable Statements ..
 *       This is just to keep ftnchek happy
@@ -784,14 +784,14 @@
          ELSE
             CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', 1, 1, TORECV, 1, 0,
      $                    I-1 )
-            IF( TORECV.NE.0 ) THEN
-               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV, 1, IWORK,
-     $                       TORECV, 0, I-1 )
-               CALL DGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV, 1, WORK,
-     $                       TORECV, 0, I-1 )
-               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV, 1,
-     $                       IWORK( N+1 ), TORECV, 0, I-1 )
-               DO 120 J = 1, TORECV
+            IF( TORECV( 1, 1 ).NE.0 ) THEN
+               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV( 1, 1 ), 1,
+     $                       IWORK, TORECV( 1, 1 ), 0, I-1 )
+               CALL DGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV( 1, 1 ), 1,
+     $                       WORK, TORECV( 1, 1 ), 0, I-1 )
+               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV( 1, 1 ), 1,
+     $                       IWORK( N+1 ), TORECV( 1, 1 ), 0, I-1 )
+               DO 120 J = 1, TORECV( 1, 1 )
                   W( IWORK( J ) ) = WORK( J )
                   IBLOCK( IWORK( J ) ) = IWORK( N+J )
   120          CONTINUE

--- a/SRC/pdtrord.f
+++ b/SRC/pdtrord.f
@@ -328,12 +328,13 @@
      $                   EAST, WEST, ILOC4, SOUTH, NORTH, INDXS,
      $                   ITT, JTT, ILEN, DLEN, INDXE, TRSRC1, TCSRC1,
      $                   TRSRC2, TCSRC2, ILOS, DIR, TLIHI, TLILO, TLSEL,
-     $                   ROUND, LAST, WIN0S, WIN0E, WINE, MMAX, MMIN
+     $                   ROUND, LAST, WIN0S, WIN0E, WINE
       DOUBLE PRECISION   ELEM, ELEM1, ELEM2, ELEM3, ELEM4, SN, CS, TMP,
      $                   ELEM5
 *     ..
 *     .. Local Arrays ..
-      INTEGER            IBUFF( 8 ), IDUM1( 1 ), IDUM2( 1 )
+      INTEGER            IBUFF( 8 ), IDUM1( 1 ), IDUM2( 1 ), MMAX( 1 ),
+     $                   MMIN( 1 ), INFODUM( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -483,16 +484,16 @@
                END IF
                IF( SELECT(K).NE.0 ) M = M + 1
  10         CONTINUE
-            MMAX = M
-            MMIN = M
+            MMAX( 1 ) = M
+            MMIN( 1 ) = M
             IF( NPROCS.GT.1 )
      $         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, MMAX, 1, -1,
      $              -1, -1, -1, -1 )
             IF( NPROCS.GT.1 )
      $         CALL IGAMN2D( ICTXT, 'All', TOP, 1, 1, MMIN, 1, -1,
      $              -1, -1, -1, -1 )
-            IF( MMAX.GT.MMIN ) THEN
-               M = MMAX
+            IF( MMAX( 1 ).GT.MMIN( 1 ) ) THEN
+               M = MMAX( 1 )
                IF( NPROCS.GT.1 )
      $            CALL IGAMX2D( ICTXT, 'All', TOP, N, 1, SELECT, N,
      $                 -1, -1, -1, -1, -1 )
@@ -520,9 +521,11 @@
 *
 *     Global maximum on info.
 *
-      IF( NPROCS.GT.1 )
-     $   CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1, -1, -1,
+      IF( NPROCS.GT.1 ) THEN
+         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1, -1, -1,
      $        -1, -1 )
+         INFO = INFODUM( 1 )
+      END IF
 *
 *     Return if some argument is incorrect.
 *
@@ -1576,9 +1579,11 @@
 *        experienced a failure in the reordering.
 *
          MYIERR = IERR
-         IF( NPROCS.GT.1 )
-     $      CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
+         IF( NPROCS.GT.1 ) THEN
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $           -1, -1, -1, -1 )
+            IERR = INFODUM( 1 )
+         END IF
 *
          IF( IERR.NE.0 ) THEN
 *
@@ -1586,9 +1591,11 @@
 *           to swap.
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
-            IF( NPROCS.GT.1 )
-     $         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
+            IF( NPROCS.GT.1 ) THEN
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $              -1, -1, -1, -1 )
+               INFO = INFODUM( 1 )
+            END IF
             GO TO 300
          END IF
 *
@@ -3245,9 +3252,11 @@
 *        experienced a failure in the reordering.
 *
          MYIERR = IERR
-         IF( NPROCS.GT.1 )
-     $      CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
+         IF( NPROCS.GT.1 ) THEN
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $           -1, -1, -1, -1 )
+            IERR = INFODUM( 1 )
+         END IF
 *
          IF( IERR.NE.0 ) THEN
 *
@@ -3255,9 +3264,11 @@
 *           to swap.
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
-            IF( NPROCS.GT.1 )
-     $         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
+            IF( NPROCS.GT.1 ) THEN
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $              -1, -1, -1, -1 )
+               IERR = INFODUM( 1 )
+            END IF
             GO TO 300
          END IF
 *

--- a/SRC/pdtrsen.f
+++ b/SRC/pdtrsen.f
@@ -354,13 +354,15 @@
       LOGICAL            LQUERY, WANTBH, WANTQ, WANTS, WANTSP
       INTEGER            ICOFFT12, ICTXT, IDUM1, IDUM2, IERR, ILOC1,
      $                   IPW1, ITER, ITT, JLOC1, JTT, K, LIWMIN, LLDT,
-     $                   LLDQ, LWMIN, MMAX, MMIN, MYROW, MYCOL, N1, N2,
+     $                   LLDQ, LWMIN, MYROW, MYCOL, N1, N2,
      $                   NB, NOEXSY, NPCOL, NPROCS, NPROW, SPACE,
      $                   T12ROWS, T12COLS, TCOLS, TCSRC, TROWS, TRSRC,
      $                   WRK1, IWRK1, WRK2, IWRK2, WRK3, IWRK3
-      DOUBLE PRECISION   DPDUM1, ELEM, EST, SCALE, RNORM
+      DOUBLE PRECISION   ELEM, EST, SCALE, RNORM
 *     .. Local Arrays ..
-      INTEGER            DESCT12( DLEN_ ), MBNB2( 2 )
+      INTEGER            DESCT12( DLEN_ ), MBNB2( 2 ), MMAX( 1 ),
+     $                   MMIN( 1 )
+      DOUBLE PRECISION   DPDUM1( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -521,16 +523,16 @@
                END IF
                IF( SELECT(K) ) M = M + 1
  10         CONTINUE
-            MMAX = M
-            MMIN = M
+            MMAX( 1 ) = M
+            MMIN( 1 ) = M
             IF( NPROCS.GT.1 )
-     $           CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, MMAX, 1, -1,
-     $                -1, -1, -1, -1 )
+     $           CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, MMAX( 1 ), 1,
+     $                -1, -1, -1, -1, -1 )
             IF( NPROCS.GT.1 )
-     $           CALL IGAMN2D( ICTXT, 'All', TOP, 1, 1, MMIN, 1, -1,
-     $                -1, -1, -1, -1 )
-            IF( MMAX.GT.MMIN ) THEN
-               M = MMAX
+     $           CALL IGAMN2D( ICTXT, 'All', TOP, 1, 1, MMIN( 1 ), 1,
+     $                -1, -1, -1, -1, -1 )
+            IF( MMAX( 1 ).GT.MMIN( 1 ) ) THEN
+               M = MMAX( 1 )
                IF( NPROCS.GT.1 )
      $              CALL IGAMX2D( ICTXT, 'All', TOP, N, 1, IWORK, N,
      $                   -1, -1, -1, -1, -1 )

--- a/SRC/pshseqr.f
+++ b/SRC/pshseqr.f
@@ -259,11 +259,12 @@
      $                   HRSRC4, HCSRC4, LIWKOPT
       LOGICAL            INITZ, LQUERY, WANTT, WANTZ, PAIR, BORDER
       REAL               TMP1, TMP2, TMP3, TMP4, DUM1, DUM2, DUM3,
-     $                   DUM4, ELEM1, ELEM2, ELEM3, ELEM4,
+     $                   DUM4, ELEM1, ELEM4,
      $                   CS, SN, ELEM5, TMP, LWKOPT
 *     ..
 *     .. Local Arrays ..
       INTEGER            DESCH2( DLEN_ )
+      REAL               ELEM2( 1 ), ELEM3( 1 )
 *     ..
 *     .. External Functions ..
       INTEGER            PILAENVX, NUMROC, ICEIL
@@ -566,28 +567,28 @@
                   IF( MYROW.EQ.HRSRC1 .AND. MYCOL.EQ.HCSRC1 ) THEN
                      ELEM1 = H((JLOC1-1)*LLDH+ILOC1)
                      IF( K.LT.N ) THEN
-                        ELEM3 = H((JLOC1-1)*LLDH+ILOC1+1)
+                        ELEM3( 1 ) = H((JLOC1-1)*LLDH+ILOC1+1)
                      ELSE
-                        ELEM3 = ZERO
+                        ELEM3( 1 ) = ZERO
                      END IF
-                     IF( ELEM3.NE.ZERO ) THEN
-                        ELEM2 = H((JLOC1)*LLDH+ILOC1)
+                     IF( ELEM3( 1 ).NE.ZERO ) THEN
+                        ELEM2( 1 ) = H((JLOC1)*LLDH+ILOC1)
                         ELEM4 = H((JLOC1)*LLDH+ILOC1+1)
-                        CALL SLANV2( ELEM1, ELEM2, ELEM3, ELEM4,
-     $                       WR( K ), WI( K ), WR( K+1 ), WI( K+1 ),
-     $                       SN, CS )
+                        CALL SLANV2( ELEM1, ELEM2( 1 ), ELEM3( 1 ),
+     $                       ELEM4, WR( K ), WI( K ), WR( K+1 ),
+     $                       WI( K+1 ), SN, CS )
                         PAIR = .TRUE.
                      ELSE
                         IF( K.GT.1 ) THEN
                            TMP = H((JLOC1-2)*LLDH+ILOC1)
                            IF( TMP.NE.ZERO ) THEN
                               ELEM1 = H((JLOC1-2)*LLDH+ILOC1-1)
-                              ELEM2 = H((JLOC1-1)*LLDH+ILOC1-1)
-                              ELEM3 = H((JLOC1-2)*LLDH+ILOC1)
+                              ELEM2( 1 ) = H((JLOC1-1)*LLDH+ILOC1-1)
+                              ELEM3( 1 ) = H((JLOC1-2)*LLDH+ILOC1)
                               ELEM4 = H((JLOC1-1)*LLDH+ILOC1)
-                              CALL SLANV2( ELEM1, ELEM2, ELEM3,
-     $                             ELEM4, WR( K-1 ), WI( K-1 ),
-     $                             WR( K ), WI( K ), SN, CS )
+                              CALL SLANV2( ELEM1, ELEM2( 1 ),
+     $                             ELEM3( 1 ), ELEM4, WR( K-1 ),
+     $                             WI( K-1 ), WR( K ), WI( K ), SN, CS )
                            ELSE
                               WR( K ) = ELEM1
                            END IF
@@ -620,12 +621,12 @@
             CALL INFOG2L( K+1, K+1, DESCH, NPROW, NPCOL, MYROW, MYCOL,
      $           ILOC4, JLOC4, HRSRC4, HCSRC4 )
             IF( MYROW.EQ.HRSRC2 .AND. MYCOL.EQ.HCSRC2 ) THEN
-               ELEM2 = H((JLOC2-1)*LLDH+ILOC2)
+               ELEM2( 1 ) = H((JLOC2-1)*LLDH+ILOC2)
                IF( HRSRC1.NE.HRSRC2 .OR. HCSRC1.NE.HCSRC2 )
      $            CALL SGESD2D( ICTXT, 1, 1, ELEM2, 1, HRSRC1, HCSRC1)
             END IF
             IF( MYROW.EQ.HRSRC3 .AND. MYCOL.EQ.HCSRC3 ) THEN
-               ELEM3 = H((JLOC3-1)*LLDH+ILOC3)
+               ELEM3( 1 ) = H((JLOC3-1)*LLDH+ILOC3)
                IF( HRSRC1.NE.HRSRC3 .OR. HCSRC1.NE.HCSRC3 )
      $            CALL SGESD2D( ICTXT, 1, 1, ELEM3, 1, HRSRC1, HCSRC1)
             END IF
@@ -651,8 +652,9 @@
                ELEM5 = WORK(2)
                IF( ELEM5.EQ.ZERO ) THEN
                   IF( WR( K ).EQ.ZERO .AND. WI( K ).EQ.ZERO ) THEN
-                     CALL SLANV2( ELEM1, ELEM2, ELEM3, ELEM4, WR( K ),
-     $                    WI( K ), WR( K+1 ), WI( K+1 ), SN, CS )
+                     CALL SLANV2( ELEM1, ELEM2( 1 ), ELEM3( 1 ), ELEM4,
+     $                    WR( K ), WI( K ), WR( K+1 ), WI( K+1 ), SN,
+     $                    CS )
                   ELSEIF( WR( K+1 ).EQ.ZERO .AND. WI( K+1 ).EQ.ZERO )
      $                 THEN
                      WR( K+1 ) = ELEM4

--- a/SRC/pslarf.f
+++ b/SRC/pslarf.f
@@ -241,7 +241,7 @@
      $                   IOFFV, IPW, IROFF, IVCOL, IVROW, JJC, JJV, LDC,
      $                   LDV, MYCOL, MYROW, MP, NCC, NCV, NPCOL, NPROW,
      $                   NQ, RDEST
-      REAL               TAULOC
+      REAL               TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, PB_TOPGET, PBSTRNV,
@@ -335,7 +335,7 @@
 *
                      CALL SGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -344,7 +344,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -362,8 +362,8 @@
 *
 *                    sub( C ) := sub( C ) - v * w'
 *
-                     CALL SGER( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                          1, C( IOFFC ), LDC )
+                     CALL SGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                          WORK( IPW ), 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -378,9 +378,9 @@
 *
                   IF( MYCOL.EQ.ICCOL ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -397,8 +397,8 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL SGER( MP, NQ, -TAULOC, V( IOFFV ), 1, WORK,
-     $                             1, C( IOFFC ), LDC )
+                        CALL SGER( MP, NQ, -TAULOC( 1 ), V( IOFFV ), 1,
+     $                             WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
                   END IF
@@ -420,9 +420,9 @@
                      IPW = MP+1
                      CALL SGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -440,7 +440,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL SGER( MP, NQ, -TAULOC, WORK, 1,
+                        CALL SGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                             WORK( IPW ), 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -470,7 +470,7 @@
 *
                   CALL SGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -479,7 +479,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -499,8 +499,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL SGER( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                          1, C( IOFFC ), LDC )
+     $               CALL SGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                          WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -515,18 +515,18 @@
                   WORK(IPW) = TAU( JJV )
                   CALL SGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MP+1
                   CALL SGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -546,8 +546,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL SGER( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                          1, C( IOFFC ), LDC )
+     $               CALL SGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                          WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             END IF
@@ -576,9 +576,9 @@
 *
                   IF( MYROW.EQ.ICROW ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -596,7 +596,7 @@
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( IOFFV.GT.0 .AND. IOFFC.GT.0 )
-     $                     CALL SGER( MP, NQ, -TAULOC, WORK, 1,
+     $                     CALL SGER( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                                V( IOFFV ), LDV, C( IOFFC ), LDC )
                      END IF
 *
@@ -619,9 +619,9 @@
                      IPW = NQ+1
                      CALL SGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -639,7 +639,7 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL SGER( MP, NQ, -TAULOC, WORK( IPW ), 1,
+                        CALL SGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
      $                             WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -665,7 +665,7 @@
 *
                      CALL SGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -674,7 +674,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -692,8 +692,8 @@
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL SGER( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                          1, C( IOFFC ), LDC )
+                     CALL SGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1
+     $                         , WORK, 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -718,18 +718,18 @@
                   WORK(IPW) = TAU( IIV )
                   CALL SGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQ+1
                   CALL SGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -748,8 +748,8 @@
 *                 sub( C ) := sub( C ) - w * v'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL SGER( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                          1, C( IOFFC ), LDC )
+     $               CALL SGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                          WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -768,7 +768,7 @@
 *
                   CALL SGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -777,7 +777,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -795,8 +795,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL SGER( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                       C( IOFFC ), LDC )
+                  CALL SGER( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1, WORK,
+     $                       1, C( IOFFC ), LDC )
                END IF
 *
             END IF

--- a/SRC/pslarz.f
+++ b/SRC/pslarz.f
@@ -250,7 +250,7 @@
      $                   IVCOL, IVROW, JJC1, JJC2, JJV, LDC, LDV, MPC2,
      $                   MPV, MYCOL, MYROW, NCC, NCV, NPCOL, NPROW,
      $                   NQC2, NQV, RDEST
-      REAL               TAULOC
+      REAL               TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, PB_TOPGET, PBSTRNV,
@@ -369,7 +369,7 @@
 *
                      CALL SGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -378,7 +378,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -401,9 +401,9 @@
 *                    sub( C ) := sub( C ) - v * w'
 *
                      IF( MYROW.EQ.ICROW1 )
-     $                  CALL SAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                  CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                     CALL SGER( MPV, NQC2, -TAULOC, WORK, 1,
+                     CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                          WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -419,9 +419,9 @@
 *
                   IF( MYCOL.EQ.ICCOL2 ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -444,11 +444,11 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL SAXPY( NQC2, -TAULOC, WORK,
+     $                     CALL SAXPY( NQC2, -TAULOC( 1 ), WORK,
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL SGER( MPV, NQC2, -TAULOC, V( IOFFV ), 1,
-     $                             WORK, 1, C( IOFFC2 ), LDC )
+                        CALL SGER( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
+     $                             1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -470,9 +470,9 @@
                      IPW = MPV+1
                      CALL SGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -495,10 +495,10 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL SAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                     CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL SGER( MPV, NQC2, -TAULOC, WORK, 1,
+                        CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                             WORK( IPW ), 1, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -529,7 +529,7 @@
 *
                   CALL SGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -538,7 +538,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -561,10 +561,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL SAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL SGER( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -579,18 +579,18 @@
                   WORK( IPW ) = TAU( JJV )
                   CALL SGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MPV+1
                   CALL SGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -613,10 +613,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL SAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL SGER( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF
@@ -645,9 +645,9 @@
 *
                   IF( MYROW.EQ.ICROW2 ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -668,13 +668,13 @@
      $                               ICCOL2 )
 *
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL SAXPY( MPC2, -TAULOC, WORK, 1,
+     $                     CALL SAXPY( MPC2, -TAULOC( 1 ), WORK, 1,
      $                                 C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( MPC2.GT.0 .AND. NQV.GT.0 )
-     $                     CALL SGER( MPC2, NQV, -TAULOC, WORK, 1,
+     $                     CALL SGER( MPC2, NQV, -TAULOC( 1 ), WORK, 1,
      $                                V( IOFFV ), LDV, C( IOFFC2 ),
      $                                LDC )
                      END IF
@@ -698,9 +698,9 @@
                      IPW = NQV+1
                      CALL SGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -719,13 +719,13 @@
      $                                WORK( IPW ), MAX( 1, MPC2 ),
      $                                RDEST, ICCOL2 )
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL SAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
-     $                                 C( IOFFC1 ), 1 )
+     $                     CALL SAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ),
+     $                                 1, C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL SGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                             WORK, 1, C( IOFFC2 ), LDC )
+                        CALL SGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ),
+     $                             1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -750,7 +750,7 @@
 *
                      CALL SGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -759,7 +759,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -778,12 +778,12 @@
      $                             WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                             ICCOL2 )
                      IF( MYCOL.EQ.ICCOL1 )
-     $                  CALL SAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $                  CALL SAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                              C( IOFFC1 ), 1 )
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL SGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
+                     CALL SGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
      $                          WORK, 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -808,18 +808,18 @@
                   WORK( IPW ) = TAU( IIV )
                   CALL SGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQV+1
                   CALL SGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -839,13 +839,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL SAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL SAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL SGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL SGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                       WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -864,7 +864,7 @@
 *
                   CALL SGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -873,7 +873,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -892,13 +892,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL SAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL SAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL SGER( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                       1, C( IOFFC2 ), LDC )
+                  CALL SGER( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                       WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF

--- a/SRC/pslawil.f
+++ b/SRC/pslawil.f
@@ -120,10 +120,14 @@
       INTEGER            CONTXT, DOWN, HBL, ICOL, IROW, JSRC, LDA, LEFT,
      $                   MODKM1, MYCOL, MYROW, NPCOL, NPROW, NUM, RIGHT,
      $                   RSRC, UP
-      REAL               H11, H12, H21, H22, H33S, H44S, S, V1, V2, V3
+      REAL               H22, H33S, H44S, S, V1, V2
 *     ..
 *     .. Local Arrays ..
       REAL               BUF( 4 )
+      REAL               H11( 1 )
+      REAL               H12( 1 )
+      REAL               H21( 1 )
+      REAL               V3( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, SGERV2D, SGESD2D, INFOG2L
@@ -170,18 +174,18 @@
             IF( NPCOL.GT.1 ) THEN
                CALL SGERV2D( CONTXT, 1, 1, V3, 1, MYROW, LEFT )
             ELSE
-               V3 = A( ( ICOL-2 )*LDA+IROW )
+               V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
             END IF
             IF( NUM.GT.1 ) THEN
                CALL SGERV2D( CONTXT, 4, 1, BUF, 4, UP, LEFT )
-               H11 = BUF( 1 )
-               H21 = BUF( 2 )
-               H12 = BUF( 3 )
+               H11( 1 ) = BUF( 1 )
+               H21( 1 ) = BUF( 2 )
+               H12( 1 ) = BUF( 3 )
                H22 = BUF( 4 )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
                H22 = A( ( ICOL-2 )*LDA+IROW-1 )
             END IF
          END IF
@@ -214,20 +218,20 @@
             IF( NUM.GT.1 ) THEN
                CALL SGERV2D( CONTXT, 1, 1, H11, 1, UP, LEFT )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
             END IF
             IF( NPROW.GT.1 ) THEN
                CALL SGERV2D( CONTXT, 1, 1, H12, 1, UP, MYCOL )
             ELSE
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
             END IF
             IF( NPCOL.GT.1 ) THEN
                CALL SGERV2D( CONTXT, 1, 1, H21, 1, MYROW, LEFT )
             ELSE
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
             END IF
             H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-            V3 = A( ( ICOL-2 )*LDA+IROW )
+            V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
          END IF
       END IF
       IF( ( MYROW.NE.II ) .OR. ( MYCOL.NE.JJ ) )
@@ -236,24 +240,24 @@
       IF( MODKM1.GT.1 ) THEN
          CALL INFOG2L( M+2, M+2, DESCA, NPROW, NPCOL, MYROW, MYCOL,
      $                 IROW, ICOL, RSRC, JSRC )
-         H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-         H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-         H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+         H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+         H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+         H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
          H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-         V3 = A( ( ICOL-2 )*LDA+IROW )
+         V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
       END IF
 *
-      H44S = H44 - H11
-      H33S = H33 - H11
-      V1 = ( H33S*H44S-H43H34 ) / H21 + H12
-      V2 = H22 - H11 - H33S - H44S
-      S = ABS( V1 ) + ABS( V2 ) + ABS( V3 )
+      H44S = H44 - H11( 1 )
+      H33S = H33 - H11( 1 )
+      V1 = ( H33S*H44S-H43H34 ) / H21( 1 ) + H12( 1 )
+      V2 = H22 - H11( 1 ) - H33S - H44S
+      S = ABS( V1 ) + ABS( V2 ) + ABS( V3( 1 ) )
       V1 = V1 / S
       V2 = V2 / S
-      V3 = V3 / S
+      V3( 1 ) = V3( 1 ) / S
       V( 1 ) = V1
       V( 2 ) = V2
-      V( 3 ) = V3
+      V( 3 ) = V3( 1 )
 *
       RETURN
 *

--- a/SRC/psstebz.f
+++ b/SRC/psstebz.f
@@ -244,14 +244,14 @@
      $                   ITMP2, J, JB, K, LAST, LEXTRA, LREQ, MYCOL,
      $                   MYROW, NALPHA, NBETA, NCMP, NEIGINT, NEXT, NGL,
      $                   NGLOB, NGU, NINT, NPCOL, NPROW, OFFSET,
-     $                   ONEDCONTEXT, P, PREV, REXTRA, RREQ, SELF,
-     $                   TORECV
+     $                   ONEDCONTEXT, P, PREV, REXTRA, RREQ, SELF
       REAL               ALPHA, ATOLI, BETA, BNORM, DRECV, DSEND, GL,
      $                   GU, INITVL, INITVU, LSAVE, MID, PIVMIN, RELTOL,
      $                   SAFEMN, TMP1, TMP2, TNORM, ULP
 *     ..
 *     .. Local Arrays ..
       INTEGER            IDUM( 5, 2 )
+      INTEGER            TORECV( 1, 1 )
 *     ..
 *     .. Executable Statements ..
 *       This is just to keep ftnchek happy
@@ -774,14 +774,14 @@
          ELSE
             CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', 1, 1, TORECV, 1, 0,
      $                    I-1 )
-            IF( TORECV.NE.0 ) THEN
-               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV, 1, IWORK,
-     $                       TORECV, 0, I-1 )
-               CALL SGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV, 1, WORK,
-     $                       TORECV, 0, I-1 )
-               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV, 1,
-     $                       IWORK( N+1 ), TORECV, 0, I-1 )
-               DO 120 J = 1, TORECV
+            IF( TORECV( 1, 1 ).NE.0 ) THEN
+               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV( 1, 1 ), 1,
+     $                       IWORK, TORECV( 1, 1 ), 0, I-1 )
+               CALL SGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV( 1, 1 ), 1,
+     $                       WORK, TORECV( 1, 1 ), 0, I-1 )
+               CALL IGEBR2D( ONEDCONTEXT, 'ALL', ' ', TORECV( 1, 1 ), 1,
+     $                       IWORK( N+1 ), TORECV( 1, 1 ), 0, I-1 )
+               DO 120 J = 1, TORECV( 1, 1 )
                   W( IWORK( J ) ) = WORK( J )
                   IBLOCK( IWORK( J ) ) = IWORK( N+J )
   120          CONTINUE

--- a/SRC/pstrord.f
+++ b/SRC/pstrord.f
@@ -328,12 +328,13 @@
      $                   EAST, WEST, ILOC4, SOUTH, NORTH, INDXS,
      $                   ITT, JTT, ILEN, DLEN, INDXE, TRSRC1, TCSRC1,
      $                   TRSRC2, TCSRC2, ILOS, DIR, TLIHI, TLILO, TLSEL,
-     $                   ROUND, LAST, WIN0S, WIN0E, WINE, MMAX, MMIN
+     $                   ROUND, LAST, WIN0S, WIN0E, WINE
       REAL               ELEM, ELEM1, ELEM2, ELEM3, ELEM4, SN, CS, TMP,
      $                   ELEM5
 *     ..
 *     .. Local Arrays ..
-      INTEGER            IBUFF( 8 ), IDUM1( 1 ), IDUM2( 1 )
+      INTEGER            IBUFF( 8 ), IDUM1( 1 ), IDUM2( 1 ), MMAX( 1 ),
+     $                    MMIN( 1 ), INFODUM( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -483,16 +484,16 @@
                END IF
                IF( SELECT(K).NE.0 ) M = M + 1
  10         CONTINUE
-            MMAX = M
-            MMIN = M
+            MMAX( 1 ) = M
+            MMIN( 1 ) = M
             IF( NPROCS.GT.1 )
      $         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, MMAX, 1, -1,
      $              -1, -1, -1, -1 )
             IF( NPROCS.GT.1 )
      $         CALL IGAMN2D( ICTXT, 'All', TOP, 1, 1, MMIN, 1, -1,
      $              -1, -1, -1, -1 )
-            IF( MMAX.GT.MMIN ) THEN
-               M = MMAX
+            IF( MMAX( 1 ).GT.MMIN( 1 ) ) THEN
+               M = MMAX( 1 )
                IF( NPROCS.GT.1 )
      $            CALL IGAMX2D( ICTXT, 'All', TOP, N, 1, SELECT, N,
      $                 -1, -1, -1, -1, -1 )
@@ -520,9 +521,11 @@
 *
 *     Global maximum on info.
 *
-      IF( NPROCS.GT.1 )
-     $   CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1, -1, -1,
-     $        -1, -1 )
+      IF( NPROCS.GT.1 ) THEN
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1, -1,
+     $        -1, -1, -1 )
+            INFO = INFODUM( 1 )
+      END IF
 *
 *     Return if some argument is incorrect.
 *
@@ -1576,9 +1579,11 @@
 *        experienced a failure in the reordering.
 *
          MYIERR = IERR
-         IF( NPROCS.GT.1 )
-     $      CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
+         IF( NPROCS.GT.1 ) THEN
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $           -1, -1, -1, -1 )
+            IERR = INFODUM( 1 )
+         END IF
 *
          IF( IERR.NE.0 ) THEN
 *
@@ -1586,9 +1591,11 @@
 *           to swap.
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
-            IF( NPROCS.GT.1 )
-     $         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
+            IF( NPROCS.GT.1 ) THEN
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $              -1, -1, -1, -1 )
+               INFO = INFODUM( 1 )
+            END IF
             GO TO 300
          END IF
 *
@@ -3245,9 +3252,11 @@
 *        experienced a failure in the reordering.
 *
          MYIERR = IERR
-         IF( NPROCS.GT.1 )
-     $      CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
+         IF( NPROCS.GT.1 ) THEN
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $           -1, -1, -1, -1 )
+            IERR = INFODUM( 1 )
+         END IF
 *
          IF( IERR.NE.0 ) THEN
 *
@@ -3255,9 +3264,11 @@
 *           to swap.
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
-            IF( NPROCS.GT.1 )
-     $         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
+            IF( NPROCS.GT.1 ) THEN
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
      $              -1, -1, -1, -1 )
+               INFO = INFODUM( 1 )
+            END IF
             GO TO 300
          END IF
 *

--- a/SRC/pstrsen.f
+++ b/SRC/pstrsen.f
@@ -354,13 +354,15 @@
       LOGICAL            LQUERY, WANTBH, WANTQ, WANTS, WANTSP
       INTEGER            ICOFFT12, ICTXT, IDUM1, IDUM2, IERR, ILOC1,
      $                   IPW1, ITER, ITT, JLOC1, JTT, K, LIWMIN, LLDT,
-     $                   LLDQ, LWMIN, MMAX, MMIN, MYROW, MYCOL, N1, N2,
+     $                   LLDQ, LWMIN, MYROW, MYCOL, N1, N2,
      $                   NB, NOEXSY, NPCOL, NPROCS, NPROW, SPACE,
      $                   T12ROWS, T12COLS, TCOLS, TCSRC, TROWS, TRSRC,
      $                   WRK1, IWRK1, WRK2, IWRK2, WRK3, IWRK3
-      REAL               DPDUM1, ELEM, EST, SCALE, RNORM
+      REAL               ELEM, EST, SCALE, RNORM
 *     .. Local Arrays ..
-      INTEGER            DESCT12( DLEN_ ), MBNB2( 2 )
+      INTEGER            DESCT12( DLEN_ ), MBNB2( 2 ), MMAX( 1 ),
+     $                   MMIN( 1 ), INFODUM( 1 )
+      REAL               DPDUM1( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -521,16 +523,16 @@
                END IF
                IF( SELECT(K) ) M = M + 1
  10         CONTINUE
-            MMAX = M
-            MMIN = M
+            MMAX( 1 ) = M
+            MMIN( 1 ) = M
             IF( NPROCS.GT.1 )
      $           CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, MMAX, 1, -1,
      $                -1, -1, -1, -1 )
             IF( NPROCS.GT.1 )
      $           CALL IGAMN2D( ICTXT, 'All', TOP, 1, 1, MMIN, 1, -1,
      $                -1, -1, -1, -1 )
-            IF( MMAX.GT.MMIN ) THEN
-               M = MMAX
+            IF( MMAX( 1 ).GT.MMIN( 1 ) ) THEN
+               M = MMAX( 1 )
                IF( NPROCS.GT.1 )
      $              CALL IGAMX2D( ICTXT, 'All', TOP, N, 1, IWORK, N,
      $                   -1, -1, -1, -1, -1 )
@@ -602,9 +604,11 @@ c     $              IERR )
 *
 *     Global maximum on info
 *
-      IF( NPROCS.GT.1 )
-     $     CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1, -1, -1,
+      IF( NPROCS.GT.1 ) THEN
+         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1, -1, -1,
      $          -1, -1 )
+         INFO = INFODUM( 1 )
+      END IF
 *
 *     Return if some argument is incorrect
 *

--- a/SRC/pzlarf.f
+++ b/SRC/pzlarf.f
@@ -242,7 +242,7 @@
      $                   IOFFV, IPW, IROFF, IVCOL, IVROW, JJC, JJV, LDC,
      $                   LDV, MYCOL, MYROW, MP, NCC, NCV, NPCOL, NPROW,
      $                   NQ, RDEST
-      COMPLEX*16         TAULOC
+      COMPLEX*16         TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, PB_TOPGET, PBZTRNV,
@@ -336,7 +336,7 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -345,7 +345,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -363,8 +363,8 @@
 *
 *                    sub( C ) := sub( C ) - v * w'
 *
-                     CALL ZGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+                     CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -379,9 +379,9 @@
 *
                   IF( MYCOL.EQ.ICCOL ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -398,7 +398,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, V( IOFFV ), 1,
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), V( IOFFV ), 1,
      $                              WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -421,9 +421,9 @@
                      IPW = MP+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -441,7 +441,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, WORK, 1,
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -471,7 +471,7 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -480,7 +480,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -500,8 +500,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL ZGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+     $               CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -516,18 +516,18 @@
                   WORK(IPW) = TAU( JJV )
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MP+1
                   CALL ZGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -547,8 +547,8 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL ZGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+     $               CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             END IF
@@ -577,9 +577,9 @@
 *
                   IF( MYROW.EQ.ICROW ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -597,7 +597,7 @@
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( IOFFV.GT.0 .AND. IOFFC.GT.0 )
-     $                     CALL ZGERC( MP, NQ, -TAULOC, WORK, 1,
+     $                     CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                                 V( IOFFV ), LDV, C( IOFFC ),
      $                                 LDC )
                      END IF
@@ -621,9 +621,9 @@
                      IPW = NQ+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -641,8 +641,8 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC ), LDC )
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ),
+     $                              1, WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
                   END IF
@@ -667,7 +667,7 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -676,7 +676,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -694,8 +694,8 @@
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                           1, C( IOFFC ), LDC )
+                     CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                           WORK, 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -720,18 +720,18 @@
                   WORK(IPW) = TAU( IIV )
                   CALL ZGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQ+1
                   CALL ZGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -750,8 +750,8 @@
 *                 sub( C ) := sub( C ) - w * v'
 *
                   IF( IOFFC.GT.0 )
-     $               CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                           1, C( IOFFC ), LDC )
+     $               CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                           WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -770,7 +770,7 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -779,7 +779,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -797,8 +797,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                        C( IOFFC ), LDC )
+                  CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             END IF

--- a/SRC/pzlarfc.f
+++ b/SRC/pzlarfc.f
@@ -242,7 +242,7 @@
      $                   IOFFV, IPW, IROFF, IVCOL, IVROW, JJC, JJV, LDC,
      $                   LDV, MYCOL, MYROW, MP, NCC, NCV, NPCOL, NPROW,
      $                   NQ, RDEST
-      COMPLEX*16         TAULOC
+      COMPLEX*16         TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, PB_TOPGET, PBZTRNV,
@@ -336,17 +336,17 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = DCONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
                   ELSE
 *
                      CALL ZGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAULOC, 1, IVROW, MYCOL )
-                     TAULOC = DCONJG( TAULOC )
+                     TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -364,8 +364,8 @@
 *
 *                    sub( C ) := sub( C ) - v * w'
 *
-                     CALL ZGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ),
-     $                           1, C( IOFFC ), LDC )
+                     CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                           WORK( IPW ), 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -380,9 +380,9 @@
 *
                   IF( MYCOL.EQ.ICCOL ) THEN
 *
-                     TAULOC = DCONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -399,7 +399,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, V( IOFFV ), 1,
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), V( IOFFV ), 1,
      $                              WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -422,9 +422,9 @@
                      IPW = MP+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = DCONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -442,7 +442,7 @@
 *
 *                       sub( C ) := sub( C ) - v * w'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, WORK, 1,
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC ), LDC )
                      END IF
 *
@@ -472,17 +472,17 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = DCONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
                ELSE
 *
                   CALL ZGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1, TAULOC,
      $                          1, IVROW, MYCOL )
-                  TAULOC = DCONJG( TAULOC )
+                  TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -500,8 +500,8 @@
 *
 *                 sub( C ) := sub( C ) - v * w'
 *
-                  CALL ZGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ), 1,
-     $                        C( IOFFC ), LDC )
+                  CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -516,18 +516,18 @@
                   WORK(IPW) = TAU( JJV )
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = DCONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
                ELSE
 *
                   IPW = MP+1
                   CALL ZGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = DCONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -545,8 +545,8 @@
 *
 *                 sub( C ) := sub( C ) - v * w'
 *
-                  CALL ZGERC( MP, NQ, -TAULOC, WORK, 1, WORK( IPW ), 1,
-     $                        C( IOFFC ), LDC )
+                  CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC ), LDC )
                END IF
 *
             END IF
@@ -575,9 +575,9 @@
 *
                   IF( MYROW.EQ.ICROW ) THEN
 *
-                     TAULOC = DCONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -594,7 +594,7 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, WORK, 1,
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK, 1,
      $                              V( IOFFV ), LDV, C( IOFFC ), LDC )
                      END IF
 *
@@ -617,9 +617,9 @@
                      IPW = NQ+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = DCONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -637,8 +637,8 @@
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC ), LDC )
+                        CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ),
+     $                              1, WORK, 1, C( IOFFC ), LDC )
                      END IF
 *
                   END IF
@@ -663,17 +663,17 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = DCONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
                   ELSE
 *
                      CALL ZGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC,
      $                             1, MYROW, IVCOL )
-                     TAULOC = DCONJG( TAULOC )
+                     TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -691,8 +691,8 @@
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK,
-     $                           1, C( IOFFC ), LDC )
+                     CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                           WORK, 1, C( IOFFC ), LDC )
                   END IF
 *
                END IF
@@ -716,18 +716,18 @@
                   WORK(IPW) = TAU( IIV )
                   CALL ZGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = DCONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
                ELSE
 *
                   IPW = NQ+1
                   CALL ZGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = DCONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -745,8 +745,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                        C( IOFFC ), LDC )
+                  CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             ELSE
@@ -765,17 +765,17 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = DCONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
                ELSE
 *
                   CALL ZGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC, 1,
      $                          MYROW, IVCOL )
-                  TAULOC = DCONJG( TAULOC )
+                  TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -793,8 +793,8 @@
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MP, NQ, -TAULOC, WORK( IPW ), 1, WORK, 1,
-     $                        C( IOFFC ), LDC )
+                  CALL ZGERC( MP, NQ, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC ), LDC )
                END IF
 *
             END IF

--- a/SRC/pzlarz.f
+++ b/SRC/pzlarz.f
@@ -251,7 +251,7 @@
      $                   IVCOL, IVROW, JJC1, JJC2, JJV, LDC, LDV, MPC2,
      $                   MPV, MYCOL, MYROW, NCC, NCV, NPCOL, NPROW,
      $                   NQC2, NQV, RDEST
-      COMPLEX*16         TAULOC
+      COMPLEX*16         TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, PB_TOPGET, PBZTRNV,
@@ -370,7 +370,7 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
                   ELSE
 *
@@ -379,7 +379,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -402,9 +402,9 @@
 *                    sub( C ) := sub( C ) - v * w'
 *
                      IF( MYROW.EQ.ICROW1 )
-     $                  CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                  CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                     CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                     CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                           WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -420,9 +420,9 @@
 *
                   IF( MYCOL.EQ.ICCOL2 ) THEN
 *
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -445,11 +445,11 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL ZAXPY( NQC2, -TAULOC, WORK,
+     $                     CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK,
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL ZGERC( MPV, NQC2, -TAULOC, V( IOFFV ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
+     $                              1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -471,9 +471,9 @@
                      IPW = MPV+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -496,10 +496,10 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                     CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                        CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -530,7 +530,7 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
@@ -539,7 +539,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -562,10 +562,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -580,18 +580,18 @@
                   WORK( IPW ) = TAU( JJV )
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
                   IPW = MPV+1
                   CALL ZGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -614,10 +614,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF
@@ -646,9 +646,9 @@
 *
                   IF( MYROW.EQ.ICROW2 ) THEN
 *
-                     TAULOC = TAU( IIV )
+                     TAULOC( 1 ) = TAU( IIV )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -669,13 +669,13 @@
      $                               ICCOL2 )
 *
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL ZAXPY( MPC2, -TAULOC, WORK, 1,
+     $                     CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK, 1,
      $                                 C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
                         IF( MPC2.GT.0 .AND. NQV.GT.0 )
-     $                     CALL ZGERC( MPC2, NQV, -TAULOC, WORK, 1,
+     $                     CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK, 1,
      $                                 V( IOFFV ), LDV, C( IOFFC2 ),
      $                                 LDC )
                      END IF
@@ -699,9 +699,9 @@
                      IPW = NQV+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = WORK( IPW )
+                     TAULOC( 1 ) = WORK( IPW )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -720,13 +720,14 @@
      $                                WORK( IPW ), MAX( 1, MPC2 ),
      $                                RDEST, ICCOL2 )
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
-     $                                 C( IOFFC1 ), 1 )
+     $                     CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ),
+     $                                 1, C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL ZGERC( MPC2, NQV, -TAULOC( 1 ),
+     $                              WORK( IPW ), 1, WORK, 1,
+     $                              C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -751,7 +752,7 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = TAU( JJV )
+                     TAULOC( 1 ) = TAU( JJV )
 *
                   ELSE
 *
@@ -760,7 +761,7 @@
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -779,13 +780,13 @@
      $                             WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                             ICCOL2 )
                      IF( MYCOL.EQ.ICCOL1 )
-     $                  CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $                  CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                              C( IOFFC1 ), 1 )
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                           WORK, 1, C( IOFFC2 ), LDC )
+                     CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ),
+     $                           1, WORK, 1, C( IOFFC2 ), LDC )
                   END IF
 *
                END IF
@@ -809,18 +810,18 @@
                   WORK( IPW ) = TAU( IIV )
                   CALL ZGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = TAU( IIV )
+                  TAULOC( 1 ) = TAU( IIV )
 *
                ELSE
 *
                   IPW = NQV+1
                   CALL ZGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = WORK( IPW )
+                  TAULOC( 1 ) = WORK( IPW )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -840,13 +841,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -865,7 +866,7 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = TAU( JJV )
+                  TAULOC( 1 ) = TAU( JJV )
 *
                ELSE
 *
@@ -874,7 +875,7 @@
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -893,13 +894,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF

--- a/SRC/pzlarzc.f
+++ b/SRC/pzlarzc.f
@@ -251,7 +251,7 @@
      $                   IVCOL, IVROW, JJC1, JJC2, JJV, LDC, LDV, MPC2,
      $                   MPV, MYCOL, MYROW, NCC, NCV, NPCOL, NPROW,
      $                   NQC2, NQV, RDEST
-      COMPLEX*16         TAULOC
+      COMPLEX*16         TAULOC( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, PB_TOPGET, PBZTRNV,
@@ -370,17 +370,17 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAU( IIV ), 1 )
-                     TAULOC = DCONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
                   ELSE
 *
                      CALL ZGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                             TAULOC, 1, IVROW, MYCOL )
-                     TAULOC = DCONJG( TAULOC )
+                     TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C )' * v
 *
@@ -403,9 +403,9 @@
 *                    sub( C ) := sub( C ) - v * w'
 *
                      IF( MYROW.EQ.ICROW1 )
-     $                  CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                  CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                     CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                     CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                           WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
 *
@@ -421,9 +421,9 @@
 *
                   IF( MYCOL.EQ.ICCOL2 ) THEN
 *
-                     TAULOC = DCONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -446,11 +446,11 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL ZAXPY( NQC2, -TAULOC, WORK,
+     $                     CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK,
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL ZGERC( MPV, NQC2, -TAULOC, V( IOFFV ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
+     $                              1, WORK, 1, C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -472,9 +472,9 @@
                      IPW = MPV+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, MYROW,
      $                             IVCOL )
-                     TAULOC = DCONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C )' * v
 *
@@ -497,10 +497,10 @@
 *                       sub( C ) := sub( C ) - v * w'
 *
                         IF( MYROW.EQ.ICROW1 )
-     $                     CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $                     CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
      $                                 LDC )
-                        CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1,
+                        CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -531,17 +531,17 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Columnwise', ' ', 1, 1,
      $                          TAU( IIV ), 1 )
-                  TAULOC = DCONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
                ELSE
 *
                   CALL ZGEBR2D( ICTXT, 'Columnwise', ' ', 1, 1, TAULOC,
      $                          1, IVROW, MYCOL )
-                  TAULOC = DCONJG( TAULOC )
+                  TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -564,10 +564,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -582,18 +582,18 @@
                   WORK( IPW ) = TAU( JJV )
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = DCONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
                ELSE
 *
                   IPW = MPV+1
                   CALL ZGEBR2D( ICTXT, 'Rowwise', ROWBTOP, IPW, 1, WORK,
      $                          IPW, MYROW, IVCOL )
-                  TAULOC = DCONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C )' * v
 *
@@ -616,10 +616,10 @@
 *                 sub( C ) := sub( C ) - v * w'
 *
                   IF( MYROW.EQ.ICROW1 )
-     $               CALL ZAXPY( NQC2, -TAULOC, WORK( IPW ),
+     $               CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
      $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
-                  CALL ZGERC( MPV, NQC2, -TAULOC, WORK, 1, WORK( IPW ),
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
+     $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF
@@ -648,9 +648,9 @@
 *
                   IF( MYROW.EQ.ICROW2 ) THEN
 *
-                     TAULOC = DCONJG( TAU( IIV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -671,12 +671,12 @@
      $                               ICCOL2 )
 *
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL ZAXPY( MPC2, -TAULOC, WORK, 1,
+     $                     CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK, 1,
      $                                 C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL ZGERC( MPC2, NQV, -TAULOC, WORK, 1,
+                        CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK, 1,
      $                              V( IOFFV ), LDV, C( IOFFC2 ), LDC )
                      END IF
 *
@@ -699,9 +699,9 @@
                      IPW = NQV+1
                      CALL ZGERV2D( ICTXT, IPW, 1, WORK, IPW, IVROW,
      $                             MYCOL )
-                     TAULOC = DCONJG( WORK( IPW ) )
+                     TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
-                     IF( TAULOC.NE.ZERO ) THEN
+                     IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                       w := sub( C ) * v
 *
@@ -720,13 +720,14 @@
      $                                WORK( IPW ), MAX( 1, MPC2 ),
      $                                RDEST, ICCOL2 )
                         IF( MYCOL.EQ.ICCOL1 )
-     $                     CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
-     $                                 C( IOFFC1 ), 1 )
+     $                     CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ),
+     $                                 1, C( IOFFC1 ), 1 )
 *
 *                       sub( C ) := sub( C ) - w * v'
 *
-                        CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                              WORK, 1, C( IOFFC2 ), LDC )
+                        CALL ZGERC( MPC2, NQV, -TAULOC( 1 ),
+     $                              WORK( IPW ), 1, WORK, 1,
+     $                              C( IOFFC2 ), LDC )
                      END IF
 *
                   END IF
@@ -751,17 +752,17 @@
 *
                      CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1,
      $                             TAU( JJV ), 1 )
-                     TAULOC = DCONJG( TAU( JJV ) )
+                     TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
                   ELSE
 *
                      CALL ZGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC,
      $                             1, MYROW, IVCOL )
-                     TAULOC = DCONJG( TAULOC )
+                     TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                   END IF
 *
-                  IF( TAULOC.NE.ZERO ) THEN
+                  IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                    w := sub( C ) * v
 *
@@ -780,13 +781,13 @@
      $                             WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                             ICCOL2 )
                      IF( MYCOL.EQ.ICCOL1 )
-     $                  CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $                  CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                              C( IOFFC1 ), 1 )
 *
 *                    sub( C ) := sub( C ) - w * v'
 *
-                     CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1,
-     $                           WORK, 1, C( IOFFC2 ), LDC )
+                     CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ),
+     $                           1, WORK, 1, C( IOFFC2 ), LDC )
                   END IF
 *
                END IF
@@ -810,18 +811,18 @@
                   WORK( IPW ) = TAU( IIV )
                   CALL ZGEBS2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW )
-                  TAULOC = DCONJG( TAU( IIV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( IIV ) )
 *
                ELSE
 *
                   IPW = NQV+1
                   CALL ZGEBR2D( ICTXT, 'Columnwise', COLBTOP, IPW, 1,
      $                          WORK, IPW, IVROW, MYCOL )
-                  TAULOC = DCONJG( WORK( IPW ) )
+                  TAULOC( 1 ) = DCONJG( WORK( IPW ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -841,13 +842,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             ELSE
@@ -866,17 +867,17 @@
 *
                   CALL ZGEBS2D( ICTXT, 'Rowwise', ' ', 1, 1, TAU( JJV ),
      $                          1 )
-                  TAULOC = DCONJG( TAU( JJV ) )
+                  TAULOC( 1 ) = DCONJG( TAU( JJV ) )
 *
                ELSE
 *
                   CALL ZGEBR2D( ICTXT, 'Rowwise', ' ', 1, 1, TAULOC, 1,
      $                          MYROW, IVCOL )
-                  TAULOC = DCONJG( TAULOC )
+                  TAULOC( 1 ) = DCONJG( TAULOC( 1 ) )
 *
                END IF
 *
-               IF( TAULOC.NE.ZERO ) THEN
+               IF( TAULOC( 1 ).NE.ZERO ) THEN
 *
 *                 w := sub( C ) * v
 *
@@ -895,13 +896,13 @@
      $                          WORK( IPW ), MAX( 1, MPC2 ), RDEST,
      $                          ICCOL2 )
                   IF( MYCOL.EQ.ICCOL1 )
-     $               CALL ZAXPY( MPC2, -TAULOC, WORK( IPW ), 1,
+     $               CALL ZAXPY( MPC2, -TAULOC( 1 ), WORK( IPW ), 1,
      $                           C( IOFFC1 ), 1 )
 *
 *                 sub( C ) := sub( C ) - w * v'
 *
-                  CALL ZGERC( MPC2, NQV, -TAULOC, WORK( IPW ), 1, WORK,
-     $                        1, C( IOFFC2 ), LDC )
+                  CALL ZGERC( MPC2, NQV, -TAULOC( 1 ), WORK( IPW ), 1,
+     $                        WORK, 1, C( IOFFC2 ), LDC )
                END IF
 *
             END IF

--- a/SRC/pzlattrs.f
+++ b/SRC/pzlattrs.f
@@ -271,8 +271,9 @@
      $                   JINC, JLAST, LDA, LDX, MB, MYCOL, MYROW, NB,
      $                   NPCOL, NPROW, RSRC
       DOUBLE PRECISION   BIGNUM, GROW, REC, SMLNUM, TJJ, TMAX, TSCAL,
-     $                   XBND, XJ, XMAX
+     $                   XBND, XJ
       COMPLEX*16         CSUMJ, TJJS, USCAL, XJTMP, ZDUM
+      DOUBLE PRECISION   XMAX( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -391,11 +392,11 @@
 *     Compute a bound on the computed solution vector to see if the
 *     Level 2 PBLAS routine PZTRSV can be used.
 *
-      XMAX = ZERO
+      XMAX( 1 ) = ZERO
       CALL PZAMAX( N, ZDUM, IMAX, X, IX, JX, DESCX, 1 )
-      XMAX = CABS2( ZDUM )
+      XMAX( 1 ) = CABS2( ZDUM )
       CALL DGSUM2D( CONTXT, 'Row', ' ', 1, 1, XMAX, 1, -1, -1 )
-      XBND = XMAX
+      XBND = XMAX( 1 )
 *
       IF( NOTRAN ) THEN
 *
@@ -590,16 +591,16 @@
 *
 *        Use a Level 1 PBLAS solve, scaling intermediate results.
 *
-         IF( XMAX.GT.BIGNUM*HALF ) THEN
+         IF( XMAX( 1 ).GT.BIGNUM*HALF ) THEN
 *
 *           Scale X so that its components are less than or equal to
 *           BIGNUM in absolute value.
 *
-            SCALE = ( BIGNUM*HALF ) / XMAX
+            SCALE = ( BIGNUM*HALF ) / XMAX( 1 )
             CALL PZDSCAL( N, SCALE, X, IX, JX, DESCX, 1 )
-            XMAX = BIGNUM
+            XMAX( 1 ) = BIGNUM
          ELSE
-            XMAX = XMAX*TWO
+            XMAX( 1 ) = XMAX( 1 )*TWO
          END IF
 *
          IF( NOTRAN ) THEN
@@ -651,7 +652,7 @@
                         CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                         XJTMP = XJTMP*REC
                         SCALE = SCALE*REC
-                        XMAX = XMAX*REC
+                        XMAX( 1 ) = XMAX( 1 )*REC
                      END IF
                   END IF
 *                 X( J ) = ZLADIV( X( J ), TJJS )
@@ -682,7 +683,7 @@
                      CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
-                     XMAX = XMAX*REC
+                     XMAX( 1 ) = XMAX( 1 )*REC
                   END IF
 *                 X( J ) = ZLADIV( X( J ), TJJS )
 *                 XJ = CABS1( X( J ) )
@@ -706,7 +707,7 @@
                   XJTMP = CONE
                   XJ = ONE
                   SCALE = ZERO
-                  XMAX = ZERO
+                  XMAX( 1 ) = ZERO
                END IF
    90          CONTINUE
 *
@@ -715,7 +716,7 @@
 *
                IF( XJ.GT.ONE ) THEN
                   REC = ONE / XJ
-                  IF( CNORM( J ).GT.( BIGNUM-XMAX )*REC ) THEN
+                  IF( CNORM( J ).GT.( BIGNUM-XMAX( 1 ) )*REC ) THEN
 *
 *                    Scale x by 1/(2*abs(x(j))).
 *
@@ -724,7 +725,7 @@
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
                   END IF
-               ELSE IF( XJ*CNORM( J ).GT.( BIGNUM-XMAX ) ) THEN
+               ELSE IF( XJ*CNORM( J ).GT.( BIGNUM-XMAX( 1 ) ) ) THEN
 *
 *                 Scale x by 1/2.
 *
@@ -743,7 +744,7 @@
                      CALL PZAXPY( J-1, ZDUM, A, IA, JA+J-1, DESCA, 1, X,
      $                            IX, JX, DESCX, 1 )
                      CALL PZAMAX( J-1, ZDUM, IMAX, X, IX, JX, DESCX, 1 )
-                     XMAX = CABS1( ZDUM )
+                     XMAX( 1 ) = CABS1( ZDUM )
                      CALL DGSUM2D( CONTXT, 'Row', ' ', 1, 1, XMAX, 1,
      $                             -1, -1 )
                   END IF
@@ -757,7 +758,7 @@
                      CALL PZAXPY( N-J, ZDUM, A, IA+J, JA+J-1, DESCA, 1,
      $                            X, IX+J, JX, DESCX, 1 )
                      CALL PZAMAX( N-J, ZDUM, I, X, IX+J, JX, DESCX, 1 )
-                     XMAX = CABS1( ZDUM )
+                     XMAX( 1 ) = CABS1( ZDUM )
                      CALL DGSUM2D( CONTXT, 'Row', ' ', 1, 1, XMAX, 1,
      $                             -1, -1 )
                   END IF
@@ -785,7 +786,7 @@
                END IF
                XJ = CABS1( XJTMP )
                USCAL = DCMPLX( TSCAL )
-               REC = ONE / MAX( XMAX, ONE )
+               REC = ONE / MAX( XMAX( 1 ), ONE )
                IF( CNORM( J ).GT.( BIGNUM-XJ )*REC ) THEN
 *
 *                 If x(j) could overflow, scale x by 1/(2*XMAX).
@@ -820,7 +821,7 @@
                      CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
-                     XMAX = XMAX*REC
+                     XMAX( 1 ) = XMAX( 1 )*REC
                   END IF
                END IF
 *
@@ -924,7 +925,7 @@
                            CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                            XJTMP = XJTMP*REC
                            SCALE = SCALE*REC
-                           XMAX = XMAX*REC
+                           XMAX( 1 ) = XMAX( 1 )*REC
                         END IF
                      END IF
 *                    X( J ) = ZLADIV( X( J ), TJJS )
@@ -945,7 +946,7 @@
                         CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                         XJTMP = XJTMP*REC
                         SCALE = SCALE*REC
-                        XMAX = XMAX*REC
+                        XMAX( 1 ) = XMAX( 1 )*REC
                      END IF
 *                    X( J ) = ZLADIV( X( J ), TJJS )
                      XJTMP = ZLADIV( XJTMP, TJJS )
@@ -966,7 +967,7 @@
                      END IF
                      XJTMP = CONE
                      SCALE = ZERO
-                     XMAX = ZERO
+                     XMAX( 1 ) = ZERO
                   END IF
   110             CONTINUE
                ELSE
@@ -981,7 +982,7 @@
                      X( IROWX ) = XJTMP
                   END IF
                END IF
-               XMAX = MAX( XMAX, CABS1( XJTMP ) )
+               XMAX( 1 ) = MAX( XMAX( 1 ), CABS1( XJTMP ) )
   120       CONTINUE
 *
          ELSE
@@ -1004,7 +1005,7 @@
                END IF
                XJ = CABS1( XJTMP )
                USCAL = TSCAL
-               REC = ONE / MAX( XMAX, ONE )
+               REC = ONE / MAX( XMAX( 1 ), ONE )
                IF( CNORM( J ).GT.( BIGNUM-XJ )*REC ) THEN
 *
 *                 If x(j) could overflow, scale x by 1/(2*XMAX).
@@ -1039,7 +1040,7 @@
                      CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                      XJTMP = XJTMP*REC
                      SCALE = SCALE*REC
-                     XMAX = XMAX*REC
+                     XMAX( 1 ) = XMAX( 1 )*REC
                   END IF
                END IF
 *
@@ -1145,7 +1146,7 @@
                            CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                            XJTMP = XJTMP*REC
                            SCALE = SCALE*REC
-                           XMAX = XMAX*REC
+                           XMAX( 1 ) = XMAX( 1 )*REC
                         END IF
                      END IF
 *                    X( J ) = ZLADIV( X( J ), TJJS )
@@ -1164,7 +1165,7 @@
                         CALL PZDSCAL( N, REC, X, IX, JX, DESCX, 1 )
                         XJTMP = XJTMP*REC
                         SCALE = SCALE*REC
-                        XMAX = XMAX*REC
+                        XMAX( 1 ) = XMAX( 1 )*REC
                      END IF
 *                    X( J ) = ZLADIV( X( J ), TJJS )
                      XJTMP = ZLADIV( XJTMP, TJJS )
@@ -1181,7 +1182,7 @@
      $                  X( IROWX ) = CONE
                      XJTMP = CONE
                      SCALE = ZERO
-                     XMAX = ZERO
+                     XMAX( 1 ) = ZERO
                   END IF
   130             CONTINUE
                ELSE
@@ -1194,7 +1195,7 @@
                   IF( ( MYROW.EQ.ITMP1X ) .AND. ( MYCOL.EQ.ITMP2X ) )
      $               X( IROWX ) = XJTMP
                END IF
-               XMAX = MAX( XMAX, CABS1( XJTMP ) )
+               XMAX( 1 ) = MAX( XMAX( 1 ), CABS1( XJTMP ) )
   140       CONTINUE
          END IF
          SCALE = SCALE / TSCAL

--- a/SRC/pzlawil.f
+++ b/SRC/pzlawil.f
@@ -124,11 +124,10 @@
      $                   MODKM1, MYCOL, MYROW, NPCOL, NPROW, NUM, RIGHT,
      $                   RSRC, UP
       DOUBLE PRECISION   S
-      COMPLEX*16         CDUM, H11, H12, H21, H22, H33S, H44S, V1, V2,
-     $                   V3
+      COMPLEX*16         CDUM, H22, H33S, H44S, V1, V2
 *     ..
 *     .. Local Arrays ..
-      COMPLEX*16         BUF( 4 )
+      COMPLEX*16         BUF( 4 ), H11( 1 ), H12( 1 ), H21( 1 ), V3( 1 )
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           BLACS_GRIDINFO, INFOG2L, ZGERV2D, ZGESD2D
@@ -181,18 +180,18 @@
             IF( NPCOL.GT.1 ) THEN
                CALL ZGERV2D( CONTXT, 1, 1, V3, 1, MYROW, LEFT )
             ELSE
-               V3 = A( ( ICOL-2 )*LDA+IROW )
+               V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
             END IF
             IF( NUM.GT.1 ) THEN
                CALL ZGERV2D( CONTXT, 4, 1, BUF, 4, UP, LEFT )
-               H11 = BUF( 1 )
-               H21 = BUF( 2 )
-               H12 = BUF( 3 )
+               H11( 1 ) = BUF( 1 )
+               H21( 1 ) = BUF( 2 )
+               H12( 1 ) = BUF( 3 )
                H22 = BUF( 4 )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
                H22 = A( ( ICOL-2 )*LDA+IROW-1 )
             END IF
          END IF
@@ -225,20 +224,20 @@
             IF( NUM.GT.1 ) THEN
                CALL ZGERV2D( CONTXT, 1, 1, H11, 1, UP, LEFT )
             ELSE
-               H11 = A( ( ICOL-3 )*LDA+IROW-2 )
+               H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
             END IF
             IF( NPROW.GT.1 ) THEN
                CALL ZGERV2D( CONTXT, 1, 1, H12, 1, UP, MYCOL )
             ELSE
-               H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+               H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
             END IF
             IF( NPCOL.GT.1 ) THEN
                CALL ZGERV2D( CONTXT, 1, 1, H21, 1, MYROW, LEFT )
             ELSE
-               H21 = A( ( ICOL-3 )*LDA+IROW-1 )
+               H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
             END IF
             H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-            V3 = A( ( ICOL-2 )*LDA+IROW )
+            V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
          END IF
       END IF
       IF( ( MYROW.NE.II ) .OR. ( MYCOL.NE.JJ ) )
@@ -247,24 +246,24 @@
       IF( MODKM1.GT.1 ) THEN
          CALL INFOG2L( M+2, M+2, DESCA, NPROW, NPCOL, MYROW, MYCOL,
      $                 IROW, ICOL, RSRC, JSRC )
-         H11 = A( ( ICOL-3 )*LDA+IROW-2 )
-         H21 = A( ( ICOL-3 )*LDA+IROW-1 )
-         H12 = A( ( ICOL-2 )*LDA+IROW-2 )
+         H11( 1 ) = A( ( ICOL-3 )*LDA+IROW-2 )
+         H21( 1 ) = A( ( ICOL-3 )*LDA+IROW-1 )
+         H12( 1 ) = A( ( ICOL-2 )*LDA+IROW-2 )
          H22 = A( ( ICOL-2 )*LDA+IROW-1 )
-         V3 = A( ( ICOL-2 )*LDA+IROW )
+         V3( 1 ) = A( ( ICOL-2 )*LDA+IROW )
       END IF
 *
-      H44S = H44 - H11
-      H33S = H33 - H11
-      V1 = ( H33S*H44S-H43H34 ) / H21 + H12
-      V2 = H22 - H11 - H33S - H44S
-      S = CABS1( V1 ) + CABS1( V2 ) + CABS1( V3 )
+      H44S = H44 - H11( 1 )
+      H33S = H33 - H11( 1 )
+      V1 = ( H33S*H44S-H43H34 ) / H21( 1 ) + H12( 1 )
+      V2 = H22 - H11( 1 ) - H33S - H44S
+      S = CABS1( V1 ) + CABS1( V2 ) + CABS1( V3( 1 ) )
       V1 = V1 / S
       V2 = V2 / S
-      V3 = V3 / S
+      V3( 1 ) = V3( 1 ) / S
       V( 1 ) = V1
       V( 2 ) = V2
-      V( 3 ) = V3
+      V( 3 ) = V3( 1 )
 *
       RETURN
 *

--- a/SRC/pztrevc.f
+++ b/SRC/pztrevc.f
@@ -218,11 +218,12 @@
      $                   ITMP2, J, K, KI, LDT, LDVL, LDVR, LDW, MB,
      $                   MYCOL, MYROW, NB, NPCOL, NPROW, RSRC
       REAL               SELF
-      DOUBLE PRECISION   OVFL, REMAXD, SCALE, SMIN, SMLNUM, ULP, UNFL
+      DOUBLE PRECISION   OVFL, REMAXD, SCALE, SMLNUM, ULP, UNFL
       COMPLEX*16         CDUM, REMAXC, SHIFT
 *     ..
 *     .. Local Arrays ..
       INTEGER            DESCW( DLEN_ )
+      DOUBLE PRECISION   SMIN( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -355,13 +356,13 @@
      $            GO TO 70
             END IF
 *
-            SMIN = ZERO
+            SMIN( 1 ) = ZERO
             SHIFT = CZERO
             CALL INFOG2L( KI, KI, DESCT, NPROW, NPCOL, MYROW, MYCOL,
      $                    IROW, ICOL, ITMP1, ITMP2 )
             IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                SHIFT = T( ( ICOL-1 )*LDT+IROW )
-               SMIN = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
+               SMIN( 1 ) = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
             END IF
             CALL DGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SMIN, 1, -1, -1 )
             CALL ZGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SHIFT, 1, -1, -1 )
@@ -396,8 +397,9 @@
                IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                   T( ( ICOL-1 )*LDT+IROW ) = T( ( ICOL-1 )*LDT+IROW ) -
      $               SHIFT
-                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN ) THEN
-                     T( ( ICOL-1 )*LDT+IROW ) = DCMPLX( SMIN )
+                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN( 1 ) )
+     $            THEN
+                     T( ( ICOL-1 )*LDT+IROW ) = DCMPLX( SMIN( 1 ) )
                   END IF
                END IF
    50       CONTINUE
@@ -467,13 +469,13 @@
      $            GO TO 110
             END IF
 *
-            SMIN = ZERO
+            SMIN( 1 ) = ZERO
             SHIFT = CZERO
             CALL INFOG2L( KI, KI, DESCT, NPROW, NPCOL, MYROW, MYCOL,
      $                    IROW, ICOL, ITMP1, ITMP2 )
             IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                SHIFT = T( ( ICOL-1 )*LDT+IROW )
-               SMIN = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
+               SMIN( 1 ) = MAX( ULP*( CABS1( SHIFT ) ), SMLNUM )
             END IF
             CALL DGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SMIN, 1, -1, -1 )
             CALL ZGSUM2D( CONTXT, 'ALL', ' ', 1, 1, SHIFT, 1, -1, -1 )
@@ -507,8 +509,8 @@
                IF( ( MYROW.EQ.ITMP1 ) .AND. ( MYCOL.EQ.ITMP2 ) ) THEN
                   T( ( ICOL-1 )*LDT+IROW ) = T( ( ICOL-1 )*LDT+IROW ) -
      $               SHIFT
-                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN )
-     $               T( ( ICOL-1 )*LDT+IROW ) = DCMPLX( SMIN )
+                  IF( CABS1( T( ( ICOL-1 )*LDT+IROW ) ).LT.SMIN( 1 ) )
+     $               T( ( ICOL-1 )*LDT+IROW ) = DCMPLX( SMIN( 1 ) )
                END IF
    90       CONTINUE
 *

--- a/TESTING/EIG/CMakeLists.txt
+++ b/TESTING/EIG/CMakeLists.txt
@@ -97,3 +97,6 @@ target_link_libraries(xzheevr scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 target_link_libraries(xshseqr scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 target_link_libraries(xdhseqr scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy" )  # local to this directory
+endif()

--- a/TESTING/LIN/CMakeLists.txt
+++ b/TESTING/LIN/CMakeLists.txt
@@ -110,3 +110,7 @@ target_link_libraries(xsls scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 target_link_libraries(xdls scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 target_link_libraries(xcls scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 target_link_libraries(xzls scalapack ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy" )  # local to this directory
+endif()


### PR DESCRIPTION
While the original pattern starts to break with GCC 10+, it wasn't portable for a long time already.
Instead of setting `-fallow-argument-mismatch` for the whole project as in #23 I only set `-std=legacy` for the tests while the files in `SRC/` are properly fixed.

(sorry for the spam, used the wrong branch from my repo)