### PR TITLE
Fix make -j

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,13 @@ all: lib exe example
 SCALAPACKLIBS=toolslib pblaslib redistlib scalapacklib
 
 $(SCALAPACKLIBS): blacslib
+pblaslib:     toolslib
+redistlib:    pblaslib
+scalapacklib: redistlib
 lib: $(SCALAPACKLIBS)
+
+blacsexe pblasexe redistexe scalapackexe: lib
+example: lib
 
 exe: blacsexe pblasexe redistexe scalapackexe
 

--- a/PBLAS/SRC/Makefile
+++ b/PBLAS/SRC/Makefile
@@ -117,6 +117,11 @@ PCBLAS = $(PCBLAS1) $(PCBLAS2) $(PCBLAS3) $(APPBLAS)
 PDBLAS = $(PDBLAS1) $(PDBLAS2) $(PDBLAS3) $(APPBLAS)
 PZBLAS = $(PZBLAS1) $(PZBLAS2) $(PZBLAS3) $(APPBLAS)
 
+single:    integer
+double:    single
+complex:   double
+complex16: complex
+
 integer: $(PIBLAS)
 	$(ARCH) $(ARCHFLAGS) ../../$(SCALAPACKLIB) $(PIBLAS)
 	$(RANLIB) ../../$(SCALAPACKLIB)

--- a/REDIST/SRC/Makefile
+++ b/REDIST/SRC/Makefile
@@ -62,6 +62,11 @@ all: integer single complex double complex16
 
 lib: all
 
+single:    integer
+complex:   single
+double:    complex
+complex16: double
+
 integer: $(IMRSRC) $(ALLAUX)
 	$(ARCH) $(ARCHFLAGS) ../../$(SCALAPACKLIB) $(IMRSRC) $(ALLAUX)
 	$(RANLIB) ../../$(SCALAPACKLIB)

--- a/SRC/Makefile
+++ b/SRC/Makefile
@@ -192,6 +192,10 @@ ZLASRC = \
 
 all: single complex double complex16
 
+complex:   single
+double:    complex
+complex16: double
+
 single: $(SLASRC) $(SCLAUX) $(ALLAUX)
 	$(ARCH) $(ARCHFLAGS) ../$(SCALAPACKLIB) $(SLASRC) $(SCLAUX) \
 	$(ALLAUX)

--- a/TOOLS/Makefile
+++ b/TOOLS/Makefile
@@ -48,35 +48,32 @@ ZTOOLS = zzdotu.o     zzdotc.o     zlatcpy.o    zmatadd.o     pzmatadd.o \
 
 all: single double complex complex16
 
-slapackaux:
-	( cd LAPACK; $(MAKE) single )
-
-dlapackaux:
-	( cd LAPACK; $(MAKE) double )
-
-clapackaux:
-	( cd LAPACK; $(MAKE) complex )
-
-zlapackaux:
-	( cd LAPACK; $(MAKE) complex16 )
+single:    integer
+double:    single
+complex:   double
+complex16: complex
 
 integer: $(ATOOLS) $(ITOOLS)
 	$(ARCH) $(ARCHFLAGS) ../$(SCALAPACKLIB) $(ATOOLS) $(ITOOLS)
 	$(RANLIB) ../$(SCALAPACKLIB)
 
-single: slapackaux integer $(STOOLS)
+single: integer $(STOOLS)
+	( cd LAPACK; $(MAKE) single )
 	$(ARCH) $(ARCHFLAGS) ../$(SCALAPACKLIB) $(STOOLS)
 	$(RANLIB) ../$(SCALAPACKLIB)
 
-double: dlapackaux integer $(DTOOLS)
+double: integer $(DTOOLS)
+	( cd LAPACK; $(MAKE) double )
 	$(ARCH) $(ARCHFLAGS) ../$(SCALAPACKLIB) $(DTOOLS)
 	$(RANLIB) ../$(SCALAPACKLIB)
 
-complex: clapackaux integer $(CTOOLS)
+complex: integer $(CTOOLS)
+	( cd LAPACK; $(MAKE) complex )
 	$(ARCH) $(ARCHFLAGS) ../$(SCALAPACKLIB) $(CTOOLS)
 	$(RANLIB) ../$(SCALAPACKLIB)
 
-complex16: zlapackaux integer $(ZTOOLS)
+complex16: integer $(ZTOOLS)
+	( cd LAPACK; $(MAKE) complex16 )
 	$(ARCH) $(ARCHFLAGS) ../$(SCALAPACKLIB) $(ZTOOLS)
 	$(RANLIB) ../$(SCALAPACKLIB)
 


### PR DESCRIPTION
This PR adresses the issue https://github.com/Reference-ScaLAPACK/scalapack/issues/54.
I accomplishes that by chaining the precision targets so that `ar` does not write the the same file at the same time possibly replacing the contents by another instance of `ar`.
Chain the library dirs toolslib, pblaslib, redistlib, scalapacklib and make blacsexe, pblasexe, redistexe, scalapackexe and example depend on lib.
Tested on macOS with GNU Make 3.81.