### PR TITLE
fix missing II update in NPROW=1 branch of p?lanhs

### DIFF
--- a/SRC/pclanhs.f
+++ b/SRC/pclanhs.f
@@ -222,6 +222,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -344,6 +345,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -492,6 +494,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -631,6 +634,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns

--- a/SRC/pdlanhs.f
+++ b/SRC/pdlanhs.f
@@ -221,6 +221,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -343,6 +344,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -491,6 +493,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -630,6 +633,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns

--- a/SRC/pslanhs.f
+++ b/SRC/pslanhs.f
@@ -221,6 +221,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -343,6 +344,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -491,6 +493,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -630,6 +633,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns

--- a/SRC/pzlanhs.f
+++ b/SRC/pzlanhs.f
@@ -222,6 +222,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -344,6 +345,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -492,6 +494,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -631,6 +634,7 @@
                JJ = JJ + JB
             END IF
 *
+            II = II + JB
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns


### PR DESCRIPTION
In the `NPROW=1` path of `PCLANHS`/`PDLANHS`/`PSLANHS`/`PZLANHS`, `II` was not incremented by `JB` after processing the first block of columns. As a result, the row bound `MIN(II+LL-JJ+1, IIA+NP-1)` used inside the subsequent column-block loop tracked the Hessenberg diagonal at the wrong row, causing upper-triangle entries past the first block to be skipped and the computed norm to be incorrect.

Add II = II + JB after the first-block END IF in each of the four norm branches (M, 1, I, F), matching the equivalent update already present in the NPROW>1 branch.

## Repro
`NORM=M`, `N = 8`, `NB = 4`, `1×1` grid, with `99` planted at `A(6,5)` (true `||A||_max = 99`):
```
        c1   c2   c3   c4   c5   c6   c7   c8
   r1 [  1    2    3    4    5    6    7    8 ]
   r2 [  9   10   11   12   13   14   15   16 ]
   r3 [  0   17   18   19   20   21   22   23 ]
   r4 [  0    0   24   25   26   27   28   29 ]
   r5 [  0    0    0   30   31   32   33   34 ]
   r6 [  0    0    0    0   99   35   36   37 ]
   r7 [  0    0    0    0    0   38   39   40 ]
   r8 [  0    0    0    0    0    0   41   42 ]
```

- Buggy: return s 34. the second block scans `min(LL - 3, 8)` rows instead of `min(LL + 1, 8)`, missing the
  entry at row 6.
- Fixed: returns 99.