### PR TITLE
Revert "Add an exception for TOOLS/SL_gridreshape.c wrt implicit function declaration"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,6 @@ append_subdir_files(src "SRC")
 append_subdir_files(src-C "SRC")
 
 if (NOT MSVC)
-   set_source_files_properties(TOOLS/SL_gridreshape.c PROPERTIES COMPILE_OPTIONS "-Wno-error=implicit-function-declaration")
    add_library(scalapack ${blacs} ${tools} ${tools-C} ${extra_lapack} ${pblas} ${pblas-F} ${ptzblas} ${ptools} ${pbblas} ${redist} ${src} ${src-C})
    set_target_properties(scalapack PROPERTIES
     VERSION ${SCALAPACK_VERSION}


### PR DESCRIPTION

This reverts commit 966b62b23140b5fc4d731d5b75b99ff36d401956, because I don't find [uses of] implicit function declarations in this file.

close #165, where NVIDIA nvc compiler fails as it does not support the option `-Wno-error=implicit-function-declaration`.