### PR TITLE
refactor: replace obsolescent K&R syntax

### DIFF
--- a/BLACS/TESTING/Cbt.c
+++ b/BLACS/TESTING/Cbt.c
@@ -1,970 +1,426 @@
 #ifdef BTCINTFACE
 #include "Cbt.h"
 
-void blacs_gridinit_(ConTxt, order, nprow, npcol)
-Int *ConTxt;
-char *order;
-Int *nprow;
-Int  *npcol;
+void blacs_gridinit_(Int *ConTxt, char *order, Int *nprow, Int *npcol)
 {
    void Cblacs_gridinit();
 
    Cblacs_gridinit(ConTxt, order, *nprow, *npcol);
 }
 
-void blacs_setup_(mypnum, nprocs)
-Int *mypnum;
-Int  *nprocs;
+void blacs_setup_(Int *mypnum, Int *nprocs)
 {
    void Cblacs_setup();
    Cblacs_setup(mypnum, nprocs);
 }
 
-void blacs_pinfo_(mypnum, nprocs)
-Int *mypnum;
-Int  *nprocs;
+void blacs_pinfo_(Int *mypnum, Int *nprocs)
 {
    void Cblacs_pinfo();
    Cblacs_pinfo(mypnum, nprocs);
 }
 
-void blacs_gridmap_(ConTxt, usermap, ldup, nprow, npcol)
-Int *ConTxt;
-Int *usermap;
-Int *ldup;
-Int *nprow;
-Int  *npcol;
+void blacs_gridmap_(Int *ConTxt, Int *usermap, Int *ldup, Int *nprow, Int *npcol)
 {
    void Cblacs_gridmap();
    Cblacs_gridmap(ConTxt, usermap, *ldup, *nprow, *npcol);
 }
 
-void blacs_gridexit_(ConTxt)
-Int  *ConTxt;
+void blacs_gridexit_(Int *ConTxt)
 {
    void Cblacs_gridexit();
    Cblacs_gridexit(*ConTxt);
 }
 
-void blacs_abort_(ConTxt, ErrNo)
-Int *ConTxt;
-Int  *ErrNo;
+void blacs_abort_(Int *ConTxt, Int *ErrNo)
 {
    void Cblacs_abort();
    Cblacs_abort(*ConTxt, *ErrNo);
 }
 
-void blacs_exit_(NotDone)
-Int  *NotDone;
+void blacs_exit_(Int *NotDone)
 {
    void Cblacs_exit();
    Cblacs_exit(*NotDone);
 }
 
-void blacs_freebuff_(ConTxt, Wait)
-Int *ConTxt;
-Int  *Wait;
+void blacs_freebuff_(Int *ConTxt, Int *Wait)
 {
    void Cblacs_freebuff();
    Cblacs_freebuff(*ConTxt, *Wait);
 }
 
-void blacs_gridinfo_(ConTxt, nprow, npcol, myrow, mycol)
-Int *ConTxt;
-Int *nprow;
-Int *npcol;
-Int *myrow;
-Int  *mycol;
+void blacs_gridinfo_(Int *ConTxt, Int *nprow, Int *npcol, Int *myrow, Int *mycol)
 {
    void Cblacs_gridinfo();
    Cblacs_gridinfo(*ConTxt, nprow, npcol, myrow, mycol);
 }
 
-void blacs_barrier_(ConTxt, scope)
-Int *ConTxt;
-char  *scope;
+void blacs_barrier_(Int *ConTxt, char *scope)
 {
    void Cblacs_barrier();
    Cblacs_barrier(*ConTxt, scope);
 }
 
-Int blacs_pnum_(ConTxt, prow, pcol)
-Int *ConTxt;
-Int *prow;
-Int  *pcol;
+Int blacs_pnum_(Int *ConTxt, Int *prow, Int *pcol)
 {
    Int Cblacs_pnum();
    return( Cblacs_pnum(*ConTxt, *prow, *pcol) );
 }
 
-void blacs_pcoord_(ConTxt, nodenum, prow, pcol)
-Int *ConTxt;
-Int *nodenum;
-Int *prow;
-Int  *pcol;
+void blacs_pcoord_(Int *ConTxt, Int *nodenum, Int *prow, Int *pcol)
 {
    void Cblacs_pcoord();
    Cblacs_pcoord(*ConTxt, *nodenum, prow, pcol);
 }
 
-void blacs_get_(ConTxt, what, I)
-Int *ConTxt;
-Int *what;
-Int  *I;
+void blacs_get_(Int *ConTxt, Int *what, Int *I)
 {
    void Cblacs_get();
    Cblacs_get(*ConTxt, *what, I);
 }
 
-void blacs_set_(ConTxt, what, I)
-Int *ConTxt;
-Int *what;
-Int  *I;
+void blacs_set_(Int *ConTxt, Int *what, Int *I)
 {
    void Cblacs_set();
    Cblacs_set(*ConTxt, *what, I);
 }
 
 
-void igesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void igesd2d_(Int *ConTxt, Int *m, Int *n, Int *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cigesd2d();
    Cigesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void igerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void igerv2d_(Int *ConTxt, Int *m, Int *n, Int *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cigerv2d();
    Cigerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void igebs2d_(ConTxt, scope, top, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-Int *A;
-Int  *lda;
+void igebs2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, Int *A, Int *lda)
 {
    void Cigebs2d();
    Cigebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
-void igebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void igebr2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, Int *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cigebr2d();
    Cigebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void itrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void itrsd2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, Int *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Citrsd2d();
    Citrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void itrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void itrrv2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, Int *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Citrrv2d();
    Citrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void itrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-Int *A;
-Int  *lda;
+void itrbs2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, Int *A, Int *lda)
 {
    void Citrbs2d();
    Citrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
-void itrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void itrbr2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, Int *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Citrbr2d();
    Citrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void igsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void igsum2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, Int *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cigsum2d();
    Cigsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void igamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void igamx2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, Int *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Cigamx2d();
    Cigamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void igamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-Int *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void igamn2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, Int *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Cigamn2d();
    Cigamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void dgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void dgesd2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cdgesd2d();
    Cdgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void dgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void dgerv2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cdgerv2d();
    Cdgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void dgebs2d_(ConTxt, scope, top, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int  *lda;
+void dgebs2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda)
 {
    void Cdgebs2d();
    Cdgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
-void dgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void dgebr2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cdgebr2d();
    Cdgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void dtrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void dtrsd2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cdtrsd2d();
    Cdtrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void dtrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void dtrrv2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cdtrrv2d();
    Cdtrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void dtrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int  *lda;
+void dtrbs2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda)
 {
    void Cdtrbs2d();
    Cdtrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
-void dtrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void dtrbr2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cdtrbr2d();
    Cdtrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void dgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void dgsum2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cdgsum2d();
    Cdgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void dgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void dgamx2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Cdgamx2d();
    Cdgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void dgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void dgamn2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Cdgamn2d();
    Cdgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void sgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void sgesd2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Csgesd2d();
    Csgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void sgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void sgerv2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Csgerv2d();
    Csgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void sgebs2d_(ConTxt, scope, top, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int  *lda;
+void sgebs2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda)
 {
    void Csgebs2d();
    Csgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
-void sgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void sgebr2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Csgebr2d();
    Csgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void strsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void strsd2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cstrsd2d();
    Cstrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void strrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void strrv2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cstrrv2d();
    Cstrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void strbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int  *lda;
+void strbs2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda)
 {
    void Cstrbs2d();
    Cstrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
-void strbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void strbr2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cstrbr2d();
    Cstrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void sgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void sgsum2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Csgsum2d();
    Csgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void sgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void sgamx2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Csgamx2d();
    Csgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void sgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void sgamn2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Csgamn2d();
    Csgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void cgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void cgesd2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Ccgesd2d();
    Ccgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void cgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void cgerv2d_(Int *ConTxt, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Ccgerv2d();
    Ccgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void cgebs2d_(ConTxt, scope, top, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int  *lda;
+void cgebs2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda)
 {
    void Ccgebs2d();
    Ccgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
-void cgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void cgebr2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Ccgebr2d();
    Ccgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void ctrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void ctrsd2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cctrsd2d();
    Cctrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void ctrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void ctrrv2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cctrrv2d();
    Cctrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void ctrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int  *lda;
+void ctrbs2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda)
 {
    void Cctrbs2d();
    Cctrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
-void ctrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void ctrbr2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, float *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cctrbr2d();
    Cctrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void cgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void cgsum2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Ccgsum2d();
    Ccgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void cgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void cgamx2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Ccgamx2d();
    Ccgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void cgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-float *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void cgamn2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, float *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Ccgamn2d();
    Ccgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void zgesd2d_(ConTxt, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void zgesd2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Czgesd2d();
    Czgesd2d(*ConTxt, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void zgerv2d_(ConTxt, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void zgerv2d_(Int *ConTxt, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Czgerv2d();
    Czgerv2d(*ConTxt, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void zgebs2d_(ConTxt, scope, top, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int  *lda;
+void zgebs2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda)
 {
    void Czgebs2d();
    Czgebs2d(*ConTxt, scope, top, *m, *n, A, *lda);
 }
 
-void zgebr2d_(ConTxt, scope, top, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void zgebr2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Czgebr2d();
    Czgebr2d(*ConTxt, scope, top, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void ztrsd2d_(ConTxt, uplo, diag, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void ztrsd2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Cztrsd2d();
    Cztrsd2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void ztrrv2d_(ConTxt, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void ztrrv2d_(Int *ConTxt, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cztrrv2d();
    Cztrrv2d(*ConTxt, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void ztrbs2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int  *lda;
+void ztrbs2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda)
 {
    void Cztrbs2d();
    Cztrbs2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda);
 }
 
-void ztrbr2d_(ConTxt, scope, top, uplo, diag, m, n, A, lda, rsrc, csrc)
-Int *ConTxt;
-char *scope;
-char *top;
-char *uplo;
-char *diag;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rsrc;
-Int  *csrc;
+void ztrbr2d_(Int *ConTxt, char *scope, char *top, char *uplo, char *diag, Int *m, Int *n, double *A, Int *lda, Int *rsrc, Int *csrc)
 {
    void Cztrbr2d();
    Cztrbr2d(*ConTxt, scope, top, uplo, diag, *m, *n, A, *lda, *rsrc, *csrc);
 }
 
-void zgsum2d_(ConTxt, scope, top, m, n, A, lda, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rdest;
-Int  *cdest;
+void zgsum2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rdest, Int *cdest)
 {
    void Czgsum2d();
    Czgsum2d(*ConTxt, scope, top, *m, *n, A, *lda, *rdest, *cdest);
 }
 
-void zgamx2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void zgamx2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Czgamx2d();
    Czgamx2d(*ConTxt, scope, top, *m, *n, A, *lda,  rA, cA, *ldia,
             *rdest, *cdest);
 }
 
-void zgamn2d_(ConTxt, scope, top, m, n, A, lda, rA, cA, ldia, rdest, cdest)
-Int *ConTxt;
-char *scope;
-char *top;
-Int *m;
-Int *n;
-double *A;
-Int *lda;
-Int *rA;
-Int *cA;
-Int *ldia;
-Int *rdest;
-Int  *cdest;
+void zgamn2d_(Int *ConTxt, char *scope, char *top, Int *m, Int *n, double *A, Int *lda, Int *rA, Int *cA, Int *ldia, Int *rdest, Int *cdest)
 {
    void Czgamn2d();
    Czgamn2d(*ConTxt, scope, top, *m, *n, A, *lda, rA, cA, *ldia,

--- a/PBLAS/SRC/PTOOLS/PB_Cctypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cctypeset.c
@@ -16,7 +16,7 @@
 #include "../PBblacs.h"
 #include "../PBblas.h"
 
-PBTYP_T * PB_Cctypeset()
+PBTYP_T * PB_Cctypeset(void)
 {
 /*
 *  Purpose

--- a/PBLAS/SRC/PTOOLS/PB_Cdtypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cdtypeset.c
@@ -16,7 +16,7 @@
 #include "../PBblacs.h"
 #include "../PBblas.h"
 
-PBTYP_T * PB_Cdtypeset()
+PBTYP_T * PB_Cdtypeset(void)
 {
 /*
 *  Purpose

--- a/PBLAS/SRC/PTOOLS/PB_Citypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Citypeset.c
@@ -16,7 +16,7 @@
 #include "../PBblacs.h"
 #include "../PBblas.h"
 
-PBTYP_T * PB_Citypeset()
+PBTYP_T * PB_Citypeset(void)
 {
 /*
 *  Purpose

--- a/PBLAS/SRC/PTOOLS/PB_Cstypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cstypeset.c
@@ -16,7 +16,7 @@
 #include "../PBblacs.h"
 #include "../PBblas.h"
 
-PBTYP_T * PB_Cstypeset()
+PBTYP_T * PB_Cstypeset(void)
 {
 /*
 *  Purpose

--- a/PBLAS/SRC/PTOOLS/PB_Cztypeset.c
+++ b/PBLAS/SRC/PTOOLS/PB_Cztypeset.c
@@ -16,7 +16,7 @@
 #include "../PBblacs.h"
 #include "../PBblas.h"
 
-PBTYP_T * PB_Cztypeset()
+PBTYP_T * PB_Cztypeset(void)
 {
 /*
 *  Purpose

--- a/PBLAS/SRC/PTOOLS/PB_freebuf_.c
+++ b/PBLAS/SRC/PTOOLS/PB_freebuf_.c
@@ -16,7 +16,7 @@
 #include "../PBblacs.h"
 #include "../PBblas.h"
 
-void PB_freebuf_()
+void PB_freebuf_(void)
 {
 /*
 *  Purpose

--- a/REDIST/SRC/pcgemr.c
+++ b/REDIST/SRC/pcgemr.c
@@ -244,23 +244,16 @@ extern void Cpcgemr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  complex *A, *B;
+fortran_mr2d(Int *m, Int *n, complex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     complex *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpcgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  complex *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(Int *m, Int *n, complex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		complex *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpcgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -572,9 +565,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -645,11 +636,7 @@ Int _m,_n,_lda,_ldb; \
     } \
 }
 static2 Int 
-block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *ma;
-  complex *buff, *ptra;
+block2buff(IDESC *vi, Int vinb, IDESC *hi, Int hinb, complex *ptra, MDESC *ma, complex *buff)
 {
   Int   h, v, sizebuff;
   complex *ptr2;
@@ -667,11 +654,7 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
   return sizebuff;
 }
 static2 void 
-buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *mb;
-  complex *buff, *ptrb;
+buff2block(IDESC *vi, Int vinb, IDESC *hi, Int hinb, complex *buff, complex *ptrb, MDESC *mb)
 {
   Int   h, v, sizebuff;
   complex *ptr2;
@@ -688,9 +671,7 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
   }
 }
 static2 Int 
-inter_len(hinb, hi, vinb, vi)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
+inter_len(Int hinb, IDESC *hi, Int vinb, IDESC *vi)
 {
   Int   hlen, vlen, h, v;
   hlen = 0;
@@ -702,9 +683,7 @@ inter_len(hinb, hi, vinb, vi)
   return hlen * vlen;
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  complex *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, complex *a, Int lda, complex *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -718,8 +697,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pcgemr2.c
+++ b/REDIST/SRC/pcgemr2.c
@@ -113,9 +113,7 @@ extern void Cpcgemr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  complex **adpointer;
-  Int   blocksize;
+setmemory(complex **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -128,8 +126,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  complex *ptrtobefreed;
+freememory(complex *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pctrmr.c
+++ b/REDIST/SRC/pctrmr.c
@@ -259,25 +259,16 @@ extern void Cpctrmr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  complex *A, *B;
+fortran_mr2d(char *uplo, char *diag, Int *m, Int *n, complex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     complex *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpctrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  complex *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(char *uplo, char *diag, Int *m, Int *n, complex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		complex *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpctrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -596,9 +587,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -652,9 +641,7 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
     }
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  complex *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, complex *a, Int lda, complex *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -668,8 +655,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pctrmr2.c
+++ b/REDIST/SRC/pctrmr2.c
@@ -113,9 +113,7 @@ extern void Cpctrmr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  complex **adpointer;
-  Int   blocksize;
+setmemory(complex **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -128,8 +126,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  complex *ptrtobefreed;
+freememory(complex *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pdgemr.c
+++ b/REDIST/SRC/pdgemr.c
@@ -241,23 +241,16 @@ extern void Cpdgemr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  double *A, *B;
+fortran_mr2d(Int *m, Int *n, double *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     double *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpdgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  double *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(Int *m, Int *n, double *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		double *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpdgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -685,9 +678,7 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
   }
 }
 static2 Int 
-inter_len(hinb, hi, vinb, vi)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
+inter_len(Int hinb, IDESC *hi, Int vinb, IDESC *vi)
 {
   Int   hlen, vlen, h, v;
   hlen = 0;
@@ -699,9 +690,7 @@ inter_len(hinb, hi, vinb, vi)
   return hlen * vlen;
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  double *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, double *a, Int lda, double *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -715,8 +704,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pdgemr2.c
+++ b/REDIST/SRC/pdgemr2.c
@@ -110,9 +110,7 @@ extern void Cpdgemr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  double **adpointer;
-  Int   blocksize;
+setmemory(double **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -125,8 +123,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  double *ptrtobefreed;
+freememory(double *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pdtrmr.c
+++ b/REDIST/SRC/pdtrmr.c
@@ -256,25 +256,16 @@ extern void Cpdtrmr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  double *A, *B;
+fortran_mr2d(char *uplo, char *diag, Int *m, Int *n, double *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     double *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpdtrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  double *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(char *uplo, char *diag, Int *m, Int *n, double *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		double *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpdtrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -593,9 +584,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -649,9 +638,7 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
     }
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  double *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, double *a, Int lda, double *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -665,8 +652,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pdtrmr2.c
+++ b/REDIST/SRC/pdtrmr2.c
@@ -110,9 +110,7 @@ extern void Cpdtrmr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  double **adpointer;
-  Int   blocksize;
+setmemory(double **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -125,8 +123,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  double *ptrtobefreed;
+freememory(double *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pgemraux.c
+++ b/REDIST/SRC/pgemraux.c
@@ -105,8 +105,7 @@ extern void Cpigemr2d();
 #include <stdlib.h>
 #include <assert.h>
 void *
-mr2d_malloc(n)
-  Int   n;
+mr2d_malloc(Int n)
 {
   void *ptr;
   assert(n > 0);
@@ -118,8 +117,7 @@ mr2d_malloc(n)
   return ptr;
 }
 Int 
-pgcd(a, b)
-  Int   a, b;
+pgcd(Int a, Int b)
 {
   Int   aux;
   if (a < b)
@@ -133,8 +131,7 @@ pgcd(a, b)
   }
 }
 Int 
-ppcm(a, b)
-  Int   a, b;
+ppcm(Int a, Int b)
 {
   Int   pg;
   pg = pgcd(a, b);
@@ -145,8 +142,7 @@ ppcm(a, b)
  * grid of processors with p rows with blocksize nbrow : this procedure can
  * also be used to compute the number of cols by replacing rows by cols */
 Int 
-localsize(myprow, p, nbrow, m)
-  Int   myprow, p, nbrow, m;
+localsize(Int myprow, Int p, Int nbrow, Int m)
 {
   Int   templateheight, blockheight;
   templateheight = p * nbrow;
@@ -174,8 +170,7 @@ localsize(myprow, p, nbrow, m)
 /****************************************************************/
 /* Returns the exact memory block size corresponding to the parameters */
 Int
-memoryblocksize(a)
-  MDESC *a;
+memoryblocksize(MDESC *a)
 {
   Int   myprow, mypcol, p, q;
   /* Compute the (myprow,mypcol) indices of processor mypnum in P0xQ0 We
@@ -188,8 +183,7 @@ memoryblocksize(a)
 	localsize(mypcol, q, a->nbcol, a->n);
 }
 void 
-checkequal(ctxt, a)
-  Int   a, ctxt;
+checkequal(Int ctxt, Int a)
 {
   Int   np, dummy, nbrow, myp, b;
   Cblacs_gridinfo(ctxt, &nbrow, &np, &dummy, &myp);
@@ -207,9 +201,7 @@ checkequal(ctxt, a)
   }
 }
 void 
-paramcheck(a, i, j, m, n, p, q, gcontext)
-  MDESC *a;
-  Int   i, j, m, n, p, q;
+paramcheck(MDESC *a, Int i, Int j, Int m, Int n, Int p, Int q, Int gcontext)
 {
   Int   p2, q2, myprow, mypcol;
 #ifndef NDEBUG
@@ -255,9 +247,7 @@ nbrow=%d,lda=%d,sprow=%d\n",
  * i' with i'< blocksize return the line number on the local process where
  * the new matrix begin, the new process number, and i' */
 Int 
-changeorigin(myp, sp, p, bs, i, decal, newsp)
-  Int   myp, sp, p, bs, i;
-  Int  *decal, *newsp;
+changeorigin(Int myp, Int sp, Int p, Int bs, Int i, Int *decal, Int *newsp)
 {
   Int   tempheight, firstblock, firsttemp;
   /* we begin by changing the parameters so that ia < templatewidth,... */
@@ -274,9 +264,7 @@ changeorigin(myp, sp, p, bs, i, decal, newsp)
 /******************************************************************/
 /* Return the indice in local memory of element of indice a in the matrix */
 Int
-localindice(ig, jg, templateheight, templatewidth, a)
-  Int   templateheight, templatewidth, ig, jg;
-  MDESC *a;
+localindice(Int ig, Int jg, Int templateheight, Int templatewidth, MDESC *a)
 /* Return the indice in local memory (scattered distribution) of the element
  * of indice a in global matrix */
 {

--- a/REDIST/SRC/pigemr.c
+++ b/REDIST/SRC/pigemr.c
@@ -241,23 +241,16 @@ extern void Cpigemr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  Int  *A, *B;
+fortran_mr2d(Int *m, Int *n, Int *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     Int *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpigemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  Int  *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(Int *m, Int *n, Int *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		Int *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpigemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -569,9 +562,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -642,11 +633,7 @@ Int _m,_n,_lda,_ldb; \
     } \
 }
 static2 Int 
-block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *ma;
-  Int  *buff, *ptra;
+block2buff(IDESC *vi, Int vinb, IDESC *hi, Int hinb, Int *ptra, MDESC *ma, Int *buff)
 {
   Int   h, v, sizebuff;
   Int  *ptr2;
@@ -664,11 +651,7 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
   return sizebuff;
 }
 static2 void 
-buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *mb;
-  Int  *buff, *ptrb;
+buff2block(IDESC *vi, Int vinb, IDESC *hi, Int hinb, Int *buff, Int *ptrb, MDESC *mb)
 {
   Int   h, v, sizebuff;
   Int  *ptr2;
@@ -685,9 +668,7 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
   }
 }
 static2 Int 
-inter_len(hinb, hi, vinb, vi)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
+inter_len(Int hinb, IDESC *hi, Int vinb, IDESC *vi)
 {
   Int   hlen, vlen, h, v;
   hlen = 0;
@@ -699,9 +680,7 @@ inter_len(hinb, hi, vinb, vi)
   return hlen * vlen;
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  Int  *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, Int *a, Int lda, Int *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -715,8 +694,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pigemr2.c
+++ b/REDIST/SRC/pigemr2.c
@@ -110,9 +110,7 @@ extern void Cpigemr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  Int **adpointer;
-  Int   blocksize;
+setmemory(Int **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -125,8 +123,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  Int  *ptrtobefreed;
+freememory(Int *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pitrmr.c
+++ b/REDIST/SRC/pitrmr.c
@@ -256,25 +256,16 @@ extern void Cpitrmr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  Int  *A, *B;
+fortran_mr2d(char *uplo, char *diag, Int *m, Int *n, Int *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     Int *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpitrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  Int  *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(char *uplo, char *diag, Int *m, Int *n, Int *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		Int *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpitrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -593,9 +584,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -649,9 +638,7 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
     }
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  Int  *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, Int *a, Int lda, Int *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -665,8 +652,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pitrmr2.c
+++ b/REDIST/SRC/pitrmr2.c
@@ -110,9 +110,7 @@ extern void Cpitrmr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  Int **adpointer;
-  Int   blocksize;
+setmemory(Int **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -125,8 +123,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  Int  *ptrtobefreed;
+freememory(Int *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;
@@ -173,21 +170,13 @@ insidemat(uplo, diag, i, j, m, n, offset)
  * action can be the filling of the memory buffer, the count of the memory
  * buffer size or the setting of the memory with the element received) */
 static2 void
-intersect(uplo, diag,
-	  j, start, end,
-	  action,
-	  ptrsizebuff, pptrbuff, ptrblock,
-	  m, n,
-	  ma, ia, ja, templateheight0, templatewidth0,
-	  mb, ib, jb, templateheight1, templatewidth1)
-  Int   action, *ptrsizebuff;
-  Int   j, start, end;
-  Int **pptrbuff, *ptrblock;
-  Int   templateheight0, templatewidth0;
-  Int   templateheight1, templatewidth1;
-  MDESC *ma, *mb;
-  Int   ia, ja, ib, jb, m, n;
-  char *uplo, *diag;
+intersect(char *uplo, char *diag,
+	  Int j, Int start, Int end,
+	  Int action,
+	  Int *ptrsizebuff, Int **pptrbuff, Int *ptrblock,
+	  Int m, Int n,
+	  MDESC *ma, Int ia, Int ja, Int templateheight0, Int templatewidth0,
+	  MDESC *mb, Int ib, Int jb, Int templateheight1, Int templatewidth1)
 /* Execute the action on the local memory for the current interval and
  * increment pptrbuff and ptrsizebuff of the intervalsize */
 /* Notice that if the interval is contigous in the virtual matrice, it is

--- a/REDIST/SRC/psgemr.c
+++ b/REDIST/SRC/psgemr.c
@@ -241,23 +241,16 @@ extern void Cpsgemr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  float *A, *B;
+fortran_mr2d(Int *m, Int *n, float *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     float *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpsgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  float *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(Int *m, Int *n, float *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		float *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpsgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -573,9 +566,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -646,11 +637,7 @@ Int _m,_n,_lda,_ldb; \
     } \
 }
 static2 Int 
-block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *ma;
-  float *buff, *ptra;
+block2buff(IDESC *vi, Int vinb, IDESC *hi, Int hinb, float *ptra, MDESC *ma, float *buff)
 {
   Int   h, v, sizebuff;
   float *ptr2;
@@ -668,11 +655,7 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
   return sizebuff;
 }
 static2 void 
-buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *mb;
-  float *buff, *ptrb;
+buff2block(IDESC *vi, Int vinb, IDESC *hi, Int hinb, float *buff, float *ptrb, MDESC *mb)
 {
   Int   h, v, sizebuff;
   float *ptr2;
@@ -689,9 +672,7 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
   }
 }
 static2 Int 
-inter_len(hinb, hi, vinb, vi)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
+inter_len(Int hinb, IDESC *hi, Int vinb, IDESC *vi)
 {
   Int   hlen, vlen, h, v;
   hlen = 0;
@@ -703,9 +684,7 @@ inter_len(hinb, hi, vinb, vi)
   return hlen * vlen;
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  float *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, float *a, Int lda, float *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -719,8 +698,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/psgemr2.c
+++ b/REDIST/SRC/psgemr2.c
@@ -110,9 +110,7 @@ extern void Cpsgemr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  float **adpointer;
-  Int   blocksize;
+setmemory(float **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -125,8 +123,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  float *ptrtobefreed;
+freememory(float *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pstrmr.c
+++ b/REDIST/SRC/pstrmr.c
@@ -256,25 +256,16 @@ extern void Cpstrmr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  float *A, *B;
+fortran_mr2d(char *uplo, char *diag, Int *m, Int *n, float *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     float *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpstrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  float *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(char *uplo, char *diag, Int *m, Int *n, float *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		float *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpstrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -311,15 +302,9 @@ Cpstrmr2do(uplo, diag, m, n,
 			 * idem B puis ia,ja puis ib,jb */
 #define MAGIC_MAX 100000000
 void
-Cpstrmr2d(uplo, diag, m, n,
-	  ptrmyblock, ia, ja, ma,
-	  ptrmynewblock, ib, jb, mb, globcontext)
-  char *uplo, *diag;
-  float *ptrmyblock, *ptrmynewblock;
-/* pointers to the memory location of the matrix and the redistributed matrix */
-  MDESC *ma;
-  MDESC *mb;
-  Int   ia, ja, ib, jb, m, n, globcontext;
+Cpstrmr2d(char *uplo, char *diag, Int m, Int n,
+	  float *ptrmyblock, Int ia, Int ja, MDESC *ma,
+	  float *ptrmynewblock, Int ib, Int jb, MDESC *mb, Int globcontext)
 {
   float *ptrsendbuff, *ptrrecvbuff, *ptrNULL = 0;
   float *recvptr;
@@ -593,9 +578,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -649,9 +632,7 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
     }
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  float *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, float *a, Int lda, float *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -665,8 +646,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pstrmr2.c
+++ b/REDIST/SRC/pstrmr2.c
@@ -110,9 +110,7 @@ extern void Cpstrmr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  float **adpointer;
-  Int   blocksize;
+setmemory(float **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -125,8 +123,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  float *ptrtobefreed;
+freememory(float *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pzgemr.c
+++ b/REDIST/SRC/pzgemr.c
@@ -244,23 +244,16 @@ extern void Cpzgemr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  dcomplex *A, *B;
+fortran_mr2d(Int *m, Int *n, dcomplex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     dcomplex *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpzgemr2do(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  dcomplex *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(Int *m, Int *n, dcomplex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		dcomplex *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpzgemr2d(*m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -572,9 +565,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -645,11 +636,7 @@ Int _m,_n,_lda,_ldb; \
     } \
 }
 static2 Int 
-block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *ma;
-  dcomplex *buff, *ptra;
+block2buff(IDESC *vi, Int vinb, IDESC *hi, Int hinb, dcomplex *ptra, MDESC *ma, dcomplex *buff)
 {
   Int   h, v, sizebuff;
   dcomplex *ptr2;
@@ -667,11 +654,7 @@ block2buff(vi, vinb, hi, hinb, ptra, ma, buff)
   return sizebuff;
 }
 static2 void 
-buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
-  MDESC *mb;
-  dcomplex *buff, *ptrb;
+buff2block(IDESC *vi, Int vinb, IDESC *hi, Int hinb, dcomplex *buff, dcomplex *ptrb, MDESC *mb)
 {
   Int   h, v, sizebuff;
   dcomplex *ptr2;
@@ -688,9 +671,7 @@ buff2block(vi, vinb, hi, hinb, buff, ptrb, mb)
   }
 }
 static2 Int 
-inter_len(hinb, hi, vinb, vi)
-  Int   hinb, vinb;
-  IDESC *hi, *vi;
+inter_len(Int hinb, IDESC *hi, Int vinb, IDESC *vi)
 {
   Int   hlen, vlen, h, v;
   hlen = 0;
@@ -702,9 +683,7 @@ inter_len(hinb, hi, vinb, vi)
   return hlen * vlen;
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  dcomplex *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, dcomplex *a, Int lda, dcomplex *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -718,8 +697,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pzgemr2.c
+++ b/REDIST/SRC/pzgemr2.c
@@ -113,9 +113,7 @@ extern void Cpzgemr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  dcomplex **adpointer;
-  Int   blocksize;
+setmemory(dcomplex **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -128,8 +126,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  dcomplex *ptrtobefreed;
+freememory(dcomplex *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/SRC/pztrmr.c
+++ b/REDIST/SRC/pztrmr.c
@@ -259,25 +259,16 @@ extern void Cpztrmr2d();
 #include <assert.h>
 #define DESCLEN 9
 void 
-fortran_mr2d(uplo, diag, m, n, A, ia, ja, desc_A,
-	     B, ib, jb, desc_B)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  dcomplex *A, *B;
+fortran_mr2d(char *uplo, char *diag, Int *m, Int *n, dcomplex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+	     dcomplex *B, Int *ib, Int *jb, Int desc_B[DESCLEN])
 {
   Cpztrmr2do(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	     B, *ib, *jb, (MDESC *) desc_B);
   return;
 }
 void 
-fortran_mr2dnew(uplo, diag, m, n, A, ia, ja, desc_A,
-		B, ib, jb, desc_B, gcontext)
-  char *uplo, *diag;
-  Int  *ia, *ib, *ja, *jb, *m, *n;
-  Int   desc_A[DESCLEN], desc_B[DESCLEN];
-  dcomplex *A, *B;
-  Int  *gcontext;
+fortran_mr2dnew(char *uplo, char *diag, Int *m, Int *n, dcomplex *A, Int *ia, Int *ja, Int desc_A[DESCLEN],
+		dcomplex *B, Int *ib, Int *jb, Int desc_B[DESCLEN], Int *gcontext)
 {
   Cpztrmr2d(uplo, diag, *m, *n, A, *ia, *ja, (MDESC *) desc_A,
 	    B, *ib, *jb, (MDESC *) desc_B, *gcontext);
@@ -596,9 +587,7 @@ after_comm:
   free(param);
 }/* distrib */
 static2 void 
-init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
-  Int   nprocs, mypnum, n0, n1;
-  Int  *proc0, *proc1, **psend, **precv, *myrang;
+init_chenille(Int mypnum, Int nprocs, Int n0, Int *proc0, Int n1, Int *proc1, Int **psend, Int **precv, Int *myrang)
 {
   Int   ns, nr, i, tot;
   Int  *sender, *recver, *g0, *g1;
@@ -652,9 +641,7 @@ init_chenille(mypnum, nprocs, n0, proc0, n1, proc1, psend, precv, myrang)
     }
 }
 void 
-Clacpy(m, n, a, lda, b, ldb)
-  dcomplex *a, *b;
-  Int   m, n, lda, ldb;
+Clacpy(Int m, Int n, dcomplex *a, Int lda, dcomplex *b, Int ldb)
 {
   Int   i, j;
   lda -= m;
@@ -668,8 +655,7 @@ Clacpy(m, n, a, lda, b, ldb)
   }
 }
 static2 void 
-gridreshape(ctxtp)
-  Int  *ctxtp;
+gridreshape(Int *ctxtp)
 {
   Int   ori, final;	/* original context, and new context created, with
 			 * line form */

--- a/REDIST/SRC/pztrmr2.c
+++ b/REDIST/SRC/pztrmr2.c
@@ -113,9 +113,7 @@ extern void Cpztrmr2d();
 /************************************************************************/
 /* Set the memory space with the malloc function */
 void
-setmemory(adpointer, blocksize)
-  dcomplex **adpointer;
-  Int   blocksize;
+setmemory(dcomplex **adpointer, Int blocksize)
 {
   assert(blocksize >= 0);
   if (blocksize == 0) {
@@ -128,8 +126,7 @@ setmemory(adpointer, blocksize)
 /******************************************************************/
 /* Free the memory space after the malloc */
 void
-freememory(ptrtobefreed)
-  dcomplex *ptrtobefreed;
+freememory(dcomplex *ptrtobefreed)
 {
   if (ptrtobefreed == NULL)
     return;

--- a/REDIST/TESTING/pcgemrdrv.c
+++ b/REDIST/TESTING/pcgemrdrv.c
@@ -165,9 +165,7 @@ extern void Cpcgemr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  complex *block;
-  Int   m, n;
+initblock(complex *block, Int m, Int n)
 {
   complex *pdata;
   Int   i;
@@ -225,9 +223,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -244,9 +240,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pctrmrdrv.c
+++ b/REDIST/TESTING/pctrmrdrv.c
@@ -165,9 +165,7 @@ extern void Cpctrmr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  complex *block;
-  Int   m, n;
+initblock(complex *block, Int m, Int n)
 {
   complex *pdata;
   Int   i;
@@ -225,9 +223,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -244,9 +240,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pdgemrdrv.c
+++ b/REDIST/TESTING/pdgemrdrv.c
@@ -162,9 +162,7 @@ extern void Cpdgemr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  double *block;
-  Int   m, n;
+initblock(double *block, Int m, Int n)
 {
   double *pdata;
   Int   i;
@@ -222,9 +220,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -241,9 +237,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pdtrmrdrv.c
+++ b/REDIST/TESTING/pdtrmrdrv.c
@@ -162,9 +162,7 @@ extern void Cpdtrmr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  double *block;
-  Int   m, n;
+initblock(double *block, Int m, Int n)
 {
   double *pdata;
   Int   i;
@@ -222,9 +220,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -241,9 +237,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pigemrdrv.c
+++ b/REDIST/TESTING/pigemrdrv.c
@@ -161,9 +161,7 @@ extern void Cpigemr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  Int  *block;
-  Int   m, n;
+initblock(Int *block, Int m, Int n)
 {
   Int  *pdata;
   Int   i;
@@ -221,9 +219,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -240,9 +236,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pitrmrdrv.c
+++ b/REDIST/TESTING/pitrmrdrv.c
@@ -161,9 +161,7 @@ extern void Cpitrmr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  Int  *block;
-  Int   m, n;
+initblock(Int *block, Int m, Int n)
 {
   Int  *pdata;
   Int   i;
@@ -221,9 +219,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -240,9 +236,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/psgemrdrv.c
+++ b/REDIST/TESTING/psgemrdrv.c
@@ -161,9 +161,7 @@ extern void Cpsgemr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  float *block;
-  Int   m, n;
+initblock(float *block, Int m, Int n)
 {
   float *pdata;
   Int   i;
@@ -221,9 +219,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -240,9 +236,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pstrmrdrv.c
+++ b/REDIST/TESTING/pstrmrdrv.c
@@ -161,9 +161,7 @@ extern void Cpstrmr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  float *block;
-  Int   m, n;
+initblock(float *block, Int m, Int n)
 {
   float *pdata;
   Int   i;
@@ -221,9 +219,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -240,9 +236,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pzgemrdrv.c
+++ b/REDIST/TESTING/pzgemrdrv.c
@@ -165,9 +165,7 @@ extern void Cpzgemr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  dcomplex *block;
-  Int   m, n;
+initblock(dcomplex *block, Int m, Int n)
 {
   dcomplex *pdata;
   Int   i;
@@ -225,9 +223,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -244,9 +240,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/REDIST/TESTING/pztrmrdrv.c
+++ b/REDIST/TESTING/pztrmrdrv.c
@@ -165,9 +165,7 @@ extern void Cpztrmr2d();
 /* initblock: intialize the local part of a matrix with random data (well,
  * not very random) */
 static2 void
-initblock(block, m, n)
-  dcomplex *block;
-  Int   m, n;
+initblock(dcomplex *block, Int m, Int n)
 {
   dcomplex *pdata;
   Int   i;
@@ -225,9 +223,7 @@ va_dcl
   va_end(ap);
 }
 void 
-initforpvm(argc, argv)
-  Int   argc;
-  char *argv[];
+initforpvm(Int argc, char *argv[])
 {
   Int   pnum, nproc;
   Cblacs_pinfo(&pnum, &nproc);
@@ -244,9 +240,7 @@ initforpvm(argc, argv)
   }
 }
 int
-main(argc, argv)
-  int   argc;
-  char *argv[];
+main(int argc, char *argv[])
 {
   /* We initialize the data-block on the current processor, then redistribute
    * it, and perform the inverse redistribution  to compare the local memory

--- a/SRC/getpbbuf.c
+++ b/SRC/getpbbuf.c
@@ -1,14 +1,6 @@
 #include "tools.h"
 
-char * getpbbuf( mess, length )
-/*
-*  .. Scalar Arguments ..
-*/
-   Int         length;
-/*
-*  .. Array Arguments ..
-*/
-   char        * mess;
+char * getpbbuf( char *mess, Int length )
 {
 /*
 *  Purpose

--- a/SRC/pbchkvect.c
+++ b/SRC/pbchkvect.c
@@ -12,17 +12,8 @@
 */
 #include "tools.h"
 
-void pbchkvect( n, npos0, ix, jx, desc_X, incx, dpos0, iix, jjx, ixrow,
-                ixcol, nprow, npcol, myrow, mycol, info )
-/*
-*  .. Scalar Arguments ..
-*/
-   Int         dpos0, * iix, incx, * info, ix, * ixcol, * ixrow, * jjx,
-               jx, myrow, mycol, npcol, nprow, n, npos0;
-/*
-*  .. Array Arguments ..
-*/
-   Int         desc_X[];
+void pbchkvect( Int n, Int npos0, Int ix, Int jx, Int desc_X[], Int incx, Int dpos0, Int *iix, Int *jjx, Int *ixrow,
+                Int *ixcol, Int nprow, Int npcol, Int myrow, Int mycol, Int *info )
 {
 /*
 *

--- a/SRC/pcrot.c
+++ b/SRC/pcrot.c
@@ -10,23 +10,11 @@
 */
 #include "pblas.h"
 
-void pcrot_( n, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y, incy, c, s )
+void pcrot_( Int *n, complex X[], Int *ix, Int *jx, Int desc_X[], Int *incx, complex Y[], Int *iy, Int *jy, Int desc_Y[], Int *incy, float *c, complex *s )
 /*
 *  Mark Fahey
 *  June 22, 2000
 */
-/*
-*  .. Scalar Arguments ..
-*/
-   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
-   float       * c;
-   complex     * s;
-/*
-*  ..
-*  .. Array Arguments ..
-*/
-   Int         desc_X[], desc_Y[];
-   complex     X[], Y[];
 {
 /*
 *  Purpose

--- a/SRC/pzrot.c
+++ b/SRC/pzrot.c
@@ -10,23 +10,11 @@
 */
 #include "pblas.h"
 
-void pzrot_( n, X, ix, jx, desc_X, incx, Y, iy, jy, desc_Y, incy, c, s )
+void pzrot_( Int *n, complex16 X[], Int *ix, Int *jx, Int desc_X[], Int *incx, complex16 Y[], Int *iy, Int *jy, Int desc_Y[], Int *incy, double *c, complex16 *s )
 /*
 *  Mark Fahey
 *  June 22, 2000
 */
-/*
-*  .. Scalar Arguments ..
-*/
-   Int         * incx, * incy, * ix, * iy, * jx, * jy, * n;
-   double      * c;
-   complex16   * s;
-/*
-*  ..
-*  .. Array Arguments ..
-*/
-   Int         desc_X[], desc_Y[];
-   complex16   X[], Y[];
 {
 /*
 *  Purpose

--- a/TOOLS/SL_gridreshape.c
+++ b/TOOLS/SL_gridreshape.c
@@ -5,8 +5,7 @@
 #define Int int
 #endif
 
-Int SL_Cgridreshape(ctxt, pstart, row_major_in, row_major_out, P, Q)
-Int ctxt, pstart, row_major_in, row_major_out, P, Q;
+Int SL_Cgridreshape(Int ctxt, Int pstart, Int row_major_in, Int row_major_out, Int P, Int Q)
 {
    Int Cblacs_pnum();
    Int nctxt, P0, Q0, Np, i, *g;
@@ -49,29 +48,25 @@ Int ctxt, pstart, row_major_in, row_major_out, P, Q;
    return(nctxt);
 }
 
-Int sl_gridreshape_(ctxt, pstart, row_major_in, row_major_out, P, Q)
-Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int sl_gridreshape_(Int *ctxt, Int *pstart, Int *row_major_in, Int *row_major_out, Int *P, Int *Q)
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );
 }
 
-Int SL_GRIDRESHAPE(ctxt, pstart, row_major_in, row_major_out, P, Q)
-Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int SL_GRIDRESHAPE(Int *ctxt, Int *pstart, Int *row_major_in, Int *row_major_out, Int *P, Int *Q)
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );
 }
 
-Int sl_gridreshape__(ctxt, pstart, row_major_in, row_major_out, P, Q)
-Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int sl_gridreshape__(Int *ctxt, Int *pstart, Int *row_major_in, Int *row_major_out, Int *P, Int *Q)
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );
 }
 
-Int sl_gridreshape(ctxt, pstart, row_major_in, row_major_out, P, Q)
-Int *ctxt, *pstart, *row_major_in, *row_major_out, *P, *Q;
+Int sl_gridreshape(Int *ctxt, Int *pstart, Int *row_major_in, Int *row_major_out, Int *P, Int *Q)
 {
    return( SL_Cgridreshape(*ctxt, *pstart, *row_major_in, *row_major_out,
                            *P, *Q) );

--- a/TOOLS/reshape.c
+++ b/TOOLS/reshape.c
@@ -4,9 +4,8 @@
 #define Int int
 #endif
 
-void Creshape( context_in, major_in, context_out, major_out,
-                    first_proc, nprow_new, npcol_new )
-Int context_in, *context_out, first_proc, major_in, major_out, nprow_new, npcol_new;
+void Creshape( Int context_in, Int major_in, Int* context_out, Int major_out,
+                    Int first_proc, Int nprow_new, Int npcol_new )
 /* major in, major out represent whether processors go row major (1) or
 column major (2) in the input and output grids */
 {
@@ -78,32 +77,28 @@ column major (2) in the input and output grids */
 }
 
 /*************************************************************************/
-void reshape( context_in, major_in, context_out, major_out,
-                    first_proc, nprow_new, npcol_new )
-Int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
+void reshape( Int* context_in, Int* major_in, Int* context_out, Int* major_out,
+                    Int* first_proc, Int* nprow_new, Int* npcol_new )
 {
    Creshape( *context_in, *major_in, context_out, *major_out,
                     *first_proc, *nprow_new, *npcol_new );
 }
 /*************************************************************************/
-void RESHAPE( context_in, major_in, context_out, major_out,
-                    first_proc, nprow_new, npcol_new )
-Int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
+void RESHAPE( Int* context_in, Int* major_in, Int* context_out, Int* major_out,
+                    Int* first_proc, Int* nprow_new, Int* npcol_new )
 {
    Creshape( *context_in, *major_in, context_out, *major_out,
                     *first_proc, *nprow_new, *npcol_new );
 }
 /*************************************************************************/
-void reshape_( context_in, major_in, context_out, major_out,
-                    first_proc, nprow_new, npcol_new )
-Int *context_in, *context_out, *first_proc, *major_in, *major_out, *nprow_new, *npcol_new;
+void reshape_( Int* context_in, Int* major_in, Int* context_out, Int* major_out,
+                    Int* first_proc, Int* nprow_new, Int* npcol_new )
 {
    Creshape( *context_in, *major_in, context_out, *major_out,
                     *first_proc, *nprow_new, *npcol_new );
 }
 /*************************************************************************/
-void proc_inc( myrow, mycol, nprow, npcol, major )
-Int *myrow, *mycol, nprow, npcol, major;
+void proc_inc( Int* myrow, Int* mycol, Int nprow, Int npcol, Int major )
 {
    if( major == 1) /* row major */
    {


### PR DESCRIPTION
K&R syntax is obsolescent and [will be removed in C23](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2432.pdf).
[gcc](https://gcc.gnu.org/onlinedocs/gcc-10.3.0/gcc/Warning-Options.html#index-Wstrict-prototypes) and [clang](https://releases.llvm.org/11.0.0/tools/clang/docs/DiagnosticsReference.html#wstrict-prototypes) warn it if `-Wstrict-prototypes` option is supplied—the former also offers [`-Wold-style-definition`](https://gcc.gnu.org/onlinedocs/gcc-10.3.0/gcc/Warning-Options.html#index-Wold-style-definition).

Note that some of functions are not modfified due to compilation error (even without the options).