### PR TITLE
Add installation of lapack and blas to Makefile github action runner

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Setup MPI
       uses: mpi4py/setup-mpi@v1
 
+    - name: Install BLAS and LAPACK
+      run: sudo apt -y install libblas-dev liblapack-dev
+
     - name: Build ScaLAPACK
       run: |
         cp SLmake.inc.example SLmake.inc


### PR DESCRIPTION
It looks like the Makefile CI is failing on [some prs](https://github.com/Reference-ScaLAPACK/scalapack/actions/runs/16199584594/job/45734943013?pr=140) due to a missing lapack install, this is copied from the cmake github action install of lapack, which I assume is sufficient.