### PR TITLE
fix bug in topology restoration in pzungql and pzunml2

### DIFF
--- a/SRC/pzungql.f
+++ b/SRC/pzungql.f
@@ -289,8 +289,8 @@
 *
    10 CONTINUE
 *
-      CALL PB_TOPGET( ICTXT, 'Broadcast', 'Rowwise', ROWBTOP )
-      CALL PB_TOPGET( ICTXT, 'Broadcast', 'Columnwise', COLBTOP )
+      CALL PB_TOPSET( ICTXT, 'Broadcast', 'Rowwise', ROWBTOP )
+      CALL PB_TOPSET( ICTXT, 'Broadcast', 'Columnwise', COLBTOP )
 *
       WORK( 1 ) = DCMPLX( DBLE( LWMIN ) )
 *

--- a/SRC/pzunml2.f
+++ b/SRC/pzunml2.f
@@ -391,8 +391,8 @@
 *
    10 CONTINUE
 *
-      CALL PB_TOPGET( ICTXT, 'Broadcast', 'Rowwise', ROWBTOP )
-      CALL PB_TOPGET( ICTXT, 'Broadcast', 'Columnwise', COLBTOP )
+      CALL PB_TOPSET( ICTXT, 'Broadcast', 'Rowwise', ROWBTOP )
+      CALL PB_TOPSET( ICTXT, 'Broadcast', 'Columnwise', COLBTOP )
 *
       WORK( 1 ) = DCMPLX( DBLE( LWMIN ) )
 *


### PR DESCRIPTION
Replaced PB_TOPGET with PB_TOPSET at the ends of pzungql and pzunml2.
Commit 1804c1cd updated the single precision version pcungqr and pcunml2, but omitted the double precision version.