### PR TITLE
Fix WORK strides in P?LARZ ?AXPY calls

### DIFF
--- a/SRC/pclarz.f
+++ b/SRC/pclarz.f
@@ -394,7 +394,7 @@
                      END IF
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL CAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                              WORK( IPW ), MAX( 1, NQC2 ) )
+     $                              WORK( IPW ), 1 )
 *
                      CALL CGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                             WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -404,7 +404,7 @@
 *
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                              1, C( IOFFC1 ), LDC )
                      CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                           WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
@@ -437,7 +437,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL CAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK, MAX( 1, NQC2 ) )
+     $                                 WORK, 1 )
 *
                         CALL CGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK, MAX( 1, NQC2 ), RDEST,
@@ -447,7 +447,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL CAXPY( NQC2, -TAULOC( 1 ), WORK,
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL CGERC( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
      $                              1, WORK, 1, C( IOFFC2 ), LDC )
@@ -488,7 +488,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL CAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK( IPW ), MAX( 1, NQC2 ) )
+     $                                 WORK( IPW ), 1 )
 *
                         CALL CGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK( IPW ), MAX( 1, NQC2 ),
@@ -498,7 +498,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC2 ), LDC )
@@ -554,7 +554,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL CAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL CGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -564,7 +564,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
@@ -606,7 +606,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL CAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL CGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -616,7 +616,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL CAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL CGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF

--- a/SRC/pdlarz.f
+++ b/SRC/pdlarz.f
@@ -393,7 +393,7 @@
                      END IF
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL DAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                              WORK( IPW ), MAX( 1, NQC2 ) )
+     $                              WORK( IPW ), 1 )
 *
                      CALL DGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                             WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -403,7 +403,7 @@
 *
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                              1, C( IOFFC1 ), LDC )
                      CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                          WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
@@ -436,7 +436,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL DAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK, MAX( 1, NQC2 ) )
+     $                                 WORK, 1 )
 *
                         CALL DGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK, MAX( 1, NQC2 ), RDEST,
@@ -446,7 +446,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL DAXPY( NQC2, -TAULOC( 1 ), WORK,
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL DGER( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
      $                             1, WORK, 1, C( IOFFC2 ), LDC )
@@ -487,7 +487,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL DAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK( IPW ), MAX( 1, NQC2 ) )
+     $                                 WORK( IPW ), 1 )
 *
                         CALL DGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK( IPW ), MAX( 1, NQC2 ),
@@ -497,7 +497,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                             WORK( IPW ), 1, C( IOFFC2 ), LDC )
@@ -553,7 +553,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL DAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL DGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -563,7 +563,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
@@ -605,7 +605,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL DAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL DGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -615,7 +615,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL DAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL DGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF

--- a/SRC/pslarz.f
+++ b/SRC/pslarz.f
@@ -393,7 +393,7 @@
                      END IF
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL SAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                              WORK( IPW ), MAX( 1, NQC2 ) )
+     $                              WORK( IPW ), 1 )
 *
                      CALL SGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                             WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -403,7 +403,7 @@
 *
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                              1, C( IOFFC1 ), LDC )
                      CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                          WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
@@ -436,7 +436,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL SAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK, MAX( 1, NQC2 ) )
+     $                                 WORK, 1 )
 *
                         CALL SGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK, MAX( 1, NQC2 ), RDEST,
@@ -446,7 +446,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL SAXPY( NQC2, -TAULOC( 1 ), WORK,
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL SGER( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
      $                             1, WORK, 1, C( IOFFC2 ), LDC )
@@ -487,7 +487,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL SAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK( IPW ), MAX( 1, NQC2 ) )
+     $                                 WORK( IPW ), 1 )
 *
                         CALL SGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK( IPW ), MAX( 1, NQC2 ),
@@ -497,7 +497,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                             WORK( IPW ), 1, C( IOFFC2 ), LDC )
@@ -553,7 +553,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL SAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL SGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -563,7 +563,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
@@ -605,7 +605,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL SAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL SGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -615,7 +615,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL SAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL SGER( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                       WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF

--- a/SRC/pzlarz.f
+++ b/SRC/pzlarz.f
@@ -394,7 +394,7 @@
                      END IF
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL ZAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                              WORK( IPW ), MAX( 1, NQC2 ) )
+     $                              WORK( IPW ), 1 )
 *
                      CALL ZGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                             WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -404,7 +404,7 @@
 *
                      IF( MYROW.EQ.ICROW1 )
      $                  CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                              MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                              1, C( IOFFC1 ), LDC )
                      CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                           WORK( IPW ), 1, C( IOFFC2 ), LDC )
                   END IF
@@ -437,7 +437,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL ZAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK, MAX( 1, NQC2 ) )
+     $                                 WORK, 1 )
 *
                         CALL ZGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK, MAX( 1, NQC2 ), RDEST,
@@ -447,7 +447,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK,
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), V( IOFFV ),
      $                              1, WORK, 1, C( IOFFC2 ), LDC )
@@ -488,7 +488,7 @@
                         END IF
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL ZAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                                 WORK( IPW ), MAX( 1, NQC2 ) )
+     $                                 WORK( IPW ), 1 )
 *
                         CALL ZGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                                WORK( IPW ), MAX( 1, NQC2 ),
@@ -498,7 +498,7 @@
 *
                         IF( MYROW.EQ.ICROW1 )
      $                     CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                                 MAX( 1, NQC2 ), C( IOFFC1 ),
+     $                                 1, C( IOFFC1 ),
      $                                 LDC )
                         CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                              WORK( IPW ), 1, C( IOFFC2 ), LDC )
@@ -554,7 +554,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL ZAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL ZGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -564,7 +564,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF
@@ -606,7 +606,7 @@
                   END IF
                   IF( MYROW.EQ.ICROW1 )
      $               CALL ZAXPY( NQC2, ONE, C( IOFFC1 ), LDC,
-     $                           WORK( IPW ), MAX( 1, NQC2 ) )
+     $                           WORK( IPW ), 1 )
 *
                   CALL ZGSUM2D( ICTXT, 'Columnwise', ' ', NQC2, 1,
      $                          WORK( IPW ), MAX( 1, NQC2 ), RDEST,
@@ -616,7 +616,7 @@
 *
                   IF( MYROW.EQ.ICROW1 )
      $               CALL ZAXPY( NQC2, -TAULOC( 1 ), WORK( IPW ),
-     $                           MAX( 1, NQC2 ), C( IOFFC1 ), LDC )
+     $                           1, C( IOFFC1 ), LDC )
                   CALL ZGERC( MPV, NQC2, -TAULOC( 1 ), WORK, 1,
      $                        WORK( IPW ), 1, C( IOFFC2 ), LDC )
                END IF


### PR DESCRIPTION
Fix incorrect BLAS vector increments in `P?LARZ` left-side `?AXPY` calls.

`WORK(IPW)` stores a contiguous local work vector, so the `?AXPY` increment must be `1`. The previous calls used `MAX(1,NQC2)`, which is appropriate as a leading dimension for matrix-style BLACS/LAPACK calls but incorrect as a BLAS vector stride.

- Updated left-side `?AXPY` calls that read/write `WORK` or `WORK(IPW)` to use increment `1`.
- Kept `C` increments unchanged:
  - `LDC` when traversing a row of local `C`
  - `1` when traversing a column of local `C`

For comparison, LAPACK's DLARZ uses INCX=1 in the analogous DAXPY:

    DAXPY( N, -TAU, WORK, 1, C, LDC )

The value MAX(1, NQC2) does belong nearby — it is the legitimate LDA of the surrounding DLASET / DGSUM2D matrix-shaped calls. The bug looks like a copy-paste of that LDA into the DAXPY's stride slot.

The previous stride could skip elements in `WORK` and potentially access out-of-bounds memory when `NQC2 > 1`. This fixes the local Householder update path without changing the algorithm.