### PR TITLE
New option: SCALAPACK_BUILD_TESTS

### DIFF
--- a/BLACS/CMakeLists.txt
+++ b/BLACS/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(SRC)
-if(BUILD_TESTING)
+if(${SCALAPACK_BUILD_TESTING})
   add_subdirectory(TESTING)
-endif(BUILD_TESTING)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(SCALAPACK C Fortran)
 # Configure the warning and code coverage suppression file
-configure_file( 
+configure_file(
   "${SCALAPACK_SOURCE_DIR}/CMAKE/CTestCustom.cmake.in"
   "${SCALAPACK_BINARY_DIR}/CTestCustom.cmake"
   COPYONLY
@@ -48,8 +48,8 @@ if (MPI_FOUND)
       PATH_SUFFIXES bin
       DOC "MPI Fortran compiler.")
    MARK_AS_ADVANCED(MPI_Fortran_COMPILER)
-   
-   
+
+
 
    if ("${MPI_Fortran_COMPILER}" STREQUAL "MPI_Fortran_COMPILER-NOTFOUND")
       message(ERROR "--> MPI Fortran Compiler NOT FOUND (please set MPI_BASE_DIR accordingly")
@@ -59,7 +59,7 @@ if (MPI_FOUND)
       SET(CMAKE_Fortran_COMPILER "${MPI_Fortran_COMPILER}")
       message(STATUS "--> Fortran Compiler : ${CMAKE_Fortran_COMPILER}")
    endif()
-   
+
 else()
    message(STATUS "Found MPI_LIBRARY : ${MPI_FOUND} ")
    set(MPI_BASE_DIR ${MPI_BASE_DIR} CACHE PATH "MPI Path")
@@ -184,7 +184,7 @@ OPTION(BUILD_STATIC_LIBS "Build static libraries" ON )
 
 # --------------------------------------------------
 # Subdirectories that need to be processed
-   
+
 macro(append_subdir_files variable dirname)
 get_directory_property(holder DIRECTORY ${dirname} DEFINITION ${variable})
 foreach(depfile ${holder})
@@ -250,7 +250,7 @@ if(${SCALAPACK_BUILD_TESTS})
 endif()
 
 # --------------------------------------------------
-# CPACK Packaging 
+# CPACK Packaging
 
 SET(CPACK_PACKAGE_NAME "ScaLAPACK")
 SET(CPACK_PACKAGE_VENDOR "University of Tennessee, Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,11 @@ else (UNIX) # Need to separate Fortran and C Code
    scalapack_install_library(scalapack)
    scalapack_install_library(scalapack-F)
 endif (UNIX)
-add_subdirectory(TESTING)
+
+option(SCALAPACK_BUILD_TESTS "Build all tests of the ScaLAPACK library" ON)
+if(${SCALAPACK_BUILD_TESTS})
+  add_subdirectory(TESTING)
+endif()
 
 # --------------------------------------------------
 # CPACK Packaging 

--- a/PBLAS/CMakeLists.txt
+++ b/PBLAS/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(SRC)
-add_subdirectory(TESTING)
-add_subdirectory(TIMING)
+if(${SCALAPACK_BUILD_TESTING})
+  add_subdirectory(TESTING)
+  add_subdirectory(TIMING)
+endif()

--- a/REDIST/CMakeLists.txt
+++ b/REDIST/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(SRC)
-add_subdirectory(TESTING)
+if(${SCALAPACK_BUILD_TESTING})
+  add_subdirectory(TESTING)
+endif()


### PR DESCRIPTION
## Allow users to choose whether they want to build tests or not.

See #29  for some initial discussion.
By default, tests are build as was the case before this PR.
By using `cmake -DSCALAPACK_BUILD_TESTS=OFF`, users can turn off building tests and save on build time.
The same was possible by specifying a target (`make scalapack`), but giving a cmake option is good practice I believe.

Note that PBLAS/TIMING is also considered a "test" and is thus not build when `SCALAPACK_BUILD_TESTS` is turned off by the user.

## Miscellaneous 
I also deleted some spaces at the end of several lines (automatically, many editors like vim do this).