### PR TITLE
enh: no memory leaks for blacs_exit and allow re-call

### DIFF
--- a/BLACS/SRC/blacs_exit_.c
+++ b/BLACS/SRC/blacs_exit_.c
@@ -12,6 +12,7 @@ F_VOID_FUNC blacs_exit_(Int *NotDone)
    Int BI_BuffIsFree(BLACBUFF *, Int);
    BLACBUFF *bp;
    extern BLACBUFF *BI_ReadyB, *BI_ActiveQ, BI_AuxBuff;
+   extern MPI_Status *BI_Stats;
    Int i;
    extern Int BI_MaxNCtxt, BI_Np;
    extern BLACSCONTEXT **BI_MyContxts;
@@ -30,6 +31,7 @@ F_VOID_FUNC blacs_exit_(Int *NotDone)
       free(bp);
    }
    free (BI_AuxBuff.Aops);
+   free (BI_Stats);
 
 /*
  * Reset parameters to initial values
@@ -39,7 +41,12 @@ F_VOID_FUNC blacs_exit_(Int *NotDone)
    BI_Np = -1;
    if (!Mpval(NotDone))
    {
-      MPI_Finalize();
+     free(BI_COMM_WORLD);
+     BI_COMM_WORLD = NULL;
+     MPI_Finalize();
    }
    BI_ReadyB = NULL;
+   BI_ActiveQ = NULL;
+   BI_AuxBuff.Aops = NULL;
+   BI_Stats = NULL;
 }

--- a/BLACS/SRC/blacs_pinfo_.c
+++ b/BLACS/SRC/blacs_pinfo_.c
@@ -20,9 +20,9 @@ F_VOID_FUNC blacs_pinfo_(Int *mypnum, Int *nprocs)
 
       BI_COMM_WORLD = (Int *) malloc(sizeof(Int));
       *BI_COMM_WORLD = MPI_Comm_c2f(MPI_COMM_WORLD);
-      MPI_Comm_size(MPI_COMM_WORLD, &Np);
-      MPI_Comm_rank(MPI_COMM_WORLD, &Iam);
    }
+   MPI_Comm_size(MPI_COMM_WORLD, &Np);
+   MPI_Comm_rank(MPI_COMM_WORLD, &Iam);
    *mypnum = BI_Iam = Iam;
    *nprocs = BI_Np  = Np;
 }


### PR DESCRIPTION
This should enable ScaLAPACK/BLACS to be exited and restarted
at will without memory leaks or problems.

When called with blacs_exit(true), the comm_world will be
retained and MPI_Finalized won't be called.
Only when blacs_exit(false) is called will the BI_COMM_WORLD
be de-allocated. So one should expect a memory leak of
an integer if the hosting application calls MPI_Finalize.

For instance the `blacs_exit` test example can now be extended to this:
```fortran
      PROGRAM HELLO
*     -- BLACS example code --
*     Written by Clint Whaley 7/26/94
*     Performs a simple check-in type hello world
*     ..
*     .. External Functions ..
      INTEGER BLACS_PNUM
      EXTERNAL BLACS_PNUM
*     ..
*     .. Variable Declaration ..
      INTEGER CONTXT, IAM, NPROCS, NPROW, NPCOL, MYPROW, MYPCOL
      INTEGER ICALLER, I, J, HISROW, HISCOL

      INTEGER :: loop
*
*     Determine my process number and the number of processes in
*     machine
*
      do loop = 1, 3
        CALL BLACS_PINFO(IAM, NPROCS)
        print * , '1: iam ', iam, ' nprocs ', nprocs
*
*     If in PVM, create virtual machine if it doesn't exist
*
      IF (NPROCS .LT. 1) THEN
	 IF (IAM .EQ. 0) THEN
	    WRITE(*, 1000)
	    READ(*, 2000) NPROCS
         END IF
         CALL BLACS_SETUP(IAM, NPROCS)
      END IF
        print * , '2: iam ', iam, ' nprocs ', nprocs
*
*     Set up process grid that is as close to square as possible
*     Set up process grid that is as close to square as possible
*
      NPROW = INT( SQRT( REAL(NPROCS) ) )
      NPCOL = NPROCS / NPROW
*
*     Get default system context, and define grid
*
      CALL BLACS_GET(0, 0, CONTXT)
      CALL BLACS_GRIDINIT(CONTXT, 'Row', NPROW, NPCOL)
      CALL BLACS_GRIDINFO(CONTXT, NPROW, NPCOL, MYPROW, MYPCOL)
*
*     If I'm not in grid, go to end of program
*
      IF ( (MYPROW.GE.NPROW) .OR. (MYPCOL.GE.NPCOL) ) GOTO 30
*
*     Get my process ID from my grid coordinates
*
      ICALLER = BLACS_PNUM(CONTXT, MYPROW, MYPCOL)
*
*     If I am process {0,0}, receive check-in messages from
*     all nodes
*
      IF ( (MYPROW.EQ.0) .AND. (MYPCOL.EQ.0) ) THEN

         WRITE(*,*) ' '
         DO 20 I = 0, NPROW-1
	    DO 10 J = 0, NPCOL-1

	       IF ( (I.NE.0) .OR. (J.NE.0) ) THEN
		  CALL IGERV2D(CONTXT, 1, 1, ICALLER, 1, I, J) 
               ENDIF
*
*              Make sure ICALLER is where we think in process grid
*
               CALL BLACS_PCOORD(CONTXT, ICALLER, HISROW, HISCOL)
               IF ( (HISROW.NE.I) .OR. (HISCOL.NE.J) ) THEN
                  WRITE(*,*) 'Grid error!  Halting . . .'
                  STOP
               END IF
	       WRITE(*, 3000) I, J, ICALLER

10          CONTINUE
20       CONTINUE
         WRITE(*,*) ' '
         WRITE(*,*) 'All processes checked in.  Run finished.'
*
*     All processes but {0,0} send process ID as a check-in
*
      ELSE
	 CALL IGESD2D(CONTXT, 1, 1, ICALLER, 1, 0, 0)
      END IF

30    CONTINUE

      if ( loop == 3 ) then
        CALL BLACS_EXIT(.false.)
      else
        CALL BLACS_EXIT(.true.)
      end if
      end do

1000  FORMAT('How many processes in machine?')
2000  FORMAT(i4)
3000  FORMAT('Process {',i2,',',i2,'} (node number =',I0,
     $       ') has checked in.')

      STOP
      END
```