### PR TITLE
Update CMake requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.7)
 
 project(SCALAPACK VERSION 2.2.1 LANGUAGES C Fortran)
 


### PR DESCRIPTION
The CMake operator `VERSION_GREATER_EQUAL` was introduced in CMake 3.7, and therefore we should require this version in ScaLAPACK.