### PR TITLE
Fix process row tracking for Hessenberg matrices in `p*lanhs` and `p*lascl`

### DIFF
--- a/SRC/pclanhs.f
+++ b/SRC/pclanhs.f
@@ -274,7 +274,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -307,7 +307,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   140       CONTINUE
@@ -404,7 +404,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -441,7 +441,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   280       CONTINUE
@@ -550,7 +550,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -585,7 +585,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   430       CONTINUE
@@ -684,7 +684,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -715,7 +715,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   510       CONTINUE

--- a/SRC/pclascl.f
+++ b/SRC/pclascl.f
@@ -477,7 +477,7 @@
             IF( MYROW.EQ.ICURROW )
      $         II = II + JB
             ICURROW = INXTROW
-            ICURROW = MOD( ICURROW+1, NPROW )
+            INXTROW = MOD( ICURROW+1, NPROW )
             ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -510,7 +510,7 @@
                IF( MYROW.EQ.ICURROW )
      $            II = II + JB
                ICURROW = INXTROW
-               ICURROW = MOD( ICURROW+1, NPROW )
+               INXTROW = MOD( ICURROW+1, NPROW )
                ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
   350       CONTINUE

--- a/SRC/pdlanhs.f
+++ b/SRC/pdlanhs.f
@@ -273,7 +273,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -306,7 +306,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   140       CONTINUE
@@ -403,7 +403,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -440,7 +440,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   280       CONTINUE
@@ -549,7 +549,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -584,7 +584,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   430       CONTINUE
@@ -683,7 +683,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -714,7 +714,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   510       CONTINUE

--- a/SRC/pdlascl.f
+++ b/SRC/pdlascl.f
@@ -477,7 +477,7 @@
             IF( MYROW.EQ.ICURROW )
      $         II = II + JB
             ICURROW = INXTROW
-            ICURROW = MOD( ICURROW+1, NPROW )
+            INXTROW = MOD( ICURROW+1, NPROW )
             ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -510,7 +510,7 @@
                IF( MYROW.EQ.ICURROW )
      $            II = II + JB
                ICURROW = INXTROW
-               ICURROW = MOD( ICURROW+1, NPROW )
+               INXTROW = MOD( ICURROW+1, NPROW )
                ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
   350       CONTINUE

--- a/SRC/pslanhs.f
+++ b/SRC/pslanhs.f
@@ -273,7 +273,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -306,7 +306,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   140       CONTINUE
@@ -403,7 +403,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -440,7 +440,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   280       CONTINUE
@@ -549,7 +549,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -584,7 +584,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   430       CONTINUE
@@ -683,7 +683,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -714,7 +714,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   510       CONTINUE

--- a/SRC/pslascl.f
+++ b/SRC/pslascl.f
@@ -477,7 +477,7 @@
             IF( MYROW.EQ.ICURROW )
      $         II = II + JB
             ICURROW = INXTROW
-            ICURROW = MOD( ICURROW+1, NPROW )
+            INXTROW = MOD( ICURROW+1, NPROW )
             ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -510,7 +510,7 @@
                IF( MYROW.EQ.ICURROW )
      $            II = II + JB
                ICURROW = INXTROW
-               ICURROW = MOD( ICURROW+1, NPROW )
+               INXTROW = MOD( ICURROW+1, NPROW )
                ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
   350       CONTINUE

--- a/SRC/pzlanhs.f
+++ b/SRC/pzlanhs.f
@@ -274,7 +274,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -307,7 +307,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   140       CONTINUE
@@ -404,7 +404,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -441,7 +441,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   280       CONTINUE
@@ -550,7 +550,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -585,7 +585,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   430       CONTINUE
@@ -684,7 +684,7 @@
             IF( MYROW.EQ.IAROW )
      $         II = II + JB
             IAROW = INXTROW
-            IAROW = MOD( IAROW+1, NPROW )
+            INXTROW = MOD( IAROW+1, NPROW )
             IACOL = MOD( IACOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -715,7 +715,7 @@
                IF( MYROW.EQ.IAROW )
      $            II = II + JB
                IAROW = INXTROW
-               IAROW = MOD( IAROW+1, NPROW )
+               INXTROW = MOD( IAROW+1, NPROW )
                IACOL = MOD( IACOL+1, NPCOL )
 *
   510       CONTINUE

--- a/SRC/pzlascl.f
+++ b/SRC/pzlascl.f
@@ -477,7 +477,7 @@
             IF( MYROW.EQ.ICURROW )
      $         II = II + JB
             ICURROW = INXTROW
-            ICURROW = MOD( ICURROW+1, NPROW )
+            INXTROW = MOD( ICURROW+1, NPROW )
             ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
 *           Loop over remaining block of columns
@@ -510,7 +510,7 @@
                IF( MYROW.EQ.ICURROW )
      $            II = II + JB
                ICURROW = INXTROW
-               ICURROW = MOD( ICURROW+1, NPROW )
+               INXTROW = MOD( ICURROW+1, NPROW )
                ICURCOL = MOD( ICURCOL+1, NPCOL )
 *
   350       CONTINUE


### PR DESCRIPTION
This pull request fixes a critical bug in the process row tracking logic for Hessenberg matrices across the `P?LANHS` (norm) and `P?LASCL` (scaling) auxiliary routines.

### The Bug
In the `NPROW > 1` path of both routine families, when iterating over the remaining blocks of columns, the code correctly sets the active row (`IAROW` or `ICURROW`) to the next row (`INXTROW`). However, immediately after, it incorrectly updated the active row again instead of updating the `INXTROW` pointer.

For example, in `PDLANHS`, the code was:
```fortran
               IAROW = INXTROW
               IAROW = MOD( IAROW+1, NPROW )  ! <-- TYPO
```

This typographical error caused two major issues for matrices spanning more than two column blocks:
1. `INXTROW` remained completely stagnant after its initialization.
2. `IAROW` (or `ICURROW`) kept getting assigned to the constant `INXTROW` and incremented, getting stuck on the exact same value across all subsequent iterations of the column block loop.

### The Impact
Because the process rows owning the diagonal and sub-diagonal were tracked incorrectly, the routines would look at the wrong processes for sub-diagonal elements and update local pointers incorrectly. 
- In `P?LANHS`, this led to incorrect norm calculations for distributed Hessenberg matrices. 
- In `P?LASCL`, this could result in scaling the wrong sub-diagonal elements.

### The Fix
The second assignment has been corrected across all affected routines to properly update `INXTROW`:

```fortran
               IAROW = INXTROW
               INXTROW = MOD( IAROW+1, NPROW )
```
*(and similarly for `ICURROW` in `P?LASCL`)*

### Affected Files
- `SRC/pclanhs.f`, `SRC/pdlanhs.f`, `SRC/pslanhs.f`, `SRC/pzlanhs.f`
- `SRC/pclascl.f`, `SRC/pdlascl.f`, `SRC/pslascl.f`, `SRC/pzlascl.f`
