### PR TITLE
make: fix CCFLAGS. Resolves #17.

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -37,9 +37,10 @@ jobs:
     - name: Build ScaLAPACK
       run: |
         cp SLmake.inc.example SLmake.inc
-        make --silent -j lib
-        make --silent all
-        
+        # make -j is buggy; see #54.
+        make lib
+        make all
+
     - name: Run examples
       working-directory: ${{github.workspace}}/EXAMPLE
       run: |

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -217,13 +217,13 @@ dlamov.o: dlamov.c
 clamov.o: clamov.c
 zlamov.o: zlamov.c
 slamov.o dlamov.o clamov.o zlamov.o: lamov.h
-	$(CC) -c $(CFLAGS) $(CDEFS) $(@:.o=.c) -o $@
+	$(CC) -c $(CCFLAGS) $(CDEFS) $(@:.o=.c) -o $@
 
 clean :
 	rm -f *.o
 
-.f.o : 
+.f.o :
 	$(FC) -c $(FCFLAGS) $*.f
 
-.c.o : 
+.c.o :
 	$(CC) -c $(CDEFS) $(CCFLAGS) $*.c


### PR DESCRIPTION
The `CFLAGS` in this line should be `CCFLAGS`, as used everywhere else. See discussion in #17.

`CFLAGS` is more standard, but since online instructions and scripts refer to `CCFLAGS`, it makes sense to keep that.

Also in the CI, disable `make -j`, which is buggy. See #54.