### PR TITLE
Fix uninitialized EST in Placon

### DIFF
--- a/SRC/pclacon.f
+++ b/SRC/pclacon.f
@@ -186,6 +186,7 @@
 *
 *     Get grid parameters.
 *
+      EST = ZERO
       ICTXT = DESCX( CTXT_ )
       CALL BLACS_GRIDINFO( ICTXT, NPROW, NPCOL, MYROW, MYCOL )
 *

--- a/SRC/pdlacon.f
+++ b/SRC/pdlacon.f
@@ -184,6 +184,7 @@
 *
 *     Get grid parameters.
 *
+      EST = ZERO
       ESTWORK( 1 ) = EST
       ICTXT = DESCX( CTXT_ )
       CALL BLACS_GRIDINFO( ICTXT, NPROW, NPCOL, MYROW, MYCOL )

--- a/SRC/pslacon.f
+++ b/SRC/pslacon.f
@@ -186,6 +186,7 @@
 *
 *     Get grid parameters.
 *
+      EST = ZERO
       ESTWORK( 1 ) = EST
       ICTXT = DESCX( CTXT_ )
       CALL BLACS_GRIDINFO( ICTXT, NPROW, NPCOL, MYROW, MYCOL )

--- a/SRC/pzlacon.f
+++ b/SRC/pzlacon.f
@@ -186,6 +186,7 @@
 *
 *     Get grid parameters.
 *
+      EST = ZERO
       ICTXT = DESCX( CTXT_ )
       CALL BLACS_GRIDINFO( ICTXT, NPROW, NPCOL, MYROW, MYCOL )
 *


### PR DESCRIPTION
Turned out that the problem was with uninitialized output param `EST` in `p?lacon`. Simply `EST = ZERO` solves the problem

Closes #121 