### PR TITLE
Use standard `GNUInstallDirs`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,6 @@ endif ()
 
 macro(SCALAPACK_install_library lib)
   install(TARGETS ${lib} EXPORT scalapack-targets
-    ARCHIVE DESTINATION lib${LIB_SUFFIX}
-    LIBRARY DESTINATION lib${LIB_SUFFIX}
     RUNTIME DESTINATION Testing
   )
 endmacro()
@@ -120,9 +118,8 @@ endif ()
 include( CheckBLACSCompilerFlags )
 CheckBLACSCompilerFlags()
 
-set(prefix ${CMAKE_INSTALL_PREFIX})
-set(libdir ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
-set(PKG_CONFIG_DIR ${libdir}/pkgconfig)
+include(GNUInstallDirs)
+set(PKG_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE PATH "pkg-config install path")
 
 # --------------------------------------------------
 # BLACS Internal variables
@@ -307,7 +304,7 @@ export(TARGETS scalapack FILE scalapack-targets.cmake)
 if( NOT LAPACK_FOUND )
  install(FILES
   ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES}
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
    )
 endif( NOT LAPACK_FOUND )
 
@@ -327,8 +324,8 @@ configure_file(${SCALAPACK_SOURCE_DIR}/CMAKE/scalapack-config-install.cmake.in
 install(FILES
   ${SCALAPACK_BINARY_DIR}/CMakeFiles/scalapack-config.cmake
   ${SCALAPACK_BINARY_DIR}/scalapack-config-version.cmake
-  DESTINATION lib/cmake/scalapack-${SCALAPACK_VERSION}
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scalapack-${SCALAPACK_VERSION}
   )
 
 install(EXPORT scalapack-targets
-  DESTINATION lib/cmake/scalapack-${SCALAPACK_VERSION})
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scalapack-${SCALAPACK_VERSION})

--- a/scalapack.pc.in
+++ b/scalapack.pc.in
@@ -1,5 +1,5 @@
-prefix=@prefix@
-libdir=@libdir@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: scalapack
 Description: SCALAPACK reference implementation


### PR DESCRIPTION
`LIB_SUFFIX` is not a standardized variable. Instead you should use `GNUInstallDirs` which is upstream standardized. This applies for MPI packages as well where the change involves a simple change of `CMAKE_INSTALL_PREFIX` and `CMAKE_INSTALL_LIBDIR` to conform to the packaging guidelines.

There are various points that I am not happy with such as `MPI_BASE_DIR` not being defined as a cache variable, or `CMAKE_FORTRAN_FLAGS` being overwritten, but I will not go into them until I get some confirmation that a review and rewrite is welcome by upstream.