### PR TITLE
find_package(MPI): remove 11-year old code that conflicts with CMake FindMPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,55 +21,16 @@ endif ()
 #
 #   MPI
 #
-set(CMAKE_PREFIX_PATH "${MPI_BASE_DIR};${CMAKE_PREFIX_PATH}")
 
 find_package(MPI)
-if (MPI_FOUND)
-   message(STATUS "Found MPI_LIBRARY : ${MPI_FOUND} ")
-   
-   find_program(MPI_C_COMPILER
-      NAMES mpicc
-      HINTS "${MPI_BASE_DIR}"
-      PATH_SUFFIXES bin
-      DOC "MPI C compiler.")
-   MARK_AS_ADVANCED(MPI_C_COMPILER)
-   if ("${MPI_C_COMPILER}" STREQUAL "MPI_C_COMPILER-NOTFOUND")
-      message(ERROR "--> MPI C Compiler NOT FOUND (please set MPI_BASE_DIR accordingly")
-   else()
-      message(STATUS "--> MPI C Compiler : ${MPI_C_COMPILER}")
-      #SET(CMAKE_C_COMPILER "${MPI_C_COMPILER}")
-      message(STATUS "--> C Compiler : ${CMAKE_C_COMPILER}")
-   endif()
-   find_program(MPI_Fortran_COMPILER
-      NAMES mpif77
-      HINTS "${MPI_BASE_DIR}"
-      PATH_SUFFIXES bin
-      DOC "MPI Fortran compiler.")
-   MARK_AS_ADVANCED(MPI_Fortran_COMPILER)
-
-   if ("${MPI_Fortran_COMPILER}" STREQUAL "MPI_Fortran_COMPILER-NOTFOUND")
-      message(ERROR "--> MPI Fortran Compiler NOT FOUND (please set MPI_BASE_DIR accordingly")
-   else()
-      message(STATUS "--> MPI Fortran Compiler : ${MPI_Fortran_COMPILER}")
-      SET(Fortran_COMPILER "${CMAKE_Fortran_COMPILER}")
-      #SET(CMAKE_Fortran_COMPILER "${MPI_Fortran_COMPILER}")
-      message(STATUS "--> Fortran Compiler : ${CMAKE_Fortran_COMPILER}")
-   endif()
-
-else()
-   message(STATUS "Found MPI_LIBRARY : ${MPI_FOUND} ")
-   set(MPI_BASE_DIR ${MPI_BASE_DIR} CACHE PATH "MPI Path")
-   UNSET(MPIEXEC CACHE)
-   UNSET(MPIEXEC_POSTFLAGS CACHE)
-   UNSET(MPIEXEC_PREFLAGS CACHE)
-   UNSET(MPIEXEC_MAX_NUMPROCS CACHE)
-   UNSET(MPIEXEC_NUMPROC_FLAG CACHE)
-   UNSET(MPI_COMPILE_FLAGS CACHE)
-   UNSET(MPI_LINK_FLAGS CACHE)
-   UNSET(MPI_INCLUDE_PATH CACHE)
-   message(FATAL_ERROR "--> MPI Library NOT FOUND -- please set MPI_BASE_DIR accordingly --")
+if(NOT MPI_FOUND)
+   message(FATAL_ERROR "--> MPI Library NOT FOUND -- please set MPI_ROOT accordingly: https://cmake.org/cmake/help/latest/module/FindMPI.html")
 endif()
 
+message(STATUS "--> MPI C Compiler : ${MPI_C_COMPILER}")
+message(STATUS "--> C Compiler : ${CMAKE_C_COMPILER}")
+message(STATUS "--> MPI Fortran Compiler : ${MPI_Fortran_COMPILER}")
+message(STATUS "--> Fortran Compiler : ${CMAKE_Fortran_COMPILER}")
 
 if (UNIX)
    if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")


### PR DESCRIPTION
even back to CMake 3.9, the code removed duplicates or possibly conflicts with what factory `find_package(MPI)` is doing, and is at best a NO-OP in contemporary CMake vs. what may have been intended 11 years ago.