### PR TITLE
Set C std to C17 to avoid errors with gcc 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.26...4.0)
 
 project(SCALAPACK VERSION 2.2.2 LANGUAGES C Fortran)
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_EXTENSIONS OFF)
 
 # Add the CMake directory for custon CMake modules
 set(CMAKE_MODULE_PATH "${SCALAPACK_SOURCE_DIR}/CMAKE" ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
Hi,

I think there is no harm in setting the C standard to the version the code actually conforms to at the moment.
Though I'd agree that updating the code to conform to C23 should be the long term goal.
Addresses #129.

Cheers,
Nuno