### PR TITLE
fix reduction scope for column scale bounds in p?geequ

### DIFF
--- a/SRC/pcgeequ.f
+++ b/SRC/pcgeequ.f
@@ -337,9 +337,9 @@
          RCMIN = MIN( RCMIN, C( J ) )
          RCMAX = MAX( RCMAX, C( J ) )
   100 CONTINUE
-      CALL SGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMAX, 1, IDUMM,
+      CALL SGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMAX, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
-      CALL SGAMN2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMIN, 1, IDUMM,
+      CALL SGAMN2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMIN, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
 *
       IF( RCMIN.EQ.ZERO ) THEN
@@ -351,7 +351,7 @@
      $         INFO = M + INDXL2G( J, DESCA( NB_ ), MYCOL,
      $                DESCA( CSRC_ ), NPCOL ) - JA + 1
   110    CONTINUE
-         CALL IGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, INFO, 1,
+         CALL IGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, INFO, 1,
      $                 IDUMM, IDUMM, -1, -1, MYCOL )
          IF( INFO.NE.0 )
      $      RETURN

--- a/SRC/pdgeequ.f
+++ b/SRC/pdgeequ.f
@@ -329,9 +329,9 @@
          RCMIN = MIN( RCMIN, C( J ) )
          RCMAX = MAX( RCMAX, C( J ) )
   100 CONTINUE
-      CALL DGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMAX, 1, IDUMM,
+      CALL DGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMAX, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
-      CALL DGAMN2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMIN, 1, IDUMM,
+      CALL DGAMN2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMIN, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
 *
       IF( RCMIN.EQ.ZERO ) THEN
@@ -343,7 +343,7 @@
      $         INFO = M + INDXL2G( J, DESCA( NB_ ), MYCOL,
      $                DESCA( CSRC_ ), NPCOL ) - JA + 1
   110    CONTINUE
-         CALL IGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, INFO, 1,
+         CALL IGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, INFO, 1,
      $                 IDUMM, IDUMM, -1, -1, MYCOL )
          IF( INFO.NE.0 )
      $      RETURN

--- a/SRC/psgeequ.f
+++ b/SRC/psgeequ.f
@@ -329,9 +329,9 @@
          RCMIN = MIN( RCMIN, C( J ) )
          RCMAX = MAX( RCMAX, C( J ) )
   100 CONTINUE
-      CALL SGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMAX, 1, IDUMM,
+      CALL SGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMAX, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
-      CALL SGAMN2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMIN, 1, IDUMM,
+      CALL SGAMN2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMIN, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
 *
       IF( RCMIN.EQ.ZERO ) THEN
@@ -343,7 +343,7 @@
      $         INFO = M + INDXL2G( J, DESCA( NB_ ), MYCOL,
      $                DESCA( CSRC_ ), NPCOL ) - JA + 1
   110    CONTINUE
-         CALL IGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, INFO, 1,
+         CALL IGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, INFO, 1,
      $                 IDUMM, IDUMM, -1, -1, MYCOL )
          IF( INFO.NE.0 )
      $      RETURN

--- a/SRC/pzgeequ.f
+++ b/SRC/pzgeequ.f
@@ -337,9 +337,9 @@
          RCMIN = MIN( RCMIN, C( J ) )
          RCMAX = MAX( RCMAX, C( J ) )
   100 CONTINUE
-      CALL DGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMAX, 1, IDUMM,
+      CALL DGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMAX, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
-      CALL DGAMN2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMIN, 1, IDUMM,
+      CALL DGAMN2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, RCMIN, 1, IDUMM,
      $              IDUMM, -1, -1, MYCOL )
 *
       IF( RCMIN.EQ.ZERO ) THEN
@@ -351,7 +351,7 @@
      $         INFO = M + INDXL2G( J, DESCA( NB_ ), MYCOL,
      $                DESCA( CSRC_ ), NPCOL ) - JA + 1
   110    CONTINUE
-         CALL IGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, INFO, 1,
+         CALL IGAMX2D( ICTXT, 'Rowwise', ROWCTOP, 1, 1, INFO, 1,
      $                 IDUMM, IDUMM, -1, -1, MYCOL )
          IF( INFO.NE.0 )
      $      RETURN


### PR DESCRIPTION
# Fix reduction scope for column scale bounds in p?geequ

## Summary

`p{s,d,c,z}geequ` compute `COLCND = min(C(j)) / max(C(j))` over the global column-scale vector. The min/max reduction is currently issued along the **column** axis of the BLACS process grid, but at that point `C` has already been replicated along that same axis — so the reduction is a no-op and each process column ends up with the min/max of *only its own subset* of global columns. The returned `COLCND` (and `INFO`, on the singular-column path) is therefore wrong whenever `NPCOL ≥ 2` and the per-process-column scale ranges differ.

The fix switches three reductions in each of `p{s,d,c,z}geequ.f` from `'Columnwise'/COLCTOP` to `'Rowwise'/ROWCTOP` so the bounds are combined across process columns. `R`, `ROWCND`, `AMAX`, and the per-column entries of `C` are unaffected.

## Root cause

In `SRC/pdgeequ.f` (other precisions identical), after the per-column max is computed and replicated along each process column:

```fortran
  321  CALL DGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, NQ, C(JJA), 1, ...)   ! replicates C down each proc-column
       ...
       DO 100 J = JJA, JJA+NQ-1
          RCMIN = MIN( RCMIN, C(J) )      ! local min over THIS proc-column's NQ cols
          RCMAX = MAX( RCMAX, C(J) )
  100  CONTINUE
- 332  CALL DGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMAX, 1, ...)     ! BUG: along axis already replicated → no-op
- 334  CALL DGAMN2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, RCMIN, 1, ...)     ! BUG
+ 332  CALL DGAMX2D( ICTXT, 'Rowwise',    ROWCTOP, 1, 1, RCMAX, 1, ...)     ! combine across proc-columns
+ 334  CALL DGAMN2D( ICTXT, 'Rowwise',    ROWCTOP, 1, 1, RCMIN, 1, ...)
       ...
- 346  CALL IGAMX2D( ICTXT, 'Columnwise', COLCTOP, 1, 1, INFO, 1, ...)      ! same axis bug on the singular-column path
+ 346  CALL IGAMX2D( ICTXT, 'Rowwise',    ROWCTOP, 1, 1, INFO, 1, ...)
```

After the patch, `RCMIN/RCMAX` are the true global min/max of `C`, so `COLCND = max(RCMIN, SMLNUM) / min(RCMAX, BIGNUM)` matches the serial LAPACK `?GEEQU` result. The singular-column report (`INFO = M + j_first_zero`) is fixed the same way.

## Reproducer

Build a matrix whose column-scale spread is asymmetric across process columns, e.g. `A(i,j) = 10^(j-1)`. With `M = N = 12`, `NB = 8`, on `NPROW × NPCOL = 1 × 2`:

- proc col 0 owns global cols 1..8 → C(j) ∈ {10^11, …, 10^4} → local COLCND = 10^-7
- proc col 1 owns global cols 9..12 → C(j) ∈ {10^3, …, 10^0} → local COLCND = 10^-3
- true global → C ∈ {10^11, …, 10^0} → COLCND = 10^-11

Serial `DGEEQU` on the same matrix returns `COLCND = 1.0e-11`. Before the patch, `PDGEEQU` returns the rank-0 process column's local value `1.0e-7` — a factor-10^4 error. After the patch it returns `1.0e-11`.

A minimal Fortran example

```fortran
NPROW = 1 ; NPCOL = 2 ; M = 12 ; N = 12 ; NB = 8
...
DO J = 1, NQ
   GJ = INDXL2G( J, NB, MYCOL, 0, NPCOL )
   DO I = 1, NP
      A( I + (J-1)*LLDA ) = 10.0D0**(GJ-1)   ! constant within each global column
   END DO
END DO
CALL PDGEEQU( M, N, A, 1, 1, DESCA, R, C, ROWCND, COLCND, AMAX, INFO )
! Compare COLCND against serial DGEEQU on rank 0.
```

Observed (this matrix, several process grids):

| grid | netlib master | this PR  | serial DGEEQU |
|------|---------------|---------|---------------|
| 1×1  | 1.0e-11       | 1.0e-11 | 1.0e-11       |
| 1×2  | **1.0e-07**   | 1.0e-11 | 1.0e-11       |
| 2×2  | **1.0e-07**   | 1.0e-11 | 1.0e-11       |
| 1×4  | **1.0e-07**   | 1.0e-11 | 1.0e-11       |
| 2×3  | **1.0e-07**   | 1.0e-11 | 1.0e-11       |

`R`, `ROWCND`, and `AMAX` are correct on all grids and all builds; only `COLCND` (and the singular-column `INFO` report on the same code path) is affected. MKL inherits the bug from netlib; this PR is the only build that matches serial LAPACK on `NPCOL ≥ 2`.