### PR TITLE
fix post-loop SIDE/TRANS guard in p?ormrz / p?unmrz

### DIFF
--- a/SRC/pcunmrz.f
+++ b/SRC/pcunmrz.f
@@ -455,8 +455,8 @@
      $                 WORK( IPW ) )
    10 CONTINUE
 *
-      IF( ( LEFT .AND. .NOT.NOTRAN ) .OR.
-     $    ( .NOT.LEFT .AND. NOTRAN ) ) THEN
+      IF( ( LEFT .AND. NOTRAN ) .OR.
+     $    ( .NOT.LEFT .AND. .NOT.NOTRAN ) ) THEN
          IB = I2 - IA
          IF( LEFT ) THEN
             MI = M

--- a/SRC/pdormrz.f
+++ b/SRC/pdormrz.f
@@ -455,8 +455,8 @@
      $                 WORK( IPW ) )
    10 CONTINUE
 *
-      IF( ( LEFT .AND. .NOT.NOTRAN ) .OR.
-     $    ( .NOT.LEFT .AND. NOTRAN ) ) THEN
+      IF( ( LEFT .AND. NOTRAN ) .OR.
+     $    ( .NOT.LEFT .AND. .NOT.NOTRAN ) ) THEN
          IB = I2 - IA
          IF( LEFT ) THEN
             MI = M

--- a/SRC/psormrz.f
+++ b/SRC/psormrz.f
@@ -455,8 +455,8 @@
      $                 WORK( IPW ) )
    10 CONTINUE
 *
-      IF( ( LEFT .AND. .NOT.NOTRAN ) .OR.
-     $    ( .NOT.LEFT .AND. NOTRAN ) ) THEN
+      IF( ( LEFT .AND. NOTRAN ) .OR.
+     $    ( .NOT.LEFT .AND. .NOT.NOTRAN ) ) THEN
          IB = I2 - IA
          IF( LEFT ) THEN
             MI = M

--- a/SRC/pzunmrz.f
+++ b/SRC/pzunmrz.f
@@ -456,8 +456,8 @@
      $                 WORK( IPW ) )
    10 CONTINUE
 *
-      IF( ( LEFT .AND. .NOT.NOTRAN ) .OR.
-     $    ( .NOT.LEFT .AND. NOTRAN ) ) THEN
+      IF( ( LEFT .AND. NOTRAN ) .OR.
+     $    ( .NOT.LEFT .AND. .NOT.NOTRAN ) ) THEN
          IB = I2 - IA
          IF( LEFT ) THEN
             MI = M


### PR DESCRIPTION
In PCUNMRZ/PDORMRZ/PSORMRZ/PZUNMRZ, the post-loop guard that controls the leading-partial-block PORMR3/PUNMR3 fix-up was a byte-for-byte copy of the pre-loop guard. The same condition gated both blocks, so the post-loop fired together with the pre-loop in the (LEFT,!NOTRAN) / (RIGHT,NOTRAN) directions (over-applying K-1 reflectors to an already transformed C) and never fired in the complementary (LEFT,NOTRAN) / (RIGHT,!NOTRAN) directions (silently skipping the leading partial block of reflectors). All four SIDE/TRANS combinations produced numerically incorrect results.

Replace the post-loop guard with the complement of the pre-loop guard, matching the analogous structure in p?ormrq.f.