### PR TITLE
Fix parallel builds with GNU make

### DIFF
--- a/BLACS/Makefile
+++ b/BLACS/Makefile
@@ -1,11 +1,11 @@
 all : lib tester
 
 clean:
-	( cd TESTING ; make clean )
-	( cd SRC ; make clean )
+	( cd TESTING ; $(MAKE) clean )
+	( cd SRC ; $(MAKE) clean )
 
 tester :
-	( cd TESTING ; make )
+	( cd TESTING ; $(MAKE) )
 
 lib :
-	( cd SRC ; make )
+	( cd SRC ; $(MAKE) )

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ PRECISIONS = single double complex complex16
 
 all: lib exe example
 
-lib: blacslib toolslib pblaslib redistlib scalapacklib
+SCALAPACKLIBS=toolslib pblaslib redistlib scalapacklib
+
+$(SCALAPACKLIBS): blacslib
+lib: $(SCALAPACKLIBS)
 
 exe: blacsexe pblasexe redistexe scalapackexe
 


### PR DESCRIPTION
In order for `make -j` to work correctly, the BLACS library should be built before the other libraries. This can be achieved with an explicit dependency.

Also, the child make processes must be launched with `$(MAKE)` so that the `-j` option is propagated correctly.