### PR TITLE
Fix info distribution in P?TRORD and PSTRSEN

### DIFF
--- a/SRC/pdtrord.f
+++ b/SRC/pdtrord.f
@@ -334,7 +334,7 @@
 *     ..
 *     .. Local Arrays ..
       INTEGER            IBUFF( 8 ), IDUM1( 1 ), IDUM2( 1 ), MMAX( 1 ),
-     $                   MMIN( 1 ), INFODUM( 1 )
+     $                   MMIN( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -522,9 +522,8 @@
 *     Global maximum on info.
 *
       IF( NPROCS.GT.1 ) THEN
-         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1, -1, -1,
+         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1, -1, -1,
      $        -1, -1 )
-         INFO = INFODUM( 1 )
       END IF
 *
 *     Return if some argument is incorrect.
@@ -1580,9 +1579,8 @@
 *
          MYIERR = IERR
          IF( NPROCS.GT.1 ) THEN
-            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
      $           -1, -1, -1, -1 )
-            IERR = INFODUM( 1 )
          END IF
 *
          IF( IERR.NE.0 ) THEN
@@ -1592,9 +1590,8 @@
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
             IF( NPROCS.GT.1 ) THEN
-               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
      $              -1, -1, -1, -1 )
-               INFO = INFODUM( 1 )
             END IF
             GO TO 300
          END IF
@@ -3253,9 +3250,8 @@
 *
          MYIERR = IERR
          IF( NPROCS.GT.1 ) THEN
-            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
      $           -1, -1, -1, -1 )
-            IERR = INFODUM( 1 )
          END IF
 *
          IF( IERR.NE.0 ) THEN
@@ -3265,9 +3261,8 @@
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
             IF( NPROCS.GT.1 ) THEN
-               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
      $              -1, -1, -1, -1 )
-               IERR = INFODUM( 1 )
             END IF
             GO TO 300
          END IF

--- a/SRC/pstrord.f
+++ b/SRC/pstrord.f
@@ -334,7 +334,7 @@
 *     ..
 *     .. Local Arrays ..
       INTEGER            IBUFF( 8 ), IDUM1( 1 ), IDUM2( 1 ), MMAX( 1 ),
-     $                    MMIN( 1 ), INFODUM( 1 )
+     $                    MMIN( 1 )
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
@@ -522,9 +522,8 @@
 *     Global maximum on info.
 *
       IF( NPROCS.GT.1 ) THEN
-            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1, -1,
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1, -1,
      $        -1, -1, -1 )
-            INFO = INFODUM( 1 )
       END IF
 *
 *     Return if some argument is incorrect.
@@ -1580,9 +1579,8 @@
 *
          MYIERR = IERR
          IF( NPROCS.GT.1 ) THEN
-            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
      $           -1, -1, -1, -1 )
-            IERR = INFODUM( 1 )
          END IF
 *
          IF( IERR.NE.0 ) THEN
@@ -1592,9 +1590,8 @@
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
             IF( NPROCS.GT.1 ) THEN
-               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
      $              -1, -1, -1, -1 )
-               INFO = INFODUM( 1 )
             END IF
             GO TO 300
          END IF
@@ -3253,9 +3250,8 @@
 *
          MYIERR = IERR
          IF( NPROCS.GT.1 ) THEN
-            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+            CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, IERR, 1, -1,
      $           -1, -1, -1, -1 )
-            IERR = INFODUM( 1 )
          END IF
 *
          IF( IERR.NE.0 ) THEN
@@ -3265,9 +3261,8 @@
 *
             IF( MYIERR.NE.0 ) INFO = MAX(1,I+KKS-1)
             IF( NPROCS.GT.1 ) THEN
-               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1,
+               CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1,
      $              -1, -1, -1, -1 )
-               INFO = INFODUM( 1 )
             END IF
             GO TO 300
          END IF

--- a/SRC/pstrsen.f
+++ b/SRC/pstrsen.f
@@ -361,7 +361,7 @@
       REAL               ELEM, EST, SCALE, RNORM
 *     .. Local Arrays ..
       INTEGER            DESCT12( DLEN_ ), MBNB2( 2 ), MMAX( 1 ),
-     $                   MMIN( 1 ), INFODUM( 1 )
+     $                   MMIN( 1 )
       REAL               DPDUM1( 1 )
 *     ..
 *     .. External Functions ..
@@ -605,9 +605,8 @@ c     $              IERR )
 *     Global maximum on info
 *
       IF( NPROCS.GT.1 ) THEN
-         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFODUM, 1, -1, -1, -1,
+         CALL IGAMX2D( ICTXT, 'All', TOP, 1, 1, INFO, 1, -1, -1, -1,
      $          -1, -1 )
-         INFO = INFODUM( 1 )
       END IF
 *
 *     Return if some argument is incorrect


### PR DESCRIPTION
See #32 for details

Before this fix I had a lot of error messages about illegal value in P?TRORD in x?hseqr tests on some systems. 
```
{    1,    0}:  On entry to PDTRORD parameter number **** had an illegal value
{    0,    0}:  On entry to PDTRORD parameter number **** had an illegal value
{    1,    1}:  On entry to PDTRORD parameter number **** had an illegal value
{    0,    1}:  On entry to PDTRORD parameter number **** had an illegal value
``` 
And interesting detail is that xdhseqr test prints such messages and then finishes with PASSED check, but xshseqr test prints messages endlessly and never finishes.

After this fix these messages are gone and x?hseqr tests works normally on all systems. 

Also I found same error in PSTRSEN and fixed it.