### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/BLACS/INSTALL/CMakeLists.txt
+++ b/BLACS/INSTALL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.9)
 project(INSTALL C Fortran)
 
 add_executable(xintface Fintface.f Cintface.c)


### PR DESCRIPTION
Description of changes:
Modern cmake no longer supports versions older than 3.5. All the other cmake files in scalapack have a minimum of 3.9, except for this one, and everything it is is supported as is in 3.9. Adjusting this cmake_minimum_required value allows for Fedora to compile with cmake.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.